### PR TITLE
Ensure ordered

### DIFF
--- a/concordium-std-derive/CHANGELOG.md
+++ b/concordium-std-derive/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased changes
 - Validate contract and receive names
 - Improve precision of error locations in init and receive_workers
+- Improve precision of error locations for `size_length`
+- Unified the `map_size_length`, `set_size_length`, and `string_size_length`
+  into `size_length`.
+- Make `ensure_ordered` work without having to specify a size length.
 
 ## concordium-std-derive 0.5.0 (2021-05-12)
 

--- a/concordium-std-derive/CHANGELOG.md
+++ b/concordium-std-derive/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Validate contract and receive names
 - Improve precision of error locations in init and receive_workers
 - Improve precision of error locations for `size_length`
-- Unified the `map_size_length`, `set_size_length`, and `string_size_length`
+- Unify the `map_size_length`, `set_size_length`, and `string_size_length`
   into `size_length`.
 - Make `ensure_ordered` work without having to specify a size length.
 

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -572,7 +572,7 @@ fn contract_function_schema_tokens(
 /// In addition to the attributes supported by `derive(Serial)`, this derivation
 /// macro supports the `ensure_ordered` attribute. If applied to a field the
 /// of type `BTreeMap` or `BTreeSet` deserialization will additionally ensure
-/// that there keys are in strictly increasing order. By default deserialization
+/// that the keys are in strictly increasing order. By default deserialization
 /// only ensures uniqueness.
 ///
 /// # Example

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -697,7 +697,7 @@ fn impl_deserial_field(
         // Default size length is u32, i.e. 4 bytes.
         let l = format_ident!("U{}", 8 * size_length.unwrap_or(4));
         Ok(quote! {
-            let #ident = <#ty as DeserialCtx>::deserial_ctx(#source, concordium_std::schema::SizeLength::#l, #ensure_ordered)?;
+            let #ident = <#ty as DeserialCtx>::deserial_ctx(concordium_std::schema::SizeLength::#l, #ensure_ordered, #source)?;
         })
     } else {
         Ok(quote! {

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -700,7 +700,7 @@ fn impl_deserial_field(
 
     let ty = &f.ty;
     Ok(quote! {
-        let #ident = <#ty as DeserialCtx>::deserial_ctx(#source, concordium_std::schema::SizeLength::#size_length, #ensure_ordered)?;
+        let #ident = <#ty as DeserialCtx>::deserial_ctx(#source, &concordium_std::schema::SizeLength::#size_length, #ensure_ordered)?;
     })
 }
 
@@ -866,7 +866,7 @@ fn impl_serial_field(
     let l = find_length_attribute(&field.attrs, "size_length")?.unwrap_or(4);
     let size_length = format_ident!("U{}", 8 * l);
     Ok(quote! {
-        #ident.serial_ctx(concordium_std::schema::SizeLength::#size_length, #out)?;
+        #ident.serial_ctx(&concordium_std::schema::SizeLength::#size_length, #out)?;
     })
 }
 

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -694,12 +694,13 @@ fn impl_deserial_field(
     let concordium_attributes = get_concordium_field_attributes(&f.attrs)?;
     let ensure_ordered = contains_attribute(&concordium_attributes, "ensure_ordered");
 
-    // Default size is u32, i.e. 4 bytes.
-    let size_length = find_length_attribute(&f.attrs, "size_length")?.unwrap_or(4);
+    // Default size length is u32, i.e. 4 bytes.
+    let l = find_length_attribute(&f.attrs, "size_length")?.unwrap_or(4);
+    let size_length = format_ident!("U{}", 8 * l);
 
     let ty = &f.ty;
     Ok(quote! {
-        let #ident = <#ty as DeserialCtx>::deserial_ctx(#source, #size_length, #ensure_ordered)?;
+        let #ident = <#ty as DeserialCtx>::deserial_ctx(#source, concordium_std::schema::SizeLength::#size_length, #ensure_ordered)?;
     })
 }
 
@@ -861,10 +862,11 @@ fn impl_serial_field(
     ident: &proc_macro2::TokenStream,
     out: &syn::Ident,
 ) -> syn::Result<proc_macro2::TokenStream> {
-    // Default size is u32, i.e. 4 bytes.
-    let size_length = find_length_attribute(&field.attrs, "size_length")?.unwrap_or(4);
+    // Default size length is u32, i.e. 4 bytes.
+    let l = find_length_attribute(&field.attrs, "size_length")?.unwrap_or(4);
+    let size_length = format_ident!("U{}", 8 * l);
     Ok(quote! {
-        #ident.serial_ctx(#size_length, #out)?;
+        #ident.serial_ctx(concordium_std::schema::SizeLength::#size_length, #out)?;
     })
 }
 

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -697,7 +697,7 @@ fn impl_deserial_field(
         // Default size length is u32, i.e. 4 bytes.
         let l = format_ident!("U{}", 8 * size_length.unwrap_or(4));
         Ok(quote! {
-            let #ident = <#ty as DeserialCtx>::deserial_ctx(#source, &concordium_std::schema::SizeLength::#l, #ensure_ordered)?;
+            let #ident = <#ty as DeserialCtx>::deserial_ctx(#source, concordium_std::schema::SizeLength::#l, #ensure_ordered)?;
         })
     } else {
         Ok(quote! {
@@ -867,7 +867,7 @@ fn impl_serial_field(
     if let Some(size_length) = find_length_attribute(&field.attrs)? {
         let l = format_ident!("U{}", 8 * size_length);
         Ok(quote! {
-            #ident.serial_ctx(&concordium_std::schema::SizeLength::#l, #out)?;
+            #ident.serial_ctx(concordium_std::schema::SizeLength::#l, #out)?;
         })
     } else {
         Ok(quote! {

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -665,24 +665,25 @@ fn find_length_attribute(
         None => return Ok(None),
     };
 
+    // Save the span to be used in errors.
+    let value_span = value.span();
+
     let value = match value {
         syn::Lit::Int(int) => int,
-        _ => {
-            return Err(syn::Error::new(value.span(), "Length attribute value must be an integer."))
-        }
+        _ => return Err(syn::Error::new(value_span, "Length attribute value must be an integer.")),
     };
     let value = match value.base10_parse() {
         Ok(v) => v,
         _ => {
             return Err(syn::Error::new(
-                value.span(),
+                value_span,
                 "Length attribute value must be a base 10 integer.",
             ))
         }
     };
     match value {
         1 | 2 | 4 | 8 => Ok(Some(value)),
-        _ => Err(syn::Error::new(value.span(), "Length info must be either 1, 2, 4, or 8.")),
+        _ => Err(syn::Error::new(value_span, "Length info must be either 1, 2, 4, or 8.")),
     }
 }
 

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -697,7 +697,7 @@ fn impl_deserial_field(
         // Default size length is u32, i.e. 4 bytes.
         let l = format_ident!("U{}", 8 * size_length.unwrap_or(4));
         Ok(quote! {
-            let #ident = <#ty as DeserialCtx>::deserial_ctx(concordium_std::schema::SizeLength::#l, #ensure_ordered, #source)?;
+            let #ident = <#ty as concordium_std::DeserialCtx>::deserial_ctx(concordium_std::schema::SizeLength::#l, #ensure_ordered, #source)?;
         })
     } else {
         Ok(quote! {
@@ -867,6 +867,7 @@ fn impl_serial_field(
     if let Some(size_length) = find_length_attribute(&field.attrs)? {
         let l = format_ident!("U{}", 8 * size_length);
         Ok(quote! {
+            use concordium_std::SerialCtx;
             #ident.serial_ctx(concordium_std::schema::SizeLength::#l, #out)?;
         })
     } else {

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -680,73 +680,85 @@ impl<A: fmt::Debug> ExpectNoneReport for Option<A> {
     }
 }
 
-// fn serial_as_size_length<W: Write>(
-//     len: usize,
-//     size_length: schema::SizeLength,
-//     out: &mut W,
-// ) -> Result<(), W::Err> {
-//     match size_length {
-//         schema::SizeLength::U8 => (len as u8).serial(out),
-//         schema::SizeLength::U16 => (len as u16).serial(out),
-//         schema::SizeLength::U32 => (len as u32).serial(out),
-//         schema::SizeLength::U64 => (len as u64).serial(out),
-//     }
-// }
-
-fn deserial_length(source: &mut impl Read, size_length: u32) -> ParseResult<usize> {
+fn deserial_length(source: &mut impl Read, size_length: schema::SizeLength) -> ParseResult<usize> {
     use core::convert::TryInto;
     let res = match size_length {
-        1 => u8::deserial(source)?.into(),
-        2 => u16::deserial(source)?.into(),
-        4 => u32::deserial(source)?.try_into().map_err(|_| ParseError::default())?,
-        8 => u64::deserial(source)?.try_into().map_err(|_| ParseError::default())?,
-        _ => return Err(Default::default()),
+        schema::SizeLength::U8 => u8::deserial(source)?.into(),
+        schema::SizeLength::U16 => u16::deserial(source)?.into(),
+        schema::SizeLength::U32 => {
+            u32::deserial(source)?.try_into().map_err(|_| ParseError::default())?
+        }
+        schema::SizeLength::U64 => {
+            u64::deserial(source)?.try_into().map_err(|_| ParseError::default())?
+        }
     };
     Ok(res)
 }
 
-fn serial_length<W: Write>(len: usize, size_length: u32, out: &mut W) -> Result<(), W::Err> {
+fn serial_length<W: Write>(
+    len: usize,
+    size_length: schema::SizeLength,
+    out: &mut W,
+) -> Result<(), W::Err> {
     match size_length {
-        1 => (len as u8).serial(out)?,
-        2 => (len as u16).serial(out)?,
-        4 => (len as u32).serial(out)?,
-        8 => (len as u64).serial(out)?,
-        _ => return Err(Default::default()),
+        schema::SizeLength::U8 => (len as u8).serial(out)?,
+        schema::SizeLength::U16 => (len as u16).serial(out)?,
+        schema::SizeLength::U32 => (len as u32).serial(out)?,
+        schema::SizeLength::U64 => (len as u64).serial(out)?,
     }
     Ok(())
 }
 
 impl<K: Serial + Ord> SerialCtx for BTreeSet<K> {
-    fn serial_ctx<W: Write>(&self, size_length: u32, out: &mut W) -> Result<(), W::Err> {
+    fn serial_ctx<W: Write>(
+        &self,
+        size_length: schema::SizeLength,
+        out: &mut W,
+    ) -> Result<(), W::Err> {
         serial_length(self.len(), size_length, out)?;
         serial_set_no_length(self, out)
     }
 }
 
 impl<K: Serial + Ord, V: Serial> SerialCtx for BTreeMap<K, V> {
-    fn serial_ctx<W: Write>(&self, size_length: u32, out: &mut W) -> Result<(), W::Err> {
+    fn serial_ctx<W: Write>(
+        &self,
+        size_length: schema::SizeLength,
+        out: &mut W,
+    ) -> Result<(), W::Err> {
         serial_length(self.len(), size_length, out)?;
         serial_map_no_length(self, out)
     }
 }
 
 impl<T: Serial> SerialCtx for &[T] {
-    fn serial_ctx<W: Write>(&self, size_length: u32, out: &mut W) -> Result<(), W::Err> {
+    fn serial_ctx<W: Write>(
+        &self,
+        size_length: schema::SizeLength,
+        out: &mut W,
+    ) -> Result<(), W::Err> {
         serial_length(self.len(), size_length, out)?;
         serial_vector_no_length(self, out)
     }
 }
 
 impl SerialCtx for &str {
-    fn serial_ctx<W: Write>(&self, size_length: u32, out: &mut W) -> Result<(), W::Err> {
+    fn serial_ctx<W: Write>(
+        &self,
+        size_length: schema::SizeLength,
+        out: &mut W,
+    ) -> Result<(), W::Err> {
         serial_length(self.len(), size_length, out)?;
-        // TODO: perhaps use the one from crypto, or move to a common place
         serial_vector_no_length(&self.as_bytes().to_vec(), out)
     }
 }
 
 impl SerialCtx for String {
-    fn serial_ctx<W: Write>(&self, size_length: u32, out: &mut W) -> Result<(), W::Err> {
+    fn serial_ctx<W: Write>(
+        &self,
+        size_length: schema::SizeLength,
+        out: &mut W,
+    ) -> Result<(), W::Err> {
         self.as_str().serial_ctx(size_length, out)
     }
 }
@@ -754,7 +766,7 @@ impl SerialCtx for String {
 impl<K: Deserial + Ord + Copy> DeserialCtx for BTreeSet<K> {
     fn deserial_ctx<R: Read>(
         source: &mut R,
-        size_length: u32,
+        size_length: schema::SizeLength,
         ensure_ordered: bool,
     ) -> ParseResult<Self> {
         let len = deserial_length(source, size_length)?;
@@ -769,7 +781,7 @@ impl<K: Deserial + Ord + Copy> DeserialCtx for BTreeSet<K> {
 impl<K: Deserial + Ord + Copy, V: Deserial> DeserialCtx for BTreeMap<K, V> {
     fn deserial_ctx<R: Read>(
         source: &mut R,
-        size_length: u32,
+        size_length: schema::SizeLength,
         ensure_ordered: bool,
     ) -> ParseResult<Self> {
         let len = deserial_length(source, size_length)?;
@@ -784,7 +796,7 @@ impl<K: Deserial + Ord + Copy, V: Deserial> DeserialCtx for BTreeMap<K, V> {
 impl<T: Deserial> DeserialCtx for Vec<T> {
     fn deserial_ctx<R: Read>(
         source: &mut R,
-        size_length: u32,
+        size_length: schema::SizeLength,
         _ensure_ordered: bool,
     ) -> ParseResult<Self> {
         let len = deserial_length(source, size_length)?;
@@ -795,7 +807,7 @@ impl<T: Deserial> DeserialCtx for Vec<T> {
 impl DeserialCtx for String {
     fn deserial_ctx<R: Read>(
         source: &mut R,
-        size_length: u32,
+        size_length: schema::SizeLength,
         _ensure_ordered: bool,
     ) -> ParseResult<Self> {
         let len = deserial_length(source, size_length)?;

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -695,9 +695,9 @@ impl<K: Serial + Ord> SerialCtx for BTreeSet<K> {
 
 impl<K: Deserial + Ord + Copy> DeserialCtx for BTreeSet<K> {
     fn deserial_ctx<R: Read>(
-        source: &mut R,
         size_len: schema::SizeLength,
         ensure_ordered: bool,
+        source: &mut R,
     ) -> ParseResult<Self> {
         let len = schema::deserial_length(source, size_len)?;
         if ensure_ordered {
@@ -721,9 +721,9 @@ impl<K: Serial + Ord, V: Serial> SerialCtx for BTreeMap<K, V> {
 
 impl<K: Deserial + Ord + Copy, V: Deserial> DeserialCtx for BTreeMap<K, V> {
     fn deserial_ctx<R: Read>(
-        source: &mut R,
         size_len: schema::SizeLength,
         ensure_ordered: bool,
+        source: &mut R,
     ) -> ParseResult<Self> {
         let len = schema::deserial_length(source, size_len)?;
         if ensure_ordered {
@@ -747,9 +747,9 @@ impl<T: Serial> SerialCtx for &[T] {
 
 impl<T: Deserial> DeserialCtx for Vec<T> {
     fn deserial_ctx<R: Read>(
-        source: &mut R,
         size_len: schema::SizeLength,
         _ensure_ordered: bool,
+        source: &mut R,
     ) -> ParseResult<Self> {
         let len = schema::deserial_length(source, size_len)?;
         deserial_vector_no_length(source, len)
@@ -779,9 +779,9 @@ impl SerialCtx for String {
 
 impl DeserialCtx for String {
     fn deserial_ctx<R: Read>(
-        source: &mut R,
         size_len: schema::SizeLength,
         _ensure_ordered: bool,
+        source: &mut R,
     ) -> ParseResult<Self> {
         let len = schema::deserial_length(source, size_len)?;
         let bytes = deserial_vector_no_length(source, len)?;

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -685,7 +685,7 @@ impl<A: fmt::Debug> ExpectNoneReport for Option<A> {
 impl<K: Serial + Ord> SerialCtx for BTreeSet<K> {
     fn serial_ctx<W: Write>(
         &self,
-        size_len: &schema::SizeLength,
+        size_len: schema::SizeLength,
         out: &mut W,
     ) -> Result<(), W::Err> {
         schema::serial_length(self.len(), size_len, out)?;
@@ -696,7 +696,7 @@ impl<K: Serial + Ord> SerialCtx for BTreeSet<K> {
 impl<K: Deserial + Ord + Copy> DeserialCtx for BTreeSet<K> {
     fn deserial_ctx<R: Read>(
         source: &mut R,
-        size_len: &schema::SizeLength,
+        size_len: schema::SizeLength,
         ensure_ordered: bool,
     ) -> ParseResult<Self> {
         let len = schema::deserial_length(source, size_len)?;
@@ -711,7 +711,7 @@ impl<K: Deserial + Ord + Copy> DeserialCtx for BTreeSet<K> {
 impl<K: Serial + Ord, V: Serial> SerialCtx for BTreeMap<K, V> {
     fn serial_ctx<W: Write>(
         &self,
-        size_len: &schema::SizeLength,
+        size_len: schema::SizeLength,
         out: &mut W,
     ) -> Result<(), W::Err> {
         schema::serial_length(self.len(), size_len, out)?;
@@ -722,7 +722,7 @@ impl<K: Serial + Ord, V: Serial> SerialCtx for BTreeMap<K, V> {
 impl<K: Deserial + Ord + Copy, V: Deserial> DeserialCtx for BTreeMap<K, V> {
     fn deserial_ctx<R: Read>(
         source: &mut R,
-        size_len: &schema::SizeLength,
+        size_len: schema::SizeLength,
         ensure_ordered: bool,
     ) -> ParseResult<Self> {
         let len = schema::deserial_length(source, size_len)?;
@@ -737,7 +737,7 @@ impl<K: Deserial + Ord + Copy, V: Deserial> DeserialCtx for BTreeMap<K, V> {
 impl<T: Serial> SerialCtx for &[T] {
     fn serial_ctx<W: Write>(
         &self,
-        size_len: &schema::SizeLength,
+        size_len: schema::SizeLength,
         out: &mut W,
     ) -> Result<(), W::Err> {
         schema::serial_length(self.len(), size_len, out)?;
@@ -748,7 +748,7 @@ impl<T: Serial> SerialCtx for &[T] {
 impl<T: Deserial> DeserialCtx for Vec<T> {
     fn deserial_ctx<R: Read>(
         source: &mut R,
-        size_len: &schema::SizeLength,
+        size_len: schema::SizeLength,
         _ensure_ordered: bool,
     ) -> ParseResult<Self> {
         let len = schema::deserial_length(source, size_len)?;
@@ -759,7 +759,7 @@ impl<T: Deserial> DeserialCtx for Vec<T> {
 impl SerialCtx for &str {
     fn serial_ctx<W: Write>(
         &self,
-        size_len: &schema::SizeLength,
+        size_len: schema::SizeLength,
         out: &mut W,
     ) -> Result<(), W::Err> {
         schema::serial_length(self.len(), size_len, out)?;
@@ -770,7 +770,7 @@ impl SerialCtx for &str {
 impl SerialCtx for String {
     fn serial_ctx<W: Write>(
         &self,
-        size_len: &schema::SizeLength,
+        size_len: schema::SizeLength,
         out: &mut W,
     ) -> Result<(), W::Err> {
         self.as_str().serial_ctx(size_len, out)
@@ -780,7 +780,7 @@ impl SerialCtx for String {
 impl DeserialCtx for String {
     fn deserial_ctx<R: Read>(
         source: &mut R,
-        size_len: &schema::SizeLength,
+        size_len: schema::SizeLength,
         _ensure_ordered: bool,
     ) -> ParseResult<Self> {
         let len = schema::deserial_length(source, size_len)?;

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -628,6 +628,7 @@ impl<A, E> UnwrapAbort for Result<A, E> {
 
 #[cfg(not(feature = "std"))]
 use core::fmt;
+use std::collections::{BTreeMap, BTreeSet};
 #[cfg(feature = "std")]
 use std::fmt;
 
@@ -678,3 +679,130 @@ impl<A: fmt::Debug> ExpectNoneReport for Option<A> {
         }
     }
 }
+
+// fn serial_as_size_length<W: Write>(
+//     len: usize,
+//     size_length: schema::SizeLength,
+//     out: &mut W,
+// ) -> Result<(), W::Err> {
+//     match size_length {
+//         schema::SizeLength::U8 => (len as u8).serial(out),
+//         schema::SizeLength::U16 => (len as u16).serial(out),
+//         schema::SizeLength::U32 => (len as u32).serial(out),
+//         schema::SizeLength::U64 => (len as u64).serial(out),
+//     }
+// }
+
+fn deserial_length(source: &mut impl Read, size_length: u32) -> ParseResult<usize> {
+    use core::convert::TryInto;
+    let res = match size_length {
+        1 => u8::deserial(source)?.into(),
+        2 => u16::deserial(source)?.into(),
+        4 => u32::deserial(source)?.try_into().map_err(|_| ParseError::default())?,
+        8 => u64::deserial(source)?.try_into().map_err(|_| ParseError::default())?,
+        _ => return Err(Default::default()),
+    };
+    Ok(res)
+}
+
+fn serial_length<W: Write>(len: usize, size_length: u32, out: &mut W) -> Result<(), W::Err> {
+    match size_length {
+        1 => (len as u8).serial(out)?,
+        2 => (len as u16).serial(out)?,
+        4 => (len as u32).serial(out)?,
+        8 => (len as u64).serial(out)?,
+        _ => return Err(Default::default()),
+    }
+    Ok(())
+}
+
+impl<K: Serial + Ord> SerialCtx for BTreeSet<K> {
+    fn serial_ctx<W: Write>(&self, size_length: u32, out: &mut W) -> Result<(), W::Err> {
+        serial_length(self.len(), size_length, out)?;
+        serial_set_no_length(self, out)
+    }
+}
+
+impl<K: Serial + Ord, V: Serial> SerialCtx for BTreeMap<K, V> {
+    fn serial_ctx<W: Write>(&self, size_length: u32, out: &mut W) -> Result<(), W::Err> {
+        serial_length(self.len(), size_length, out)?;
+        serial_map_no_length(self, out)
+    }
+}
+
+impl<T: Serial> SerialCtx for &[T] {
+    fn serial_ctx<W: Write>(&self, size_length: u32, out: &mut W) -> Result<(), W::Err> {
+        serial_length(self.len(), size_length, out)?;
+        serial_vector_no_length(self, out)
+    }
+}
+
+impl SerialCtx for &str {
+    fn serial_ctx<W: Write>(&self, size_length: u32, out: &mut W) -> Result<(), W::Err> {
+        serial_length(self.len(), size_length, out)?;
+        // TODO: perhaps use the one from crypto, or move to a common place
+        serial_vector_no_length(&self.as_bytes().to_vec(), out)
+    }
+}
+
+impl SerialCtx for String {
+    fn serial_ctx<W: Write>(&self, size_length: u32, out: &mut W) -> Result<(), W::Err> {
+        self.as_str().serial_ctx(size_length, out)
+    }
+}
+
+impl<K: Deserial + Ord + Copy> DeserialCtx for BTreeSet<K> {
+    fn deserial_ctx<R: Read>(
+        source: &mut R,
+        size_length: u32,
+        ensure_ordered: bool,
+    ) -> ParseResult<Self> {
+        let len = deserial_length(source, size_length)?;
+        if ensure_ordered {
+            deserial_set_no_length(source, len)
+        } else {
+            deserial_set_no_length_no_order_check(source, len)
+        }
+    }
+}
+
+impl<K: Deserial + Ord + Copy, V: Deserial> DeserialCtx for BTreeMap<K, V> {
+    fn deserial_ctx<R: Read>(
+        source: &mut R,
+        size_length: u32,
+        ensure_ordered: bool,
+    ) -> ParseResult<Self> {
+        let len = deserial_length(source, size_length)?;
+        if ensure_ordered {
+            deserial_map_no_length(source, len)
+        } else {
+            deserial_map_no_length_no_order_check(source, len)
+        }
+    }
+}
+
+impl<T: Deserial> DeserialCtx for Vec<T> {
+    fn deserial_ctx<R: Read>(
+        source: &mut R,
+        size_length: u32,
+        _ensure_ordered: bool,
+    ) -> ParseResult<Self> {
+        let len = deserial_length(source, size_length)?;
+        deserial_vector_no_length(source, len)
+    }
+}
+
+impl DeserialCtx for String {
+    fn deserial_ctx<R: Read>(
+        source: &mut R,
+        size_length: u32,
+        _ensure_ordered: bool,
+    ) -> ParseResult<Self> {
+        let len = deserial_length(source, size_length)?;
+        let bytes = deserial_vector_no_length(source, len)?;
+        let res = String::from_utf8(bytes).map_err(|_| ParseError::default())?;
+        Ok(res)
+    }
+}
+
+// TODO: group by type instead of by trait

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1,7 +1,19 @@
 use crate::{convert, mem, num, prims, prims::*, traits::*, types::*};
+#[cfg(not(feature = "std"))]
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    string::String,
+    vec::Vec,
+};
 use concordium_contracts_common::*;
-
+#[cfg(not(feature = "std"))]
+use core::convert::{TryFrom, TryInto};
 use mem::MaybeUninit;
+#[cfg(feature = "std")]
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::{TryFrom, TryInto},
+};
 
 impl convert::From<()> for Reject {
     #[inline(always)]
@@ -88,7 +100,6 @@ impl Seek for ContractState {
     type Err = ();
 
     fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Err> {
-        use core::convert::TryFrom;
         use SeekFrom::*;
         match pos {
             Start(offset) => match u32::try_from(offset) {
@@ -145,7 +156,6 @@ impl Seek for ContractState {
 
 impl Read for ContractState {
     fn read(&mut self, buf: &mut [u8]) -> ParseResult<usize> {
-        use core::convert::TryInto;
         let len: u32 = {
             match buf.len().try_into() {
                 Ok(v) => v,
@@ -204,7 +214,6 @@ impl Write for ContractState {
     type Err = ();
 
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Err> {
-        use core::convert::TryInto;
         let len: u32 = {
             match buf.len().try_into() {
                 Ok(v) => v,
@@ -257,7 +266,6 @@ impl HasContractState<()> for ContractState {
 /// # Trait implementations for Parameter
 impl Read for Parameter {
     fn read(&mut self, buf: &mut [u8]) -> ParseResult<usize> {
-        use core::convert::TryInto;
         let len: u32 = {
             match buf.len().try_into() {
                 Ok(v) => v,
@@ -347,7 +355,6 @@ impl Iterator for PoliciesIterator {
             get_policy_section(buf.as_mut_ptr() as *mut u8, 2 + 4 + 8 + 8 + 2, self.pos);
             buf.assume_init()
         };
-        use convert::TryInto;
         let skip_part: [u8; 2] = buf[0..2].try_into().unwrap_abort();
         let ip_part: [u8; 4] = buf[2..2 + 4].try_into().unwrap_abort();
         let created_at_part: [u8; 8] = buf[2 + 4..2 + 4 + 8].try_into().unwrap_abort();
@@ -628,7 +635,6 @@ impl<A, E> UnwrapAbort for Result<A, E> {
 
 #[cfg(not(feature = "std"))]
 use core::fmt;
-use std::collections::{BTreeMap, BTreeSet};
 #[cfg(feature = "std")]
 use std::fmt;
 

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1,19 +1,15 @@
-use crate::{convert, mem, num, prims, prims::*, traits::*, types::*};
-#[cfg(not(feature = "std"))]
-use alloc::{
+use crate::{
     collections::{BTreeMap, BTreeSet},
-    string::String,
+    convert::{self, TryFrom, TryInto},
+    mem, num, prims,
+    prims::*,
+    traits::*,
+    types::*,
     vec::Vec,
+    String,
 };
 use concordium_contracts_common::*;
-#[cfg(not(feature = "std"))]
-use core::convert::{TryFrom, TryInto};
 use mem::MaybeUninit;
-#[cfg(feature = "std")]
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    convert::{TryFrom, TryInto},
-};
 
 impl convert::From<()> for Reject {
     #[inline(always)]

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -691,6 +691,21 @@ impl<K: Serial + Ord> SerialCtx for BTreeSet<K> {
     }
 }
 
+impl<K: Deserial + Ord + Copy> DeserialCtx for BTreeSet<K> {
+    fn deserial_ctx<R: Read>(
+        source: &mut R,
+        size_len: &schema::SizeLength,
+        ensure_ordered: bool,
+    ) -> ParseResult<Self> {
+        let len = schema::deserial_length(source, size_len)?;
+        if ensure_ordered {
+            deserial_set_no_length(source, len)
+        } else {
+            deserial_set_no_length_no_order_check(source, len)
+        }
+    }
+}
+
 impl<K: Serial + Ord, V: Serial> SerialCtx for BTreeMap<K, V> {
     fn serial_ctx<W: Write>(
         &self,
@@ -702,6 +717,21 @@ impl<K: Serial + Ord, V: Serial> SerialCtx for BTreeMap<K, V> {
     }
 }
 
+impl<K: Deserial + Ord + Copy, V: Deserial> DeserialCtx for BTreeMap<K, V> {
+    fn deserial_ctx<R: Read>(
+        source: &mut R,
+        size_len: &schema::SizeLength,
+        ensure_ordered: bool,
+    ) -> ParseResult<Self> {
+        let len = schema::deserial_length(source, size_len)?;
+        if ensure_ordered {
+            deserial_map_no_length(source, len)
+        } else {
+            deserial_map_no_length_no_order_check(source, len)
+        }
+    }
+}
+
 impl<T: Serial> SerialCtx for &[T] {
     fn serial_ctx<W: Write>(
         &self,
@@ -710,6 +740,17 @@ impl<T: Serial> SerialCtx for &[T] {
     ) -> Result<(), W::Err> {
         schema::serial_length(self.len(), size_len, out)?;
         serial_vector_no_length(self, out)
+    }
+}
+
+impl<T: Deserial> DeserialCtx for Vec<T> {
+    fn deserial_ctx<R: Read>(
+        source: &mut R,
+        size_len: &schema::SizeLength,
+        _ensure_ordered: bool,
+    ) -> ParseResult<Self> {
+        let len = schema::deserial_length(source, size_len)?;
+        deserial_vector_no_length(source, len)
     }
 }
 
@@ -734,47 +775,6 @@ impl SerialCtx for String {
     }
 }
 
-impl<K: Deserial + Ord + Copy> DeserialCtx for BTreeSet<K> {
-    fn deserial_ctx<R: Read>(
-        source: &mut R,
-        size_len: &schema::SizeLength,
-        ensure_ordered: bool,
-    ) -> ParseResult<Self> {
-        let len = schema::deserial_length(source, size_len)?;
-        if ensure_ordered {
-            deserial_set_no_length(source, len)
-        } else {
-            deserial_set_no_length_no_order_check(source, len)
-        }
-    }
-}
-
-impl<K: Deserial + Ord + Copy, V: Deserial> DeserialCtx for BTreeMap<K, V> {
-    fn deserial_ctx<R: Read>(
-        source: &mut R,
-        size_len: &schema::SizeLength,
-        ensure_ordered: bool,
-    ) -> ParseResult<Self> {
-        let len = schema::deserial_length(source, size_len)?;
-        if ensure_ordered {
-            deserial_map_no_length(source, len)
-        } else {
-            deserial_map_no_length_no_order_check(source, len)
-        }
-    }
-}
-
-impl<T: Deserial> DeserialCtx for Vec<T> {
-    fn deserial_ctx<R: Read>(
-        source: &mut R,
-        size_len: &schema::SizeLength,
-        _ensure_ordered: bool,
-    ) -> ParseResult<Self> {
-        let len = schema::deserial_length(source, size_len)?;
-        deserial_vector_no_length(source, len)
-    }
-}
-
 impl DeserialCtx for String {
     fn deserial_ctx<R: Read>(
         source: &mut R,
@@ -787,5 +787,3 @@ impl DeserialCtx for String {
         Ok(res)
     }
 }
-
-// TODO: group by type instead of by trait

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -220,3 +220,18 @@ pub trait ExpectNoneReport {
     /// [fail](macro.fail.html) with the given message, instead of `panic`.
     fn expect_none_report(self, msg: &str);
 }
+
+pub trait SerialCtx {
+    // TODO: use SizeLength type
+    fn serial_ctx<W: Write>(&self, size_length: u32, out: &mut W) -> Result<(), W::Err>;
+}
+
+pub trait DeserialCtx {
+    fn deserial_ctx<R: Read>(
+        source: &mut R,
+        size_length: u32,
+        ensure_ordered: bool,
+    ) -> ParseResult<Self>
+    where
+        Self: std::marker::Sized;
+}

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -221,10 +221,19 @@ pub trait ExpectNoneReport {
     fn expect_none_report(self, msg: &str);
 }
 
-/// A wrapper trait for 'Serial' with additional contextual information, namely
-/// the size_length property.
+/// The `SerialCtx` trait provides a means of writing structures into byte-sinks
+/// (`Write`) using contextual information.
+/// The contextual information is:
+///
+///   - `size_length`: The number of bytes used to record the length of the
+///     data.
 pub trait SerialCtx {
-    /// A wrapper for 'Serial::serial' which uses the `size_length` property.
+    /// Attempt to write the structure into the provided writer, failing if
+    /// if the length cannot be represented in the provided `size_length` or
+    /// only part of the structure could be written.
+    ///
+    /// NB: We use Result instead of Option for better composability with other
+    /// constructs.
     fn serial_ctx<W: Write>(
         &self,
         size_length: schema::SizeLength,
@@ -234,9 +243,17 @@ pub trait SerialCtx {
 
 /// A wrapper trait for 'Deserial' with additional contextual information,
 /// namely the size_length and ensure_ordered properties.
+/// The `DeserialCtx` trait provides a means of reading structures from
+/// byte-sinks (`Read`) using contextual information.
+/// The contextual information is:
+///
+///   - `size_length`: The expected number of bytes used for the length of the
+///     data.
+///   - `ensure_ordered`: Whether the ordering should be ensured, for example
+///     that keys in `BTreeMap` and `BTreeSet` are in strictly increasing order.
 pub trait DeserialCtx: Sized {
-    /// A wrapper for 'Deserial::deserial' which uses the `size_length` and
-    /// `ensure_ordered` properties.
+    /// Attempt to read a structure from a given source and context, failing if
+    /// an error occurs during deserialization or reading.
     fn deserial_ctx<R: Read>(
         size_length: schema::SizeLength,
         ensure_ordered: bool,

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -227,7 +227,7 @@ pub trait SerialCtx {
     /// A wrapper for 'Serial::serial' which uses the `size_length` property.
     fn serial_ctx<W: Write>(
         &self,
-        size_length: schema::SizeLength,
+        size_length: &schema::SizeLength,
         out: &mut W,
     ) -> Result<(), W::Err>;
 }
@@ -239,7 +239,7 @@ pub trait DeserialCtx: Sized {
     /// `ensure_ordered` properties.
     fn deserial_ctx<R: Read>(
         source: &mut R,
-        size_length: schema::SizeLength,
+        size_length: &schema::SizeLength,
         ensure_ordered: bool,
     ) -> ParseResult<Self>;
 }

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -241,10 +241,8 @@ pub trait SerialCtx {
     ) -> Result<(), W::Err>;
 }
 
-/// A wrapper trait for 'Deserial' with additional contextual information,
-/// namely the size_length and ensure_ordered properties.
 /// The `DeserialCtx` trait provides a means of reading structures from
-/// byte-sinks (`Read`) using contextual information.
+/// byte-sources (`Read`) using contextual information.
 /// The contextual information is:
 ///
 ///   - `size_length`: The expected number of bytes used for the length of the

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -227,7 +227,7 @@ pub trait SerialCtx {
     /// A wrapper for 'Serial::serial' which uses the `size_length` property.
     fn serial_ctx<W: Write>(
         &self,
-        size_length: &schema::SizeLength,
+        size_length: schema::SizeLength,
         out: &mut W,
     ) -> Result<(), W::Err>;
 }
@@ -239,7 +239,7 @@ pub trait DeserialCtx: Sized {
     /// `ensure_ordered` properties.
     fn deserial_ctx<R: Read>(
         source: &mut R,
-        size_length: &schema::SizeLength,
+        size_length: schema::SizeLength,
         ensure_ordered: bool,
     ) -> ParseResult<Self>;
 }

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -221,17 +221,25 @@ pub trait ExpectNoneReport {
     fn expect_none_report(self, msg: &str);
 }
 
+/// A wrapper trait for 'Serial' with additional contextual information, namely
+/// the size_length property.
 pub trait SerialCtx {
-    // TODO: use SizeLength type
-    fn serial_ctx<W: Write>(&self, size_length: u32, out: &mut W) -> Result<(), W::Err>;
+    /// A wrapper for 'Serial::serial' which uses the `size_length` property.
+    fn serial_ctx<W: Write>(
+        &self,
+        size_length: schema::SizeLength,
+        out: &mut W,
+    ) -> Result<(), W::Err>;
 }
 
-pub trait DeserialCtx {
+/// A wrapper trait for 'Deserial' with additional contextual information,
+/// namely the size_length and ensure_ordered properties.
+pub trait DeserialCtx: Sized {
+    /// A wrapper for 'Deserial::deserial' which uses the `size_length` and
+    /// `ensure_ordered` properties.
     fn deserial_ctx<R: Read>(
         source: &mut R,
-        size_length: u32,
+        size_length: schema::SizeLength,
         ensure_ordered: bool,
-    ) -> ParseResult<Self>
-    where
-        Self: std::marker::Sized;
+    ) -> ParseResult<Self>;
 }

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -238,8 +238,8 @@ pub trait DeserialCtx: Sized {
     /// A wrapper for 'Deserial::deserial' which uses the `size_length` and
     /// `ensure_ordered` properties.
     fn deserial_ctx<R: Read>(
-        source: &mut R,
         size_length: schema::SizeLength,
         ensure_ordered: bool,
+        source: &mut R,
     ) -> ParseResult<Self>;
 }

--- a/examples/auction/src/lib.rs
+++ b/examples/auction/src/lib.rs
@@ -49,7 +49,7 @@ pub struct State {
     /// displayed to the auction participants)
     expiry:        Timestamp,
     /// Keeping track of which account bid how much money
-    #[concordium(map_size_length = 2)]
+    #[concordium(size_length = 2)]
     bids:          BTreeMap<AccountAddress, Amount>,
 }
 

--- a/examples/two-step-transfer/src/lib.rs
+++ b/examples/two-step-transfer/src/lib.rs
@@ -62,7 +62,7 @@ struct TransferRequest {
 #[derive(Serialize, SchemaType)]
 struct InitParams {
     /// Who is authorized to withdraw funds from this lockup (must be non-empty)
-    #[concordium(set_size_length = 1)]
+    #[concordium(size_length = 1)]
     account_holders: BTreeSet<AccountAddress>,
 
     /// How many of the account holders need to agree before funds are released
@@ -89,7 +89,7 @@ pub struct State {
     // Requests which have not been dropped due to timing out or due to being agreed to yet
     // The request ID, the associated amount, when it times out, who is making the transfer and
     // which account holders support this transfer
-    #[concordium(map_size_length = 2)]
+    #[concordium(size_length = 2)]
     requests: BTreeMap<TransferRequestId, TransferRequest>,
 }
 


### PR DESCRIPTION
## Purpose

Allow the use of `ensure_ordered` without also setting the `size_length`.
Remove the different versions of `size_length` attributes (`map_`, `set_`, `string_`). So now you only have `size_length`.

## Changes

- Add two new traits `SerialCtx` and `DeserialCtx`, which act as wrappers for `Serial` and `Deserial`, but with the contextual information of `size_length` and `ensure_ordered`.
- Simplify `impl_serial_field` and `impl_deserial_field` by using the new (de)serial_ctx functions.
- Remove the different versions of the `size_length` attributes.
- I also switched to the correct `span` for the `size_length` attribute (not directly related to purpose).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.