### PR TITLE
Add error handling for logging.

### DIFF
--- a/concordium-std/src/constants.rs
+++ b/concordium-std/src/constants.rs
@@ -1,2 +1,8 @@
 /// Maximum size of the contract state in bytes.
 pub const MAX_CONTRACT_STATE_SIZE: u32 = 16384;
+
+/// Maximum log size.
+pub const MAX_LOG_SIZE: usize = 512;
+
+/// Maximum number of log items.
+pub const MAX_NUM_LOGS: usize = 64;

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -35,6 +35,42 @@ impl From<LogError> for Reject {
     }
 }
 
+/// MissingInitPrefix is mapped to i32::MIN + 5, and TooLong is mapped to
+/// i32::MIN + 6.
+impl From<NewContractNameError> for Reject {
+    fn from(nre: NewContractNameError) -> Self {
+        let error_code = match nre {
+            NewContractNameError::MissingInitPrefix => unsafe {
+                crate::num::NonZeroI32::new_unchecked(i32::MIN + 5)
+            },
+            NewContractNameError::TooLong => unsafe {
+                crate::num::NonZeroI32::new_unchecked(i32::MIN + 6)
+            },
+        };
+        Self {
+            error_code,
+        }
+    }
+}
+
+/// MissingDotSeparator is mapped to i32::MIN + 7, and TooLong is mapped to
+/// i32::MIN + 8.
+impl From<NewReceiveNameError> for Reject {
+    fn from(nre: NewReceiveNameError) -> Self {
+        let error_code = match nre {
+            NewReceiveNameError::MissingDotSeparator => unsafe {
+                crate::num::NonZeroI32::new_unchecked(i32::MIN + 7)
+            },
+            NewReceiveNameError::TooLong => unsafe {
+                crate::num::NonZeroI32::new_unchecked(i32::MIN + 8)
+            },
+        };
+        Self {
+            error_code,
+        }
+    }
+}
+
 /// # Contract state trait implementations.
 impl Seek for ContractState {
     type Err = ();

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -21,6 +21,20 @@ impl convert::From<ParseError> for Reject {
     }
 }
 
+/// Full is mapped to i32::MIN+3, Malformed is mapped to i32::MIN+4.
+impl From<LogError> for Reject {
+    #[inline(always)]
+    fn from(le: LogError) -> Self {
+        let error_code = match le {
+            LogError::Full => unsafe { crate::num::NonZeroI32::new_unchecked(i32::MIN + 3) },
+            LogError::Malformed => unsafe { crate::num::NonZeroI32::new_unchecked(i32::MIN + 4) },
+        };
+        Self {
+            error_code,
+        }
+    }
+}
+
 /// # Contract state trait implementations.
 impl Seek for ContractState {
     type Err = ();

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -451,10 +451,12 @@ impl HasLogger for Logger {
         }
     }
 
-    #[inline(always)]
-    fn log_raw(&mut self, event: &[u8]) {
-        unsafe {
-            log_event(event.as_ptr(), event.len() as u32);
+    fn log_raw(&mut self, event: &[u8]) -> Result<(), LogError> {
+        let res = unsafe { log_event(event.as_ptr(), event.len() as u32) };
+        match res {
+            1 => Ok(()),
+            0 => Err(LogError::Full),
+            _ => Err(LogError::Malformed),
         }
     }
 }

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -34,8 +34,11 @@ extern "C" {
     // of bytes written. The location is assumed to contain enough memory to
     // write the requested length into.
     pub(crate) fn get_policy_section(policy_bytes: *mut u8, length: u32, offset: u32) -> u32;
-    // Add a log item.
-    pub(crate) fn log_event(start: *const u8, length: u32);
+    // Add a log item. Return values are
+    // - -1 if logging failed due to the message being too long
+    // - 0 if the log is already full
+    // - 1 if data was successfully logged.
+    pub(crate) fn log_event(start: *const u8, length: u32) -> i32;
     // returns how many bytes were read.
     pub(crate) fn load_state(start: *mut u8, length: u32, offset: u32) -> u32;
     // returns how many bytes were written

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -448,7 +448,16 @@ impl HasLogger for LogRecorder {
         }
     }
 
-    fn log_raw(&mut self, event: &[u8]) { self.logs.push(event.to_vec()) }
+    fn log_raw(&mut self, event: &[u8]) -> Result<(), LogError> {
+        if event.len() > constants::MAX_LOG_SIZE {
+            return Err(LogError::Malformed);
+        }
+        if self.logs.len() >= constants::MAX_NUM_LOGS {
+            return Err(LogError::Full);
+        }
+        self.logs.push(event.to_vec());
+        Ok(())
+    }
 }
 
 /// An actions tree, used to provide a simpler presentation for testing.

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -5,6 +5,7 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+use crate::types::LogError;
 use concordium_contracts_common::*;
 
 /// Objects which can access parameters to contracts.
@@ -137,12 +138,13 @@ pub trait HasLogger {
     /// Initialize a logger.
     fn init() -> Self;
 
-    /// Log the given bytes as-is.
-    fn log_raw(&mut self, event: &[u8]);
+    /// Log the given slice as-is. If logging is not successful an error will be
+    /// returned.
+    fn log_raw(&mut self, event: &[u8]) -> Result<(), LogError>;
 
     #[inline(always)]
     /// Log a serializable event by serializing it with a supplied serializer.
-    fn log<S: Serial>(&mut self, event: &S) {
+    fn log<S: Serial>(&mut self, event: &S) -> Result<(), LogError> {
         let mut out = Vec::new();
         if event.serial(&mut out).is_err() {
             crate::trap(); // should not happen

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -27,6 +27,15 @@ pub struct Logger {
     pub(crate) _private: (),
 }
 
+/// Errors that can occur during logging.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum LogError {
+    /// The log is full.
+    Full,
+    /// The message to log was malformed (e.g., too long)
+    Malformed,
+}
+
 /// Actions that can be produced at the end of a contract execution. This
 /// type is deliberately not cloneable so that we can enforce that
 /// `and_then` and `or_else` can only be used when more than one event is

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -29,6 +29,7 @@ pub struct Logger {
 
 /// Errors that can occur during logging.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[repr(u8)]
 pub enum LogError {
     /// The log is full.
     Full,

--- a/examples/auction/Cargo.toml
+++ b/examples/auction/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-concordium-std = { path = "../../concordium-std" }
+# concordium-std = "*"
+concordium-std = {path = "../../concordium-std"}
 
 [lib]
 crate-type=["cdylib", "rlib"]


### PR DESCRIPTION
Since the amount of logs is restricted it is more ergonomic to report an error
rather than fail execution.