### PR TITLE
CB-1203: Ergonomic send

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Change the `receive_name` parameter of `HasActions::send` to use `ReceiveName`
   instead of `str`.
 - Rename `send` to `send_raw` in `HasActions`.
+- Rename `log_bytes` to `log_raw` in `HasLogger`.
 - Add `send`, a wrapper for `HasActions::send_raw`, which automatically
   serializes `parameter` (using `Serial`).
 - Allow init and receive methods to return custom error codes that will be displayed to the user

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -8,6 +8,7 @@
   reverts the change in concordium-std 0.4.1.
 - Change the `receive_name` parameter of `HasActions::send` to use `ReceiveName`
   instead of `str`.
+- Rename `send` to `send_raw` in `HasActions`.
 - Add `simple_send`, a wrapper for `HasActions::send`, which automatically
   serializes `parameter` (using `Serial`).
 - Allow init and receive methods to return custom error codes that will be displayed to the user

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Change the `receive_name` parameter of `HasActions::send` to use `ReceiveName`
   instead of `str`.
 - Rename `send` to `send_raw` in `HasActions`.
-- Add `simple_send`, a wrapper for `HasActions::send`, which automatically
+- Add `send`, a wrapper for `HasActions::send_raw`, which automatically
   serializes `parameter` (using `Serial`).
 - Allow init and receive methods to return custom error codes that will be displayed to the user
   if a smart-contract invocation fails.

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -6,6 +6,10 @@
   to be consistent with the Write implementation for ContractState.
 - Use little-endian encoding for sender contract addresses in receive contexts. This
   reverts the change in concordium-std 0.4.1.
+- Change the `receive_name` parameter of `HasActions::send` to use `ReceiveName`
+  instead of `str`.
+- Add `simple_send`, a wrapper for `HasActions::send`, which automatically
+  serializes `parameter` (using `Serial`).
 
 ## concordium-std 0.4.1 (2021-02-22)
 

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -20,7 +20,7 @@ version = "=0.5"
 
 [dependencies.concordium-contracts-common]
 path = "../concordium-contracts-common"
-version = "=0.3.1"
+version = "=0.3.2"
 default-features = false
 
 [features]

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -534,7 +534,8 @@ pub fn put_in_memory(input: &[u8]) -> *mut u8 {
     ptr
 }
 
-/// Wrapper for HasActions::send_raw, which automatically serializes the parameter.
+/// Wrapper for HasActions::send_raw, which automatically serializes the
+/// parameter.
 pub fn send<A: HasActions, P: Serial>(
     ca: &ContractAddress,
     receive_name: ReceiveName,

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -452,7 +452,7 @@ impl HasLogger for Logger {
     }
 
     #[inline(always)]
-    fn log_bytes(&mut self, event: &[u8]) {
+    fn log_raw(&mut self, event: &[u8]) {
         unsafe {
             log_event(event.as_ptr(), event.len() as u32);
         }

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -478,7 +478,7 @@ impl HasActions for Action {
     }
 
     #[inline(always)]
-    fn send(
+    fn send_raw(
         ca: &ContractAddress,
         receive_name: ReceiveName,
         amount: Amount,
@@ -534,7 +534,7 @@ pub fn put_in_memory(input: &[u8]) -> *mut u8 {
     ptr
 }
 
-/// Wrapper for HasActions::Send, which automatically serializes the parameter.
+/// Wrapper for HasActions::send_raw, which automatically serializes the parameter.
 pub fn simple_send<A: HasActions, P: Serial>(
     ca: &ContractAddress,
     receive_name: ReceiveName,
@@ -542,7 +542,7 @@ pub fn simple_send<A: HasActions, P: Serial>(
     parameter: &P,
 ) -> A {
     let param_bytes = to_bytes(parameter);
-    A::send(ca, receive_name, amount, &param_bytes)
+    A::send_raw(ca, receive_name, amount, &param_bytes)
 }
 
 impl<A, E> UnwrapAbort for Result<A, E> {

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -470,8 +470,13 @@ impl HasActions for Action {
     }
 
     #[inline(always)]
-    fn send(ca: &ContractAddress, receive_name: &ReceiveName, amount: Amount, parameter: &[u8]) -> Self {
-        let receive_bytes = receive_name.name().as_bytes();
+    fn send(
+        ca: &ContractAddress,
+        receive_name: &ReceiveName,
+        amount: Amount,
+        parameter: &[u8],
+    ) -> Self {
+        let receive_bytes = receive_name.get_chain_name().as_bytes();
         let res = unsafe {
             send(
                 ca.index,
@@ -519,6 +524,18 @@ pub fn put_in_memory(input: &[u8]) -> *mut u8 {
     #[cfg(not(feature = "std"))]
     core::mem::forget(bytes);
     ptr
+}
+
+/// Wrapper for HasActions::Send, which automatically serializes the parameter.
+#[inline(always)]
+pub fn simple_send<A: HasActions, P: Serial>(
+    ca: &ContractAddress,
+    receive_name: &ReceiveName,
+    amount: Amount,
+    parameter: &P,
+) -> A {
+    let param_bytes = to_bytes(parameter);
+    HasActions::send(ca, receive_name, amount, &param_bytes)
 }
 
 impl<A, E> UnwrapAbort for Result<A, E> {

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -470,8 +470,8 @@ impl HasActions for Action {
     }
 
     #[inline(always)]
-    fn send(ca: &ContractAddress, receive_name: &str, amount: Amount, parameter: &[u8]) -> Self {
-        let receive_bytes = receive_name.as_bytes();
+    fn send(ca: &ContractAddress, receive_name: &ReceiveName, amount: Amount, parameter: &[u8]) -> Self {
+        let receive_bytes = receive_name.name().as_bytes();
         let res = unsafe {
             send(
                 ca.index,

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -480,7 +480,7 @@ impl HasActions for Action {
     #[inline(always)]
     fn send(
         ca: &ContractAddress,
-        receive_name: &ReceiveName,
+        receive_name: ReceiveName,
         amount: Amount,
         parameter: &[u8],
     ) -> Self {
@@ -535,15 +535,14 @@ pub fn put_in_memory(input: &[u8]) -> *mut u8 {
 }
 
 /// Wrapper for HasActions::Send, which automatically serializes the parameter.
-#[inline(always)]
 pub fn simple_send<A: HasActions, P: Serial>(
     ca: &ContractAddress,
-    receive_name: &ReceiveName,
+    receive_name: ReceiveName,
     amount: Amount,
     parameter: &P,
 ) -> A {
     let param_bytes = to_bytes(parameter);
-    HasActions::send(ca, receive_name, amount, &param_bytes)
+    A::send(ca, receive_name, amount, &param_bytes)
 }
 
 impl<A, E> UnwrapAbort for Result<A, E> {

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -534,8 +534,12 @@ pub fn put_in_memory(input: &[u8]) -> *mut u8 {
     ptr
 }
 
-/// Wrapper for HasActions::send_raw, which automatically serializes the
-/// parameter.
+/// Wrapper for
+/// [HasActions::send_raw](./trait.HasActions.html#tymethod.send_raw), which
+/// automatically serializes the parameter. Note that if the parameter is
+/// already a byte array or convertible to a byte array without allocations it
+/// is preferrable to use [send_raw](./trait.HasActions.html#tymethod.send_raw).
+/// It is more efficient and avoids memory allocations.
 pub fn send<A: HasActions, P: Serial>(
     ca: &ContractAddress,
     receive_name: ReceiveName,

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1,4 +1,4 @@
-use crate::{convert, mem, num, prims::*, traits::*, types::*};
+use crate::{convert, mem, num, prims, prims::*, traits::*, types::*};
 use concordium_contracts_common::*;
 
 use mem::MaybeUninit;
@@ -486,7 +486,7 @@ impl HasActions for Action {
     ) -> Self {
         let receive_bytes = receive_name.get_chain_name().as_bytes();
         let res = unsafe {
-            send(
+            prims::send(
                 ca.index,
                 ca.subindex,
                 receive_bytes.as_ptr(),
@@ -535,7 +535,7 @@ pub fn put_in_memory(input: &[u8]) -> *mut u8 {
 }
 
 /// Wrapper for HasActions::send_raw, which automatically serializes the parameter.
-pub fn simple_send<A: HasActions, P: Serial>(
+pub fn send<A: HasActions, P: Serial>(
     ca: &ContractAddress,
     receive_name: ReceiveName,
     amount: Amount,

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -487,7 +487,7 @@ impl HasActions for ActionsTree {
 
     fn send(
         ca: &ContractAddress,
-        receive_name: &ReceiveName,
+        receive_name: ReceiveName,
         amount: Amount,
         parameter: &[u8],
     ) -> Self {

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -485,7 +485,7 @@ impl HasActions for ActionsTree {
         }
     }
 
-    fn send(
+    fn send_raw(
         ca: &ContractAddress,
         receive_name: ReceiveName,
         amount: Amount,

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -485,10 +485,10 @@ impl HasActions for ActionsTree {
         }
     }
 
-    fn send(ca: &ContractAddress, receive_name: &str, amount: Amount, parameter: &[u8]) -> Self {
+    fn send(ca: &ContractAddress, receive_name: &ReceiveName, amount: Amount, parameter: &[u8]) -> Self {
         ActionsTree::Send {
             to: *ca,
-            receive_name: receive_name.to_string(),
+            receive_name: receive_name.name().to_string(),
             amount,
             parameter: parameter.to_vec(),
         }

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -448,7 +448,7 @@ impl HasLogger for LogRecorder {
         }
     }
 
-    fn log_bytes(&mut self, event: &[u8]) { self.logs.push(event.to_vec()) }
+    fn log_raw(&mut self, event: &[u8]) { self.logs.push(event.to_vec()) }
 }
 
 /// An actions tree, used to provide a simpler presentation for testing.

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -461,7 +461,7 @@ pub enum ActionsTree {
     },
     Send {
         to:           ContractAddress,
-        receive_name: String,
+        receive_name: OwnedReceiveName,
         amount:       Amount,
         parameter:    Vec<u8>,
     },
@@ -493,7 +493,7 @@ impl HasActions for ActionsTree {
     ) -> Self {
         ActionsTree::Send {
             to: *ca,
-            receive_name: receive_name.get_chain_name().to_string(),
+            receive_name: receive_name.to_owned(),
             amount,
             parameter: parameter.to_vec(),
         }

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -485,10 +485,15 @@ impl HasActions for ActionsTree {
         }
     }
 
-    fn send(ca: &ContractAddress, receive_name: &ReceiveName, amount: Amount, parameter: &[u8]) -> Self {
+    fn send(
+        ca: &ContractAddress,
+        receive_name: &ReceiveName,
+        amount: Amount,
+        parameter: &[u8],
+    ) -> Self {
         ActionsTree::Send {
             to: *ca,
-            receive_name: receive_name.name().to_string(),
+            receive_name: receive_name.get_chain_name().to_string(),
             amount,
             parameter: parameter.to_vec(),
         }

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -164,7 +164,7 @@ pub trait HasActions {
     fn simple_transfer(acc: &AccountAddress, amount: Amount) -> Self;
 
     /// Send a message to a contract.
-    fn send(
+    fn send_raw(
         ca: &ContractAddress,
         receive_name: ReceiveName,
         amount: Amount,

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -166,7 +166,7 @@ pub trait HasActions {
     /// Send a message to a contract.
     fn send(
         ca: &ContractAddress,
-        receive_name: &ReceiveName,
+        receive_name: ReceiveName,
         amount: Amount,
         parameter: &[u8],
     ) -> Self;

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -164,7 +164,7 @@ pub trait HasActions {
     fn simple_transfer(acc: &AccountAddress, amount: Amount) -> Self;
 
     /// Send a message to a contract.
-    fn send(ca: &ContractAddress, receive_name: &str, amount: Amount, parameter: &[u8]) -> Self;
+    fn send(ca: &ContractAddress, receive_name: &ReceiveName, amount: Amount, parameter: &[u8]) -> Self;
 
     /// If the execution of the first action succeeds, run the second action
     /// as well.

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -164,7 +164,12 @@ pub trait HasActions {
     fn simple_transfer(acc: &AccountAddress, amount: Amount) -> Self;
 
     /// Send a message to a contract.
-    fn send(ca: &ContractAddress, receive_name: &ReceiveName, amount: Amount, parameter: &[u8]) -> Self;
+    fn send(
+        ca: &ContractAddress,
+        receive_name: &ReceiveName,
+        amount: Amount,
+        parameter: &[u8],
+    ) -> Self;
 
     /// If the execution of the first action succeeds, run the second action
     /// as well.

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -138,7 +138,7 @@ pub trait HasLogger {
     fn init() -> Self;
 
     /// Log the given bytes as-is.
-    fn log_bytes(&mut self, event: &[u8]);
+    fn log_raw(&mut self, event: &[u8]);
 
     #[inline(always)]
     /// Log a serializable event by serializing it with a supplied serializer.
@@ -147,7 +147,7 @@ pub trait HasLogger {
         if event.serial(&mut out).is_err() {
             crate::trap(); // should not happen
         }
-        self.log_bytes(&out)
+        self.log_raw(&out)
     }
 }
 


### PR DESCRIPTION
Closes CB-1203.

Makes `HasActions::send` more ergonomic:

- Change the `receive_name` parameter of `HasActions::send` to use `ReceiveName`
  instead of `str`.
- Rename `send` to `send_raw`
- Rename `log_bytes` to `log_raw`
- Add `send`, a wrapper for `HasActions::send_raw`, which automatically
  serializes `parameter` (using `Serial`).

Related:
https://gitlab.com/Concordium/smart-contracts/-/merge_requests/125
https://gitlab.com/Concordium/concordium-client/-/merge_requests/291
https://github.com/Concordium/concordium-contracts-common/pull/14