### PR TITLE
Returning error codes from init and receive functions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,6 +22,7 @@ jobs:
           - examples/two-step-transfer/Cargo.toml
           - examples/piggy-bank/part1/Cargo.toml
           - examples/piggy-bank/part2/Cargo.toml
+          - examples/auction/Cargo.toml
 
     steps:
       - name: Checkout sources
@@ -202,6 +203,7 @@ jobs:
           - examples/two-step-transfer/Cargo.toml
           - examples/piggy-bank/part1/Cargo.toml
           - examples/piggy-bank/part2/Cargo.toml
+          - examples/auction/Cargo.toml
 
     steps:
       - name: Checkout sources

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -209,7 +209,7 @@ fn init_worker(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream>
                         let code = Reject::from(reject).error_code;
                         let with_reserved_offset = code.checked_add(#RESERVED_ERROR_CODES).expect(#exceeded_error_code_limit);
                         -i32::try_from(with_reserved_offset).expect(#exceeded_error_code_limit)
-                    } // TODO (MRA) check that error code is in bound
+                    }
                 }
             }
         }

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -1236,10 +1236,7 @@ const RESERVED_ERROR_CODES: i32 = i32::MIN + 100;
 /// Creating custom enums for error types can provide meaningful error messages
 /// to the user of the smart contract.
 ///
-/// Please note:
-///   - At the moment, we can only derive fieldless enums.
-///   - The error-type enum needs to derive (or implement) the Copy and Clone
-///     traits.
+/// Note that at the moment, we can only derive fieldless enums.
 ///
 /// ### Example
 /// ```ignore

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -430,7 +430,7 @@ fn receive_worker(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStre
                         }
                         Err(reject) => {
                             let code = Reject::from(reject).error_code;
-                        -i32::try_from(code).expect(#exceeded_error_code_limit)
+                            -i32::try_from(code).expect(#exceeded_error_code_limit)
                         }
                     }
                 } else {

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -1312,7 +1312,7 @@ fn generate_variant_error_conversions(
 }
 
 /// Generate error conversion for a given enum variant.
-fn parse_attr_and_gen_error_conversions<'a>(
+fn parse_attr_and_gen_error_conversions(
     attr: &syn::Attribute,
     enum_name: &syn::Ident,
     variant_name: &syn::Ident,
@@ -1322,24 +1322,21 @@ fn parse_attr_and_gen_error_conversions<'a>(
             x.span(),
             "The `from` attribute expects a list of error types, e.g.: #[from(ParseError)].",
         );
-        vec![err.to_compile_error().into()]
+        vec![err.to_compile_error()]
     };
     match attr.parse_meta() {
         Ok(syn::Meta::List(list)) if list.path.is_ident("from") => {
             let mut from_error_names = vec![];
             for nested in list.nested.iter() {
-                match nested {
-                    syn::NestedMeta::Meta(syn::Meta::Path(from_error)) => {
-                        match from_error.get_ident() {
-                            Some(ident) => {
-                                from_error_names.push(ident);
-                            }
-                            None => {
-                                return wrong_from_usage(from_error);
-                            }
+                if let syn::NestedMeta::Meta(syn::Meta::Path(from_error)) = nested {
+                    match from_error.get_ident() {
+                        Some(ident) => {
+                            from_error_names.push(ident);
+                        }
+                        None => {
+                            return wrong_from_usage(from_error);
                         }
                     }
-                    _ => (),
                 }
             }
             from_error_token_stream(from_error_names, &enum_name, variant_name)

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -195,7 +195,7 @@ fn init_worker(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream>
             #[export_name = #wasm_export_fn_name]
             pub extern "C" fn #rust_export_fn_name(#amount_ident: Amount) -> i32 {
                 use concordium_std::{trap, ExternContext, InitContextExtern, ContractState};
-                use std::convert::TryFrom;
+                use concordium_std::convert::TryFrom;
                 #setup_fn_optional_args
                 let ctx = ExternContext::<InitContextExtern>::open(());
                 let mut state = ContractState::open(());
@@ -213,7 +213,7 @@ fn init_worker(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream>
             #[export_name = #wasm_export_fn_name]
             pub extern "C" fn #rust_export_fn_name(amount: Amount) -> i32 {
                 use concordium_std::{trap, ExternContext, InitContextExtern, ContractState};
-                use std::convert::TryFrom;
+                use concordium_std::convert::TryFrom;
                 #setup_fn_optional_args
                 let ctx = ExternContext::<InitContextExtern>::open(());
                 match #fn_name(&ctx, #(#fn_optional_args),*) {
@@ -388,7 +388,7 @@ fn receive_worker(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStre
             #[export_name = #wasm_export_fn_name]
             pub extern "C" fn #rust_export_fn_name(#amount_ident: Amount) -> i32 {
                 use concordium_std::{SeekFrom, ContractState, Logger, ReceiveContextExtern, ExternContext};
-                use std::convert::TryFrom;
+                use concordium_std::convert::TryFrom;
                 #setup_fn_optional_args
                 let ctx = ExternContext::<ReceiveContextExtern>::open(());
                 let mut state = ContractState::open(());
@@ -411,7 +411,7 @@ fn receive_worker(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStre
             #[export_name = #wasm_export_fn_name]
             pub extern "C" fn #rust_export_fn_name(#amount_ident: Amount) -> i32 {
                 use concordium_std::{SeekFrom, ContractState, Logger, trap};
-                use std::convert::TryFrom;
+                use concordium_std::convert::TryFrom;
                 #setup_fn_optional_args
                 let ctx = ExternContext::<ReceiveContextExtern>::open(());
                 let mut state_bytes = ContractState::open(());

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -1227,7 +1227,7 @@ fn schema_type_fields(fields: &syn::Fields) -> syn::Result<proc_macro2::TokenStr
 /// We reserve a number of error codes for custom errors, such as ParseError,
 /// that are provided by concordium-std. The error codes for user-defined error
 /// types will have this number as an offset.
-const RESERVED_ERROR_CODES: u32 = 100;
+pub const RESERVED_ERROR_CODES: u32 = 100;
 
 /// Derive the conversion of enums that represent error types into the Reject
 /// struct which can be used as the error type of init and receive functions.
@@ -1276,7 +1276,7 @@ fn reject_derive_worker(input: TokenStream) -> syn::Result<TokenStream> {
     let gen = quote! {
         impl From<#enum_ident> for Reject {
             fn from(e: #enum_ident) -> Self {
-                Reject { error_code: (e as u32).checked_add(#RESERVED_ERROR_CODES).expect(#exceeded_error_code_limit) }
+                Reject { error_code: (e as u32 + 1).checked_add(#RESERVED_ERROR_CODES).expect(#exceeded_error_code_limit) }
             }
         }
 

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -75,9 +75,9 @@ fn contains_attribute<'a, I: IntoIterator<Item = &'a Meta>>(iter: I, name: &str)
     iter.into_iter().any(|attr| attr.path().is_ident(name))
 }
 
-/// We reserve a number of error codes for custom errors, such as ParseError, that are
-/// provided by concordium-std. The error codes for user-defined error types will
-/// have this number as an offset.
+/// We reserve a number of error codes for custom errors, such as ParseError,
+/// that are provided by concordium-std. The error codes for user-defined error
+/// types will have this number as an offset.
 const RESERVED_ERROR_CODES: u32 = 100;
 
 /// Derive the appropriate export for an annotated init function.
@@ -183,7 +183,10 @@ fn init_worker(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream>
     let rust_export_fn_name = format_ident!("export_{}", fn_name);
     let wasm_export_fn_name = format!("init_{}", contract_name);
     let amount_ident = format_ident!("amount");
-    let exceeded_error_code_limit = format!("Error code should not exceed {} (i32::MAX minus reserved error-code offset).", i32::MAX - RESERVED_ERROR_CODES as i32);
+    let exceeded_error_code_limit = format!(
+        "Error code should not exceed {} (i32::MAX minus reserved error-code offset).",
+        i32::MAX - RESERVED_ERROR_CODES as i32
+    );
 
     // Accumulate a list of required arguments, if the function contains a
     // different number of arguments, than elements in this vector, then the
@@ -377,7 +380,10 @@ fn receive_worker(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStre
     let rust_export_fn_name = format_ident!("export_{}", fn_name);
     let wasm_export_fn_name = format!("{}.{}", contract_name, name);
     let amount_ident = format_ident!("amount");
-    let exceeded_error_code_limit = format!("Error code should not exceed {} (i32::MAX minus reserved error-code offset).", i32::MAX - RESERVED_ERROR_CODES as i32);
+    let exceeded_error_code_limit = format!(
+        "Error code should not exceed {} (i32::MAX minus reserved error-code offset).",
+        i32::MAX - RESERVED_ERROR_CODES as i32
+    );
 
     // Accumulate a list of required arguments, if the function contains a
     // different number of arguments, than elements in this vector, then the
@@ -1229,13 +1235,15 @@ fn schema_type_fields(fields: &syn::Fields) -> syn::Result<proc_macro2::TokenStr
     }
 }
 
-/// Derive the conversion of enums that represent error types into the Reject struct
-/// which can be used as the error type of init and receive functions. Creating custom
-/// enums for error types can provide meaningful error messages to the user of the smart contract.
+/// Derive the conversion of enums that represent error types into the Reject
+/// struct which can be used as the error type of init and receive functions.
+/// Creating custom enums for error types can provide meaningful error messages
+/// to the user of the smart contract.
 ///
 /// Please note:
 ///   - At the moment, we can only derive fieldless enums.
-///   - The error-type enum needs to derive (or implement) the Copy and Clone traits.
+///   - The error-type enum needs to derive (or implement) the Copy and Clone
+///     traits.
 ///
 /// ### Example
 /// ```ignore
@@ -1246,11 +1254,10 @@ fn schema_type_fields(fields: &syn::Fields) -> syn::Result<proc_macro2::TokenStr
 ///     // TimeExpired(time: Timestamp), /* currently not supported */
 ///     ...
 /// }
-///
 /// ```ignore
 /// #[receive(contract = "my_contract", name = "some_receive")]
-/// fn receive<A: HasActions>(ctx: &impl HasReceiveContext, state: &mut MyState) -> Result<A, MyError> {...}
-/// ```
+/// fn receive<A: HasActions>(ctx: &impl HasReceiveContext, state: &mut MyState)
+/// -> Result<A, MyError> {...} ```
 #[proc_macro_derive(Reject)]
 pub fn reject_derive(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -1222,13 +1222,20 @@ fn schema_type_fields(fields: &syn::Fields) -> syn::Result<proc_macro2::TokenStr
     }
 }
 
+/// We reserve a number of error codes for custom errors, such as ParseError,
+/// that are provided by concordium-std. The error codes for user-defined error
+/// types will have this number as an offset.
+const RESERVED_ERROR_CODES: u32 = 100;
+
 /// Derive the conversion of enums that represent error types into the Reject
 /// struct which can be used as the error type of init and receive functions.
 /// Creating custom enums for error types can provide meaningful error messages
 /// to the user of the smart contract.
 ///
-/// Note that the error-type enum needs to derive (or implement) the Copy and
-/// Clone traits.
+/// Please note:
+///   - At the moment, we can only derive fieldless enums.
+///   - The error-type enum needs to derive (or implement) the Copy and Clone
+///     traits.
 ///
 /// ### Example
 /// ```ignore
@@ -1236,7 +1243,7 @@ fn schema_type_fields(fields: &syn::Fields) -> syn::Result<proc_macro2::TokenStr
 /// enum MyError {
 ///     IllegalState,
 ///     WrongSender,
-///     TimeExpired(time: Timestamp),
+///     // TimeExpired(time: Timestamp), /* currently not supported */
 ///     ...
 /// }
 /// ```ignore
@@ -1247,34 +1254,23 @@ fn schema_type_fields(fields: &syn::Fields) -> syn::Result<proc_macro2::TokenStr
 pub fn reject_derive(input: TokenStream) -> TokenStream {
     let ast: syn::DeriveInput = syn::parse(input).unwrap(); // TODO (MRA) unsafe?
     let ts = match ast.data {
-        syn::Data::Enum(data) => Ok(impl_reject_derive(ast.ident, data)),
-        _ => Err(syn::Error::new(ast.span(), "Reject can only be derived for enums.")),
+        syn::Data::Enum(data) =>
+            Ok(impl_reject_derive(ast.ident, data)),
+        _ => Err(syn::Error::new(ast.span(), "Reject can only be derived for enums."))
     };
     unwrap_or_report(ts)
 }
 
 fn impl_reject_derive(enum_name: Ident, data: syn::DataEnum) -> TokenStream {
-    let variants = data.variants;
-    let mut error_code_counter = 0u32;
-    let variant_code_gens = variants.iter().map(|variant| {
-        let variant_name = &variant.ident;
-        let fields = variant.fields.iter().map(|field| {
-           let ty = field.ty;
-
-        });
-        error_code_counter = error_code_counter + 1;
-        quote! {
-            #enum_name::#variant_name =>  #error_code_counter
-        }
-    });
+    let exceeded_error_code_limit = format!(
+        "Error code should not exceed {} (i32::MAX minus reserved error-code offset).",
+        i32::MAX - RESERVED_ERROR_CODES as i32
+    );
 
     let gen = quote! {
         impl From<#enum_name> for Reject {
             fn from(e: #enum_name) -> Self {
-                let code = match e {
-                    #(#variant_code_gens),*
-                };
-                Reject { error_code: code }
+                Reject { error_code: (e as 32).checked_add(#RESERVED_ERROR_CODES).expect(#exceeded_error_code_limit) }
             }
         }
     };

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -1227,7 +1227,7 @@ fn schema_type_fields(fields: &syn::Fields) -> syn::Result<proc_macro2::TokenStr
 /// We reserve a number of error codes for custom errors, such as ParseError,
 /// that are provided by concordium-std. The error codes for user-defined error
 /// types will have this number as an offset.
-pub const RESERVED_ERROR_CODES: u32 = 100;
+const RESERVED_ERROR_CODES: u32 = 100;
 
 /// Derive the conversion of enums that represent error types into the Reject
 /// struct which can be used as the error type of init and receive functions.

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -8,6 +8,7 @@
   reverts the change in concordium-std 0.4.1.
 - Allow init and receive methods to return custom error codes that will be displayed to the user
   if a smart-contract invocation fails.
+- Add i128 and u128 support to serialization and schema.
 
 ## concordium-std 0.4.1 (2021-02-22)
 

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -6,6 +6,8 @@
   to be consistent with the Write implementation for ContractState.
 - Use little-endian encoding for sender contract addresses in receive contexts. This
   reverts the change in concordium-std 0.4.1.
+- Allow init and receive methods to return custom error codes that will be displayed to the user
+  if a smart-contract invocation fails.
 
 ## concordium-std 0.4.1 (2021-02-22)
 

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -20,7 +20,7 @@ version = "=0.5"
 
 [dependencies.concordium-contracts-common]
 path = "../concordium-contracts-common"
-version = "=0.3.1"
+version = "=0.3.2"
 default-features = false
 
 [features]

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -7,7 +7,7 @@ impl convert::From<()> for Reject {
     #[inline(always)]
     fn from(_: ()) -> Self {
         Reject {
-            error_code: unsafe { num::NonZeroU32::new_unchecked((i32::MAX - 1) as u32) },
+            error_code: unsafe { num::NonZeroI32::new_unchecked(i32::MIN + 1) },
         }
     }
 }
@@ -16,7 +16,7 @@ impl convert::From<ParseError> for Reject {
     #[inline(always)]
     fn from(_: ParseError) -> Self {
         Reject {
-            error_code: unsafe { num::NonZeroU32::new_unchecked((i32::MAX - 2) as u32) },
+            error_code: unsafe { num::NonZeroI32::new_unchecked(i32::MIN + 2) },
         }
     }
 }

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -5,12 +5,12 @@ use mem::MaybeUninit;
 
 impl convert::From<()> for Reject {
     #[inline(always)]
-    fn from(_: ()) -> Self { Reject {} }
+    fn from(_: ()) -> Self { Reject { error_code: 1 } }
 }
 
 impl convert::From<ParseError> for Reject {
     #[inline(always)]
-    fn from(_: ParseError) -> Self { Reject {} }
+    fn from(_: ParseError) -> Self { Reject { error_code: 2 } }
 }
 
 /// # Contract state trait implementations.

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -7,7 +7,7 @@ impl convert::From<()> for Reject {
     #[inline(always)]
     fn from(_: ()) -> Self {
         Reject {
-            error_code: 1,
+            error_code: -(i32::MIN + 1) as u32,
         }
     }
 }
@@ -16,7 +16,7 @@ impl convert::From<ParseError> for Reject {
     #[inline(always)]
     fn from(_: ParseError) -> Self {
         Reject {
-            error_code: 2,
+            error_code: -(i32::MIN + 2) as u32,
         }
     }
 }

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1,4 +1,4 @@
-use crate::{convert, mem, prims::*, traits::*, types::*};
+use crate::{convert, mem, num, prims::*, traits::*, types::*};
 use concordium_contracts_common::*;
 
 use mem::MaybeUninit;
@@ -7,7 +7,7 @@ impl convert::From<()> for Reject {
     #[inline(always)]
     fn from(_: ()) -> Self {
         Reject {
-            error_code: -(i32::MIN + 1) as u32,
+            error_code: unsafe { num::NonZeroU32::new_unchecked((i32::MAX - 1) as u32) },
         }
     }
 }
@@ -16,7 +16,7 @@ impl convert::From<ParseError> for Reject {
     #[inline(always)]
     fn from(_: ParseError) -> Self {
         Reject {
-            error_code: -(i32::MIN + 2) as u32,
+            error_code: unsafe { num::NonZeroU32::new_unchecked((i32::MAX - 2) as u32) },
         }
     }
 }

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -5,12 +5,20 @@ use mem::MaybeUninit;
 
 impl convert::From<()> for Reject {
     #[inline(always)]
-    fn from(_: ()) -> Self { Reject { error_code: 1 } }
+    fn from(_: ()) -> Self {
+        Reject {
+            error_code: 1,
+        }
+    }
 }
 
 impl convert::From<ParseError> for Reject {
     #[inline(always)]
-    fn from(_: ParseError) -> Self { Reject { error_code: 2 } }
+    fn from(_: ParseError) -> Self {
+        Reject {
+            error_code: 2,
+        }
+    }
 }
 
 /// # Contract state trait implementations.

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -150,42 +150,18 @@ fn abort_panic(_info: &core::panic::PanicInfo) -> ! {
 
 // Provide some re-exports to make it easier to use the library.
 // This should be expanded in the future.
-#[cfg(not(feature = "std"))]
-pub use core::result::*;
-
 /// Re-export.
 #[cfg(not(feature = "std"))]
-pub use alloc::collections;
+pub use alloc::{collections, string, string::String, string::ToString, vec, vec::Vec};
 /// Re-export.
 #[cfg(not(feature = "std"))]
-pub use alloc::{string, string::String, string::ToString, vec, vec::Vec};
-/// Re-export.
-#[cfg(not(feature = "std"))]
-pub use core::convert;
-/// Re-export.
-#[cfg(not(feature = "std"))]
-pub use core::marker;
-/// Re-export.
-#[cfg(not(feature = "std"))]
-pub use core::mem;
+pub use core::{convert, marker, mem, num, result::*};
 #[cfg(feature = "std")]
 pub(crate) use std::vec;
-#[cfg(feature = "std")]
-pub use std::vec::Vec;
 
 /// Re-export.
 #[cfg(feature = "std")]
-pub use std::collections;
-/// Re-export.
-#[cfg(feature = "std")]
-pub use std::convert;
-#[cfg(feature = "std")]
-pub use std::marker;
-/// Re-export.
-#[cfg(feature = "std")]
-pub use std::mem;
-#[cfg(feature = "std")]
-pub use std::string::String;
+pub use std::{collections, convert, marker, mem, num, string::String, vec::Vec};
 
 /// Chain constants that impose limits on various aspects of smart contract
 /// execution.

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -46,19 +46,33 @@ impl Action {
 /// An error message, signalling rejection of a smart contract invocation.
 /// The client will see the error code as a reject reason; if a schema is
 /// provided, the error message corresponding to the error code will be
-/// displayed. The valid range for an error code is from 1 to i32::MAX. We are
-/// using a u32 here to highlight that the error code should be nonnegative.
+/// displayed. The valid range for an error code is from i32::MIN to  -1.
 #[derive(Eq, PartialEq, Debug)]
+#[repr(transparent)]
 pub struct Reject {
-    pub error_code: crate::num::NonZeroU32,
+    pub error_code: crate::num::NonZeroI32,
 }
 
-/// Default error is i32::MAX (the i32 is deliberate)
+/// Default error is i32::MIN.
 impl Default for Reject {
     #[inline(always)]
     fn default() -> Self {
         Self {
-            error_code: unsafe { crate::num::NonZeroU32::new_unchecked(i32::MAX as u32) },
+            error_code: unsafe { crate::num::NonZeroI32::new_unchecked(i32::MIN) },
+        }
+    }
+}
+
+impl Reject {
+    /// This returns `None` for all values >= 0 and `Some` otherwise.
+    pub fn new(x: i32) -> Option<Self> {
+        if x < 0 {
+            let error_code = unsafe { crate::num::NonZeroI32::new_unchecked(x) };
+            Some(Reject {
+                error_code,
+            })
+        } else {
+            None
         }
     }
 }

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -43,10 +43,13 @@ impl Action {
     pub fn tag(&self) -> u32 { self._private }
 }
 
-/// A non-descript error message, signalling rejection of a smart contract
-/// invocation.
+/// An error message, signalling rejection of a smart contract invocation.
+/// The client will see the error code as a reject reason; if a schema is provided,
+/// the error message corresponding to the error code will be displayed.
+/// The valid range for an error code is from 1 to i32::MAX. We are using a u32 here
+/// to highlight that the error code should be nonnegative.
 #[derive(Default, Eq, PartialEq, Debug)]
-pub struct Reject {}
+pub struct Reject { pub error_code: u32 }
 
 // Macros for failing a contract function
 
@@ -207,7 +210,7 @@ macro_rules! claim_ne {
 /// The expected return type of the receive method of a smart contract.
 ///
 /// Optionally, to define a custom type for error instead of using
-/// Reject, allowing the track the reason for rejection, *but only in unit
+/// Reject, allowing to track the reason for rejection, *but only in unit
 /// tests*.
 ///
 /// See also the documentation for [bail!](macro.bail.html) for how to use

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -44,12 +44,14 @@ impl Action {
 }
 
 /// An error message, signalling rejection of a smart contract invocation.
-/// The client will see the error code as a reject reason; if a schema is provided,
-/// the error message corresponding to the error code will be displayed.
-/// The valid range for an error code is from 1 to i32::MAX. We are using a u32 here
-/// to highlight that the error code should be nonnegative.
+/// The client will see the error code as a reject reason; if a schema is
+/// provided, the error message corresponding to the error code will be
+/// displayed. The valid range for an error code is from 1 to i32::MAX. We are
+/// using a u32 here to highlight that the error code should be nonnegative.
 #[derive(Default, Eq, PartialEq, Debug)]
-pub struct Reject { pub error_code: u32 }
+pub struct Reject {
+    pub error_code: u32,
+}
 
 // Macros for failing a contract function
 

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -48,9 +48,19 @@ impl Action {
 /// provided, the error message corresponding to the error code will be
 /// displayed. The valid range for an error code is from 1 to i32::MAX. We are
 /// using a u32 here to highlight that the error code should be nonnegative.
-#[derive(Default, Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub struct Reject {
-    pub error_code: u32,
+    pub error_code: crate::num::NonZeroU32,
+}
+
+/// Default error is i32::MAX (the i32 is deliberate)
+impl Default for Reject {
+    #[inline(always)]
+    fn default() -> Self {
+        Self {
+            error_code: unsafe { crate::num::NonZeroU32::new_unchecked(i32::MAX as u32) },
+        }
+    }
 }
 
 // Macros for failing a contract function

--- a/examples/auction/Cargo.toml
+++ b/examples/auction/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-concordium-std = "*"
+concordium-std = { path = "../../concordium-std" }
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/auction/src/lib.rs
+++ b/examples/auction/src/lib.rs
@@ -70,16 +70,16 @@ struct InitParameter {
 }
 
 /// For errors in which the `bid` function can result
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Reject)]
 enum BidError {
     ContractSender, // raised if a contract, as opposed to account, tries to bid
-    BidTooLow { bid: Amount, highest_bid: Amount }, // raised if bid is lower than highest amount
+    BidTooLow/* { bid: Amount, highest_bid: Amount }*/, // raised if bid is lower than highest amount
     BidsOverWaitingForAuctionFinalization, // raised if bid is placed after auction expiry time
     AuctionFinalized, // raised if bid is placed after auction has been finalized
 }
 
 /// For errors in which the `finalize` function can result
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Reject)]
 enum FinalizeError {
     BidMapError, // raised if there is a mistake in the bid map that keeps track of all accounts' bids
     AuctionStillActive, // raised if there is an attempt to finalize the auction before its expiry
@@ -113,7 +113,7 @@ fn auction_bid<A: HasActions>(
 
     *bid_to_update += amount;
     // Ensure that the new bid exceeds the highest bid so far
-    ensure!(*bid_to_update > state.highest_bid, BidError::BidTooLow { bid: amount, highest_bid: state.highest_bid });
+    ensure!(*bid_to_update > state.highest_bid, BidError::BidTooLow /*{ bid: amount, highest_bid: state.highest_bid }*/);
     state.highest_bid = *bid_to_update;
 
     Ok(A::accept())
@@ -351,7 +351,7 @@ mod tests {
         // 2nd bid: account2 bids amount1
         // should fail because amount is equal to highest bid
         let res2: Result<ActionsTree, _> = auction_bid(&ctx2, amount, &mut state);
-        expect_error(res2, BidError::BidTooLow { bid: amount, highest_bid: amount },
+        expect_error(res2, BidError::BidTooLow /*{ bid: amount, highest_bid: amount }*/,
                      "Bidding 2 should fail because bid amount must be higher than highest bid");
     }
 
@@ -365,7 +365,7 @@ mod tests {
         let mut state = auction_init(&ctx).expect("Init results in error");
 
         let res: Result<ActionsTree, _> = auction_bid(&ctx1, Amount::zero(), &mut state);
-        expect_error(res, BidError::BidTooLow { bid: Amount::zero(), highest_bid: Amount::zero()},
+        expect_error(res, BidError::BidTooLow /*{ bid: Amount::zero(), highest_bid: Amount::zero()}*/,
                      "Bidding zero should fail");
     }
 }

--- a/examples/auction/src/lib.rs
+++ b/examples/auction/src/lib.rs
@@ -397,4 +397,19 @@ mod tests {
             "Bidding zero should fail",
         );
     }
+
+    #[test]
+    fn test_error_codes() {
+        let errors = [
+            BidError::ContractSender,
+            BidError::BidTooLow,
+            BidError::BidsOverWaitingForAuctionFinalization,
+            BidError::AuctionFinalized,
+        ]
+        .iter()
+        .enumerate();
+        for (i, error) in errors {
+            assert_eq!(i + 1, Reject::from(*error).error_code as usize);
+        }
+    }
 }

--- a/examples/auction/src/lib.rs
+++ b/examples/auction/src/lib.rs
@@ -87,8 +87,8 @@ enum BidError {
 /// For errors in which the `finalize` function can result
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Reject)]
 enum FinalizeError {
-    BidMapError, /* raised if there is a mistake in the bid map that keeps track of all
-                  * accounts' bids */
+    BidMapError,        /* raised if there is a mistake in the bid map that keeps track of all
+                         * accounts' bids */
     AuctionStillActive, // raised if there is an attempt to finalize the auction before its expiry
     AuctionFinalized,   // raised if there is an attempt to finalize an already finalized auction
 }
@@ -186,9 +186,9 @@ mod tests {
     fn dummy_active_state(highest: Amount, bids: BTreeMap<AccountAddress, Amount>) -> State {
         State {
             auction_state: AuctionState::NotSoldYet,
-            highest_bid:   highest,
-            item:          ITEM.as_bytes().to_vec(),
-            expiry:        Timestamp::from_timestamp_millis(AUCTION_END),
+            highest_bid: highest,
+            item: ITEM.as_bytes().to_vec(),
+            expiry: Timestamp::from_timestamp_millis(AUCTION_END),
             bids,
         }
     }

--- a/examples/auction/src/lib.rs
+++ b/examples/auction/src/lib.rs
@@ -116,7 +116,7 @@ fn auction_bid<A: HasActions>(
         Address::Contract(_) => bail!(BidError::ContractSender),
         Address::Account(account_address) => account_address,
     };
-    let bid_to_update = state.bids.entry(sender_address).or_insert_with(|| Amount::zero());
+    let bid_to_update = state.bids.entry(sender_address).or_insert_with(Amount::zero);
 
     *bid_to_update += amount;
     // Ensure that the new bid exceeds the highest bid so far

--- a/examples/auction/src/lib.rs
+++ b/examples/auction/src/lib.rs
@@ -397,19 +397,4 @@ mod tests {
             "Bidding zero should fail",
         );
     }
-
-    #[test]
-    fn test_error_codes() {
-        let errors = [
-            BidError::ContractSender,
-            BidError::BidTooLow,
-            BidError::BidsOverWaitingForAuctionFinalization,
-            BidError::AuctionFinalized,
-        ]
-        .iter()
-        .enumerate();
-        for (i, error) in errors {
-            assert_eq!(i + 1, Reject::from(*error).error_code as usize);
-        }
-    }
 }

--- a/examples/auction/src/lib.rs
+++ b/examples/auction/src/lib.rs
@@ -74,7 +74,7 @@ struct InitParameter {
 }
 
 /// For errors in which the `bid` function can result
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Reject)]
+#[derive(Debug, PartialEq, Eq, Clone, Reject)]
 enum BidError {
     ContractSender, // raised if a contract, as opposed to account, tries to bid
     BidTooLow,      /* { bid: Amount, highest_bid: Amount } */
@@ -85,7 +85,7 @@ enum BidError {
 }
 
 /// For errors in which the `finalize` function can result
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Reject)]
+#[derive(Debug, PartialEq, Eq, Clone, Reject)]
 enum FinalizeError {
     BidMapError,        /* raised if there is a mistake in the bid map that keeps track of all
                          * accounts' bids */

--- a/examples/piggy-bank/part2/src/lib.rs
+++ b/examples/piggy-bank/part2/src/lib.rs
@@ -46,7 +46,7 @@ fn piggy_insert<A: HasActions>(
     Ok(A::accept())
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Reject)]
 enum SmashError {
     NotOwner,
     AlreadySmashed,

--- a/examples/two-step-transfer/src/lib.rs
+++ b/examples/two-step-transfer/src/lib.rs
@@ -98,6 +98,7 @@ pub struct State {
 #[derive(Debug, PartialEq, Eq, Reject)]
 enum InitError {
     /// Failed parsing the parameter
+    #[from(ParseError)]
     ParseParams,
     /// Not enough account holders: At least two are needed for this contract
     /// to be valid.
@@ -109,10 +110,6 @@ enum InitError {
     /// The number of account holders required to accept a transfer must be two
     /// or more else you would be better off with a normal account!
     ThresholdBelowTwo,
-}
-
-impl From<ParseError> for InitError {
-    fn from(_: ParseError) -> Self { InitError::ParseParams }
 }
 
 #[init(contract = "two-step-transfer", parameter = "InitParams", payable)]
@@ -147,6 +144,7 @@ fn contract_receive_deposit<A: HasActions>(
 #[derive(Debug, PartialEq, Eq, Reject)]
 enum ReceiveError {
     /// Failed parsing the parameter.
+    #[from(ParseError)]
     ParseParams,
     /// Only account holders can interact with this contract.
     NotAccountHolder,
@@ -166,10 +164,6 @@ enum ReceiveError {
     RequestAlreadySupported,
     /// End time is not expressible, i.e., would overflow.
     Overflow,
-}
-
-impl From<ParseError> for ReceiveError {
-    fn from(_: ParseError) -> Self { ReceiveError::ParseParams }
 }
 
 #[receive(contract = "two-step-transfer", name = "receive", parameter = "Message", payable)]

--- a/examples/two-step-transfer/src/lib.rs
+++ b/examples/two-step-transfer/src/lib.rs
@@ -95,7 +95,7 @@ pub struct State {
 
 // Contract implementation
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Reject)]
 enum InitError {
     /// Failed parsing the parameter
     ParseParams,
@@ -144,7 +144,7 @@ fn contract_receive_deposit<A: HasActions>(
     Ok(A::accept())
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Reject)]
 enum ReceiveError {
     /// Failed parsing the parameter.
     ParseParams,


### PR DESCRIPTION
Note: the changes in the auction smart contract are hard to see because I did a reformatting. But the only "real" changes are that the custom error types derive `Reject` (like in the other example contracts), and that it removes fields from the `BidTooLow` error, because we don't support enums with fields yet.