### PR TITLE
Remove data from the chain context.

### DIFF
--- a/concordium-std-derive/Cargo.toml
+++ b/concordium-std-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-std-derive"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Concordium <info@concordium.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-std"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Concordium <info@concordium.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -16,11 +16,11 @@ wee_alloc="0.4.5"
 
 [dependencies.concordium-std-derive]
 path = "../concordium-std-derive"
-version = "=0.3"
+version = "=0.4"
 
 [dependencies.concordium-contracts-common]
 path = "../concordium-contracts-common"
-version = "=0.2"
+version = "=0.3"
 default-features = false
 
 [features]

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -210,15 +210,6 @@ impl HasParameter for Parameter {
 impl HasChainMetadata for ChainMetaExtern {
     #[inline(always)]
     fn slot_time(&self) -> SlotTime { Timestamp::from_timestamp_millis(unsafe { get_slot_time() }) }
-
-    #[inline(always)]
-    fn block_height(&self) -> BlockHeight { unsafe { get_block_height() } }
-
-    #[inline(always)]
-    fn finalized_height(&self) -> FinalizedHeight { unsafe { get_finalized_height() } }
-
-    #[inline(always)]
-    fn slot_number(&self) -> SlotNumber { unsafe { get_slot_number() } }
 }
 
 impl HasPolicy for Policy<AttributesCursor> {

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -63,12 +63,6 @@ extern "C" {
     pub(crate) fn get_receive_owner(start: *mut u8);
 
     // Getters for the chain meta data
-    /// Slot number from chain meta data
-    pub(crate) fn get_slot_number() -> u64;
-    /// Block height from chain meta data
-    pub(crate) fn get_block_height() -> u64;
-    /// Finalized height from chain meta data
-    pub(crate) fn get_finalized_height() -> u64;
     /// Slot time (in milliseconds) from chain meta data
     pub(crate) fn get_slot_time() -> u64;
 
@@ -178,18 +172,6 @@ mod host_dummy_functions {
     }
     #[no_mangle]
     pub(crate) extern "C" fn get_receive_owner(_start: *mut u8) {
-        unimplemented!("Dummy function! Not to be executed")
-    }
-    #[no_mangle]
-    pub(crate) extern "C" fn get_slot_number() -> u64 {
-        unimplemented!("Dummy function! Not to be executed")
-    }
-    #[no_mangle]
-    pub(crate) extern "C" fn get_block_height() -> u64 {
-        unimplemented!("Dummy function! Not to be executed")
-    }
-    #[no_mangle]
-    pub(crate) extern "C" fn get_finalized_height() -> u64 {
         unimplemented!("Dummy function! Not to be executed")
     }
     #[no_mangle]

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -67,10 +67,7 @@ use std::boxed::Box;
 /// Defaults to having all of the fields unset
 #[derive(Default, Clone)]
 pub struct ChainMetaTest {
-    pub(crate) slot_number:      Option<SlotNumber>,
-    pub(crate) block_height:     Option<BlockHeight>,
-    pub(crate) finalized_height: Option<FinalizedHeight>,
-    pub(crate) slot_time:        Option<SlotTime>,
+    pub(crate) slot_time: Option<SlotTime>,
 }
 
 /// Policy type used by init and receive contexts for testing.
@@ -268,24 +265,6 @@ impl ChainMetaTest {
         self.slot_time = Some(value);
         self
     }
-
-    /// Set the block height
-    pub fn set_block_height(&mut self, value: BlockHeight) -> &mut Self {
-        self.block_height = Some(value);
-        self
-    }
-
-    /// Set the finalized block height
-    pub fn set_finalized_height(&mut self, value: FinalizedHeight) -> &mut Self {
-        self.finalized_height = Some(value);
-        self
-    }
-
-    /// Set the slot number
-    pub fn set_slot_number(&mut self, value: SlotNumber) -> &mut Self {
-        self.slot_number = Some(value);
-        self
-    }
 }
 
 impl<'a, C> ContextTest<'a, C> {
@@ -321,24 +300,6 @@ impl<'a, C> ContextTest<'a, C> {
     /// Set the metadata block slot time
     pub fn set_metadata_slot_time(&mut self, value: SlotTime) -> &mut Self {
         self.metadata_mut().set_slot_time(value);
-        self
-    }
-
-    /// Set the metadata block height
-    pub fn set_metadata_block_height(&mut self, value: BlockHeight) -> &mut Self {
-        self.metadata_mut().set_block_height(value);
-        self
-    }
-
-    /// Set the metadata finalized block height
-    pub fn set_metadata_finalized_height(&mut self, value: FinalizedHeight) -> &mut Self {
-        self.metadata_mut().set_finalized_height(value);
-        self
-    }
-
-    /// Set the metadata slot number
-    pub fn set_metadata_slot_number(&mut self, value: SlotNumber) -> &mut Self {
-        self.metadata_mut().set_slot_number(value);
         self
     }
 }
@@ -401,18 +362,6 @@ fn unwrap_ctx_field<A>(opt: Option<A>, name: &str) -> A {
 // Getters for testing-context
 impl HasChainMetadata for ChainMetaTest {
     fn slot_time(&self) -> SlotTime { unwrap_ctx_field(self.slot_time, "metadata.slot_time") }
-
-    fn block_height(&self) -> BlockHeight {
-        unwrap_ctx_field(self.block_height, "metadata.block_height")
-    }
-
-    fn finalized_height(&self) -> FinalizedHeight {
-        unwrap_ctx_field(self.finalized_height, "metadata.finalized_height")
-    }
-
-    fn slot_number(&self) -> SlotNumber {
-        unwrap_ctx_field(self.slot_number, "metadata.slot_number")
-    }
 }
 
 impl HasPolicy for TestPolicy {

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -23,13 +23,6 @@ pub trait HasParameter: Read {
 pub trait HasChainMetadata {
     /// Get time in milliseconds at the beginning of this block.
     fn slot_time(&self) -> SlotTime;
-    /// Get block height of the current block.
-    fn block_height(&self) -> BlockHeight;
-    /// Get the height of the last finalized block, i.e., block to which the
-    /// current block has a finalized pointer to.
-    fn finalized_height(&self) -> FinalizedHeight;
-    /// Get the slot number of the current block.
-    fn slot_number(&self) -> SlotNumber;
 }
 
 /// A type which has access to a policy of a credential.

--- a/examples/piggy-bank/part1/Cargo.toml
+++ b/examples/piggy-bank/part1/Cargo.toml
@@ -17,7 +17,7 @@ default = ["std"]
 std = ["concordium-std/std"]
 
 [dependencies.concordium-std]
-version = "0.3.1"
+version = "0.4"
 path = "../../../concordium-std"
 default-features = false
 

--- a/examples/piggy-bank/part2/Cargo.toml
+++ b/examples/piggy-bank/part2/Cargo.toml
@@ -17,7 +17,7 @@ default = ["std"]
 std = ["concordium-std/std"]
 
 [dependencies.concordium-std]
-version = "0.3.1"
+version = "0.4"
 path = "../../../concordium-std"
 default-features = false
 

--- a/examples/two-step-transfer/Cargo.toml
+++ b/examples/two-step-transfer/Cargo.toml
@@ -20,7 +20,7 @@ byteorder = "1.3"
 [dependencies.concordium-std]
 # git = "https://github.com/Concordium/concordium-std.git"
 # branch = "main"
-version = "0.3.0"
+version = "0.4"
 path = "../../concordium-std"
 default-features = false
 


### PR DESCRIPTION
It is almost certainly not useful, and prevents future extensions.
slot_time should be sufficient to start with.