### PR TITLE
Add ERC721 example

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,6 +23,7 @@ jobs:
           - examples/piggy-bank/part1/Cargo.toml
           - examples/piggy-bank/part2/Cargo.toml
           - examples/auction/Cargo.toml
+          - examples/erc721/Cargo.toml
 
     steps:
       - name: Checkout sources
@@ -164,6 +165,7 @@ jobs:
 
         crates:
           - examples/two-step-transfer/Cargo.toml
+          - examples/erc721/Cargo.toml
 
         features:
           -
@@ -204,6 +206,7 @@ jobs:
           - examples/piggy-bank/part1/Cargo.toml
           - examples/piggy-bank/part2/Cargo.toml
           - examples/auction/Cargo.toml
+          - examples/erc721/Cargo.toml
 
     steps:
       - name: Checkout sources

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1,6 +1,7 @@
 use crate::{
     collections::{BTreeMap, BTreeSet},
     convert::{self, TryFrom, TryInto},
+    hash::Hash,
     mem, num, prims,
     prims::*,
     traits::*,
@@ -10,13 +11,6 @@ use crate::{
 };
 use concordium_contracts_common::*;
 use mem::MaybeUninit;
-
-#[cfg(not(feature = "std"))]
-use core::hash;
-#[cfg(feature = "std")]
-use std::hash;
-
-use hash::Hash;
 
 impl convert::From<()> for Reject {
     #[inline(always)]
@@ -741,6 +735,8 @@ impl<K: Deserial + Ord + Copy, V: Deserial> DeserialCtx for BTreeMap<K, V> {
     }
 }
 
+/// Serialization for HashSet given a size_len.
+/// Values are not serialized in any particular order.
 impl<K: Serial> SerialCtx for HashSet<K> {
     fn serial_ctx<W: Write>(
         &self,
@@ -752,6 +748,9 @@ impl<K: Serial> SerialCtx for HashSet<K> {
     }
 }
 
+/// Deserialization for HashSet given a size_len.
+/// Values are not verified to be in any particular order and setting
+/// ensure_ordering have no effect.
 impl<K: Deserial + Eq + Hash> DeserialCtx for HashSet<K> {
     fn deserial_ctx<R: Read>(
         size_len: schema::SizeLength,
@@ -763,6 +762,8 @@ impl<K: Deserial + Eq + Hash> DeserialCtx for HashSet<K> {
     }
 }
 
+/// Serialization for HashMap given a size_len.
+/// Keys are not serialized in any particular order.
 impl<K: Serial, V: Serial> SerialCtx for HashMap<K, V> {
     fn serial_ctx<W: Write>(
         &self,
@@ -774,6 +775,9 @@ impl<K: Serial, V: Serial> SerialCtx for HashMap<K, V> {
     }
 }
 
+/// Deserialization for HashMap given a size_len.
+/// Keys are not verified to be in any particular order and setting
+/// ensure_ordering have no effect.
 impl<K: Deserial + Eq + Hash, V: Deserial> DeserialCtx for HashMap<K, V> {
     fn deserial_ctx<R: Read>(
         size_len: schema::SizeLength,

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -152,7 +152,7 @@ fn abort_panic(_info: &core::panic::PanicInfo) -> ! {
 // This should be expanded in the future.
 /// Re-export.
 #[cfg(not(feature = "std"))]
-pub use alloc::{collections, string, string::String, string::ToString, vec, vec::Vec};
+pub use alloc::{string, string::String, string::ToString, vec, vec::Vec};
 /// Re-export.
 #[cfg(not(feature = "std"))]
 pub use core::{convert, marker, mem, num, result::*};
@@ -161,7 +161,17 @@ pub(crate) use std::vec;
 
 /// Re-export.
 #[cfg(feature = "std")]
-pub use std::{collections, convert, marker, mem, num, string::String, vec::Vec};
+pub use std::{convert, marker, mem, num, string::String, vec::Vec};
+
+pub mod collections {
+    #[cfg(not(feature = "std"))]
+    use alloc::collections;
+    #[cfg(feature = "std")]
+    use std::collections;
+
+    pub use collections::*;
+    pub use concordium_contracts_common::{HashMap, HashSet};
+}
 
 /// Chain constants that impose limits on various aspects of smart contract
 /// execution.

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -152,7 +152,7 @@ fn abort_panic(_info: &core::panic::PanicInfo) -> ! {
 // This should be expanded in the future.
 /// Re-export.
 #[cfg(not(feature = "std"))]
-pub use alloc::{string, string::String, string::ToString, vec, vec::Vec};
+pub use alloc::{string, string::String, string::ToString, vec, vec::Vec, borrow::ToOwned};
 /// Re-export.
 #[cfg(not(feature = "std"))]
 pub use core::{convert, marker, mem, num, result::*};

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -152,7 +152,7 @@ fn abort_panic(_info: &core::panic::PanicInfo) -> ! {
 // This should be expanded in the future.
 /// Re-export.
 #[cfg(not(feature = "std"))]
-pub use alloc::{string, string::String, string::ToString, vec, vec::Vec, borrow::ToOwned};
+pub use alloc::{borrow::ToOwned, string, string::String, string::ToString, vec, vec::Vec};
 /// Re-export.
 #[cfg(not(feature = "std"))]
 pub use core::{convert, marker, mem, num, result::*};

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -155,13 +155,13 @@ fn abort_panic(_info: &core::panic::PanicInfo) -> ! {
 pub use alloc::{borrow::ToOwned, string, string::String, string::ToString, vec, vec::Vec};
 /// Re-export.
 #[cfg(not(feature = "std"))]
-pub use core::{convert, marker, mem, num, result::*};
+pub use core::{convert, hash, marker, mem, num, result::*};
 #[cfg(feature = "std")]
 pub(crate) use std::vec;
 
 /// Re-export.
 #[cfg(feature = "std")]
-pub use std::{convert, marker, mem, num, string::String, vec::Vec};
+pub use std::{convert, hash, marker, mem, num, string::String, vec::Vec};
 
 pub mod collections {
     #[cfg(not(feature = "std"))]

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,3 +10,6 @@ the logic of the contract is reasonable, or safe.
 The list of contracts is as follows
 - [two-step-transfer](./two-step-transfer) A contract that acts like an account (can send, store and accept GTU),
  but requires n > 1 ordained accounts to agree to the sending of GTU before it is accepted.
+- [auction](./auction) A contract implementing an simple auction.
+- [piggy-bank](./piggy-bank) The smart contract created as part of the Piggy Bank tutorial.
+- [ERC721](./erc721) A simple example implementation of the ERC721 non-fungible token standard.

--- a/examples/erc-271/Cargo.toml
+++ b/examples/erc-271/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "erc271"
+version = "0.1.0"
+authors = ["Concordium <developers@concordium.com>"]
+edition = "2018"
+license = "MPL-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["std"]
+std = ["concordium-std/std"]
+
+[dependencies]
+concordium-std = {path = "../../concordium-std",  default-features = false}
+
+[lib]
+crate-type=["cdylib", "rlib"]

--- a/examples/erc-271/src/lib.rs
+++ b/examples/erc-271/src/lib.rs
@@ -1,0 +1,596 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+use concordium_std::{collections::*, *};
+
+/*
+ * An implementation of the ERC-271 Non-Fungible Token(NFT) Standard popular
+ * on the Ethereum blockchain.
+ *
+ * An smart contract instance represents a number of NFTs and tracks
+ * ownership of each. It allows other accounts to transfer a certain amount
+ * from ones account.
+ *
+ * https://eips.ethereum.org/EIPS/eip-721
+ *
+ * Instead of getter functions the information can be read directly from the
+ * contract state directly. Events can be tracked in the log.
+ */
+
+// Types
+
+/// Token Identifier, which combine with the address of the contract instance,
+/// forms the unique identifier of an NFT. The specification requires a u256,
+/// but for efficiency we use u64, which is expected to be sufficient for most
+/// cases.
+type TokenId = u64;
+
+/// Token metadata
+#[derive(Debug, Serialize, SchemaType, PartialEq, Eq)]
+struct TokenMetadata {
+    /// Name of the token, encoded as UTF8
+    name:   Vec<u8>,
+    /// Symbol of the token, encoded as UTF8
+    symbol: Vec<u8>,
+}
+
+type Tokens = BTreeMap<TokenId, TokenMetadata>;
+
+#[contract_state(contract = "erc271")]
+#[derive(Debug, Serialize, SchemaType)]
+pub struct State {
+    tokens:          Tokens,
+    /// Map from a token id to the owning account address
+    /// Every token must be an entry in this map.
+    token_owners:    BTreeMap<TokenId, AccountAddress>,
+    /// Map from a token id to an account which are allowed to transfer this
+    /// token on the owners behalf
+    /// Only tokens with approvals have entries in this map.
+    token_approvals: BTreeMap<TokenId, AccountAddress>,
+    /// Map from an account to operator accounts, which can transfer any token
+    /// on their behalf.
+    /// Only accounts with operators have entries in this map.
+    owner_operators: BTreeMap<AccountAddress, BTreeSet<AccountAddress>>,
+}
+
+// Event printed in the log
+#[derive(Debug, Serialize)]
+enum Event {
+    /// Ownership of NFT changed
+    Transfer {
+        from:     AccountAddress,
+        to:       AccountAddress,
+        token_id: TokenId,
+    },
+    /// Approved transfer of NFT, where `approved` = None means no one is
+    /// approved.
+    Approval {
+        owner:    AccountAddress,
+        approved: Option<AccountAddress>,
+        token_id: TokenId,
+    },
+    /// Change to whether an operator can manage all NFTs of the owner
+    ApprovalForAll {
+        owner:    AccountAddress,
+        operator: AccountAddress,
+        approved: bool,
+    },
+}
+
+// Contract Function Parameters
+
+#[derive(Serialize, SchemaType)]
+struct SafeTransferFromParams {
+    from:     AccountAddress,
+    to:       AccountAddress,
+    token_id: TokenId,
+}
+
+#[derive(Serialize, SchemaType)]
+struct ApproveParams {
+    approved: Option<AccountAddress>,
+    token_id: TokenId,
+}
+
+#[derive(Serialize, SchemaType)]
+struct ApproveForAllParams {
+    operator: AccountAddress,
+    approved: bool,
+}
+
+#[derive(Debug, PartialEq, Eq, Reject)]
+enum ContractError {
+    /// Failed parsing the parameter
+    ParseParams,
+    LogFull,
+    LogMalformed,
+    NoTokenWithThisId,
+    InvalidTransfer,
+    Unauthorized,
+    AccountSenderOnly,
+    ApprovedIsOwner,
+    OperatorIsSender,
+}
+
+impl From<LogError> for ContractError {
+    fn from(le: LogError) -> Self {
+        match le {
+            LogError::Full => Self::LogFull,
+            LogError::Malformed => Self::LogMalformed,
+        }
+    }
+}
+
+impl From<ParseError> for ContractError {
+    fn from(_: ParseError) -> Self { ContractError::ParseParams }
+}
+
+impl State {
+    /// Creates a new state with a number of tokens, all owned by the invoker.
+    fn new(tokens: Tokens, owner: AccountAddress) -> Self {
+        let mut token_owners = BTreeMap::new();
+        for &token_id in tokens.keys() {
+            token_owners.insert(token_id, owner);
+        }
+
+        State {
+            tokens,
+            token_owners,
+            token_approvals: BTreeMap::new(),
+            owner_operators: BTreeMap::new(),
+        }
+    }
+
+    /// Get the current owner of a token
+    fn get_owner(&self, token_id: &TokenId) -> Result<&AccountAddress, ContractError> {
+        self.token_owners.get(token_id).ok_or(ContractError::NoTokenWithThisId)
+    }
+
+    fn is_owner(&self, sender: &AccountAddress, token_id: &TokenId) -> bool {
+        if let Some(owner) = self.token_owners.get(token_id) {
+            return sender == owner;
+        }
+        false
+    }
+
+    fn is_approved(&self, sender: &AccountAddress, token_id: &TokenId) -> bool {
+        if let Some(approval) = self.token_approvals.get(token_id) {
+            return sender == approval;
+        }
+        false
+    }
+
+    fn is_operator(&self, sender: &AccountAddress, owner: &AccountAddress) -> bool {
+        if let Some(operators) = self.owner_operators.get(owner) {
+            return operators.contains(sender);
+        }
+        false
+    }
+
+    fn transfer(
+        &mut self,
+        token_id: &TokenId,
+        from: &AccountAddress,
+        to: &AccountAddress,
+    ) -> Result<(), ContractError> {
+        if let Some(previous_owner) = self.token_owners.insert(*token_id, *to) {
+            ensure!(previous_owner == *from, ContractError::InvalidTransfer)
+        } else {
+            bail!(ContractError::NoTokenWithThisId)
+        }
+        self.token_approvals.remove(token_id);
+        Ok(())
+    }
+
+    fn approve(&mut self, token_id: &TokenId, approved: &Option<AccountAddress>) {
+        if let Some(approved) = approved {
+            self.token_approvals.insert(*token_id, *approved);
+        } else {
+            self.token_approvals.remove(token_id);
+        }
+    }
+
+    fn approval_for_all(
+        &mut self,
+        owner: &AccountAddress,
+        operator: &AccountAddress,
+        approved: bool,
+    ) {
+        if let Some(operators) = self.owner_operators.get_mut(owner) {
+            if approved {
+                operators.insert(*operator);
+            } else {
+                operators.remove(operator);
+            }
+        } else {
+            if approved {
+                let mut operators = BTreeSet::new();
+                operators.insert(*operator);
+                self.owner_operators.insert(*owner, operators);
+            }
+        }
+    }
+}
+
+// Contract
+
+#[init(contract = "erc271", parameter = "Tokens")]
+fn contract_init(ctx: &impl HasInitContext) -> InitResult<State> {
+    let tokens: Tokens = ctx.parameter_cursor().get()?;
+    let invoker = ctx.init_origin();
+    Ok(State::new(tokens, invoker))
+}
+
+#[receive(
+    contract = "erc271",
+    name = "safeTransferFrom",
+    parameters = "SafeTransferFromParams",
+    enable_logger
+)]
+fn contract_safe_transfer_from<A: HasActions>(
+    ctx: &impl HasReceiveContext,
+    logger: &mut impl HasLogger,
+    state: &mut State,
+) -> Result<A, ContractError> {
+    let params: SafeTransferFromParams = ctx.parameter_cursor().get()?;
+    let sender = if let Address::Account(account) = ctx.sender() {
+        account
+    } else {
+        bail!(ContractError::AccountSenderOnly)
+    };
+
+    ensure!(
+        state.is_owner(&sender, &params.token_id)
+            || state.is_approved(&sender, &params.token_id)
+            || state.is_operator(&sender, &params.from),
+        ContractError::Unauthorized
+    );
+    state.transfer(&params.token_id, &params.from, &params.to)?;
+    logger.log(&Event::Transfer {
+        from:     params.from,
+        to:       params.to,
+        token_id: params.token_id,
+    })?;
+
+    Ok(A::accept())
+}
+
+#[receive(contract = "erc271", name = "transferFrom", enable_logger)]
+fn contract_transfer_from<A: HasActions>(
+    ctx: &impl HasReceiveContext,
+    logger: &mut impl HasLogger,
+    state: &mut State,
+) -> Result<A, ContractError> {
+    contract_safe_transfer_from(ctx, logger, state)
+}
+
+#[receive(contract = "erc271", name = "approve", enable_logger)]
+fn contract_approve<A: HasActions>(
+    ctx: &impl HasReceiveContext,
+    logger: &mut impl HasLogger,
+    state: &mut State,
+) -> Result<A, ContractError> {
+    let params: ApproveParams = ctx.parameter_cursor().get()?;
+
+    let sender = if let Address::Account(account) = ctx.sender() {
+        account
+    } else {
+        bail!(ContractError::AccountSenderOnly)
+    };
+
+    let owner = *state.get_owner(&params.token_id)?;
+
+    if let Some(approved) = params.approved {
+        ensure!(owner != approved, ContractError::ApprovedIsOwner);
+    }
+    ensure!(sender == owner || state.is_operator(&sender, &owner), ContractError::Unauthorized);
+
+    state.approve(&params.token_id, &params.approved);
+
+    logger.log(&Event::Approval {
+        owner,
+        approved: params.approved,
+        token_id: params.token_id,
+    })?;
+
+    Ok(A::accept())
+}
+
+#[receive(contract = "erc271", name = "setApprovalForAll", enable_logger)]
+fn contract_set_approval_for_all<A: HasActions>(
+    ctx: &impl HasReceiveContext,
+    logger: &mut impl HasLogger,
+    state: &mut State,
+) -> Result<A, ContractError> {
+    let params: ApproveForAllParams = ctx.parameter_cursor().get()?;
+
+    let sender = if let Address::Account(account) = ctx.sender() {
+        account
+    } else {
+        bail!(ContractError::AccountSenderOnly)
+    };
+
+    // No reason to be an operator yourself
+    ensure!(params.operator != sender, ContractError::OperatorIsSender);
+
+    state.approval_for_all(&sender, &params.operator, params.approved);
+
+    logger.log(&Event::ApprovalForAll {
+        owner:    sender,
+        operator: params.operator,
+        approved: params.approved,
+    })?;
+
+    Ok(A::accept())
+}
+
+// Tests
+
+#[concordium_cfg_test]
+mod tests {
+    use super::*;
+    use test_infrastructure::*;
+
+    const ACCOUNT_0: AccountAddress = AccountAddress([0u8; 32]);
+    const ACCOUNT_1: AccountAddress = AccountAddress([1u8; 32]);
+    const TOKEN_ID: TokenId = 0;
+
+    fn initial_state() -> State {
+        let mut tokens: Tokens = BTreeMap::new();
+        tokens.insert(TOKEN_ID, TokenMetadata {
+            name:   b"MyToken".to_vec(),
+            symbol: b"MT".to_vec(),
+        });
+
+        State::new(tokens, ACCOUNT_0)
+    }
+
+    #[concordium_test]
+    fn test_init() {
+        let mut ctx = InitContextTest::empty();
+        ctx.set_init_origin(ACCOUNT_0);
+
+        let mut tokens: Tokens = BTreeMap::new();
+        tokens.insert(0, TokenMetadata {
+            name:   b"MyToken".to_vec(),
+            symbol: b"MT".to_vec(),
+        });
+
+        let parameter_bytes = to_bytes(&tokens);
+        ctx.set_parameter(&parameter_bytes);
+
+        let result = contract_init(&ctx);
+
+        let state = result.expect_report("Contract initialization failed");
+
+        claim_eq!(state.token_approvals.len(), 0, "No token approvals at initialization");
+        claim_eq!(state.owner_operators.len(), 0, "No operators at initialization");
+        claim_eq!(state.tokens, tokens, "Initial tokens are stored in the state");
+    }
+
+    #[concordium_test]
+    fn test_transfer() {
+        let mut ctx = ReceiveContextTest::empty();
+        ctx.set_sender(Address::Account(ACCOUNT_0));
+
+        let mut state = initial_state();
+
+        let parameter = SafeTransferFromParams {
+            from:     ACCOUNT_0,
+            to:       ACCOUNT_1,
+            token_id: TOKEN_ID,
+        };
+
+        let parameter_bytes = to_bytes(&parameter);
+        ctx.set_parameter(&parameter_bytes);
+
+        let mut logger = LogRecorder::init();
+
+        let actions: ActionsTree = contract_safe_transfer_from(&ctx, &mut logger, &mut state)
+            .expect_report("Failed NFT transfer");
+        claim_eq!(actions, ActionsTree::accept(), "No action should be produced.");
+
+        let owner = state.get_owner(&TOKEN_ID).expect_report("No token with id");
+        claim_eq!(owner, &ACCOUNT_1, "Ownership should be transferred");
+
+        claim_eq!(logger.logs.len(), 1, "One event should be logged");
+        claim_eq!(
+            logger.logs[0],
+            to_bytes(&Event::Transfer {
+                from:     ACCOUNT_0,
+                to:       ACCOUNT_1,
+                token_id: TOKEN_ID,
+            }),
+            "Incorrect event emitted"
+        )
+    }
+
+    #[concordium_test]
+    fn test_transfer_not_authorized() {
+        let mut ctx = ReceiveContextTest::empty();
+        ctx.set_sender(Address::Account(ACCOUNT_1));
+
+        let mut state = initial_state();
+
+        let parameter = SafeTransferFromParams {
+            from:     ACCOUNT_0,
+            to:       ACCOUNT_1,
+            token_id: TOKEN_ID,
+        };
+
+        let parameter_bytes = to_bytes(&parameter);
+        ctx.set_parameter(&parameter_bytes);
+
+        let mut logger = LogRecorder::init();
+
+        let result: Result<ActionsTree, _> =
+            contract_safe_transfer_from(&ctx, &mut logger, &mut state);
+        let err = result.expect_err_report("Expected to fail");
+        claim_eq!(err, ContractError::Unauthorized, "Error is expected to be Unauthorized")
+    }
+
+    #[concordium_test]
+    fn test_approved_transfer() {
+        let mut ctx = ReceiveContextTest::empty();
+        ctx.set_sender(Address::Account(ACCOUNT_1));
+
+        let mut state = initial_state();
+        state.approve(&TOKEN_ID, &Some(ACCOUNT_1));
+
+        let parameter = SafeTransferFromParams {
+            from:     ACCOUNT_0,
+            to:       ACCOUNT_1,
+            token_id: TOKEN_ID,
+        };
+
+        let parameter_bytes = to_bytes(&parameter);
+        ctx.set_parameter(&parameter_bytes);
+
+        let mut logger = LogRecorder::init();
+
+        let actions: ActionsTree = contract_safe_transfer_from(&ctx, &mut logger, &mut state)
+            .expect_report("Failed NFT transfer");
+        claim_eq!(actions, ActionsTree::accept(), "No action should be produced.");
+
+        let owner = state.get_owner(&TOKEN_ID).expect_report("No token with id");
+        claim_eq!(owner, &ACCOUNT_1, "Ownership should be transferred");
+        claim_eq!(logger.logs.len(), 1, "One event should be logged");
+        claim_eq!(
+            logger.logs[0],
+            to_bytes(&Event::Transfer {
+                from:     ACCOUNT_0,
+                to:       ACCOUNT_1,
+                token_id: TOKEN_ID,
+            }),
+            "Incorrect event emitted"
+        )
+    }
+
+    #[concordium_test]
+    fn test_operator_transfer() {
+        let mut ctx = ReceiveContextTest::empty();
+        ctx.set_sender(Address::Account(ACCOUNT_1));
+
+        let mut tokens: Tokens = BTreeMap::new();
+        let token_id = 0;
+        tokens.insert(token_id, TokenMetadata {
+            name:   b"MyToken".to_vec(),
+            symbol: b"MT".to_vec(),
+        });
+
+        let mut state = State::new(tokens, ACCOUNT_0);
+        state.approval_for_all(&ACCOUNT_0, &ACCOUNT_1, true);
+
+        let parameter = SafeTransferFromParams {
+            from: ACCOUNT_0,
+            to: ACCOUNT_1,
+            token_id,
+        };
+
+        let parameter_bytes = to_bytes(&parameter);
+        ctx.set_parameter(&parameter_bytes);
+
+        let mut logger = LogRecorder::init();
+
+        let actions: ActionsTree = contract_safe_transfer_from(&ctx, &mut logger, &mut state)
+            .expect_report("Failed NFT transfer");
+        claim_eq!(actions, ActionsTree::accept(), "No action should be produced.");
+
+        let owner = state.get_owner(&TOKEN_ID).expect_report("No token with id");
+        claim_eq!(owner, &ACCOUNT_1, "Ownership should be transferred");
+        claim_eq!(logger.logs.len(), 1, "One event should be logged");
+        claim_eq!(
+            logger.logs[0],
+            to_bytes(&Event::Transfer {
+                from: ACCOUNT_0,
+                to: ACCOUNT_1,
+                token_id
+            }),
+            "Incorrect event emitted"
+        )
+    }
+
+    #[concordium_test]
+    fn test_approve() {
+        let mut ctx = ReceiveContextTest::empty();
+        ctx.set_sender(Address::Account(ACCOUNT_0));
+
+        let mut tokens: Tokens = BTreeMap::new();
+        let token_id = 0;
+        tokens.insert(token_id, TokenMetadata {
+            name:   b"MyToken".to_vec(),
+            symbol: b"MT".to_vec(),
+        });
+
+        let mut state = State::new(tokens, ACCOUNT_0);
+
+        let parameter = ApproveParams {
+            approved: Some(ACCOUNT_1),
+            token_id,
+        };
+
+        let parameter_bytes = to_bytes(&parameter);
+        ctx.set_parameter(&parameter_bytes);
+
+        let mut logger = LogRecorder::init();
+
+        let actions: ActionsTree = contract_approve(&ctx, &mut logger, &mut state)
+            .expect_report("Failed valid approve call");
+        claim_eq!(actions, ActionsTree::accept(), "No action should be produced.");
+
+        let owner = state.get_owner(&TOKEN_ID).expect_report("No token with id");
+        claim_eq!(owner, &ACCOUNT_0, "Ownership should not be transferred");
+        claim!(state.is_approved(&ACCOUNT_1, &TOKEN_ID), "Account should be approved");
+        claim_eq!(logger.logs.len(), 1, "One event should be logged");
+        claim_eq!(
+            logger.logs[0],
+            to_bytes(&Event::Approval {
+                owner: ACCOUNT_0,
+                approved: Some(ACCOUNT_1),
+                token_id
+            }),
+            "Incorrect event emitted"
+        )
+    }
+
+    #[concordium_test]
+    fn test_set_approve_for_all() {
+        let mut ctx = ReceiveContextTest::empty();
+        ctx.set_sender(Address::Account(ACCOUNT_0));
+
+        let mut tokens: Tokens = BTreeMap::new();
+        let token_id = 0;
+        tokens.insert(token_id, TokenMetadata {
+            name:   b"MyToken".to_vec(),
+            symbol: b"MT".to_vec(),
+        });
+
+        let mut state = State::new(tokens, ACCOUNT_0);
+
+        let parameter = ApproveForAllParams {
+            operator: ACCOUNT_1,
+            approved: true,
+        };
+
+        let parameter_bytes = to_bytes(&parameter);
+        ctx.set_parameter(&parameter_bytes);
+
+        let mut logger = LogRecorder::init();
+
+        let actions: ActionsTree = contract_set_approval_for_all(&ctx, &mut logger, &mut state)
+            .expect_report("Failed valid approve call");
+        claim_eq!(actions, ActionsTree::accept(), "No action should be produced.");
+
+        let owner = state.get_owner(&TOKEN_ID).expect_report("No token with id");
+        claim_eq!(owner, &ACCOUNT_0, "Ownership should not be transferred");
+        claim!(state.is_operator(&ACCOUNT_1, &ACCOUNT_0), "Account should be approved");
+        claim_eq!(logger.logs.len(), 1, "One event should be logged");
+        claim_eq!(
+            logger.logs[0],
+            to_bytes(&Event::ApprovalForAll {
+                owner:    ACCOUNT_0,
+                operator: ACCOUNT_1,
+                approved: true,
+            }),
+            "Incorrect event emitted"
+        )
+    }
+}

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -1,17 +1,19 @@
 [package]
-name = "erc271"
+name = "erc721"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["std"]
 std = ["concordium-std/std"]
 
 [dependencies]
-concordium-std = {path = "../../concordium-std",  default-features = false}
+concordium-std = {path = "../../concordium-std", default-features = false}
 
 [lib]
 crate-type=["cdylib", "rlib"]
+
+[profile.release]
+opt-level = "s"

--- a/examples/erc721/src/lib.rs
+++ b/examples/erc721/src/lib.rs
@@ -24,10 +24,10 @@
  * Since the specification is written to target the Ethereum blockchain, some
  * details are implemented differently.
  *
- * - The specification lists a number of "view" functions, which queries for
- *   the current state of the contract and since the Concordium Blockchain
- *   uses message passing for inter-contract communication, these query
- *   functions must also take a name of the callback function to receive the
+ * - The specification contains a number of "view" functions, which queries
+ *   for the current state of the contract and since the Concordium
+ *   Blockchain uses message passing for inter-contract communication, these
+ *   query functions must also take a name of a function to callback with the
  *   result of the query.
  * - The specification uses a "zero address" (which is a special address used
  *   as a null-address) which is not a thing on Concordium blockchain,
@@ -35,6 +35,8 @@
  *   the "zero address" and if not the address is followed, which in a Rust
  *   smart contract corresponds to the serialization of `Option<Address>`.
  *
+ * Note that the specification also requires implementing ERC165 for standard
+ * interface detection, which is not implemented in this example.
  */
 
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -269,7 +271,7 @@ impl State {
                 count += 1;
             }
         }
-        return count;
+        count
     }
 
     /// Get the current owner of a token.

--- a/examples/erc721/src/lib.rs
+++ b/examples/erc721/src/lib.rs
@@ -57,6 +57,7 @@ type TokenId = u64;
 /// TokenId to some Metadata struct.
 type Tokens = Set<TokenId>;
 
+#[contract_state(contract = "erc721")]
 #[derive(Serialize, SchemaType)]
 struct State {
     /// Map from a token id to the owning account address.
@@ -362,9 +363,9 @@ fn contract_init(ctx: &impl HasInitContext) -> InitResult<State> {
 ///
 /// It rejects if:
 /// - It fails to parse the parameter.
+/// - The `token_id` does not exist.
 /// - The sender is not: the owner of the token, or approved for this specific
 ///   token or an operator for the owner.
-/// - The `token_id` does not exist.
 /// - The token is not owned by the `from`.
 ///
 /// Note: It differs from `transferFrom` only when transferring to a contract
@@ -541,7 +542,7 @@ fn contract_on_erc721_received<A: HasActions>(
 
     let parameter = SafeTransferFromParams {
         from:         Address::Contract(ctx.self_address()),
-        to:           Address::Account(ctx.invoker()),
+        to:           Address::Account(ctx.owner()),
         token_id:     params.token_id,
         receive_name: None,
         data:         vec![],

--- a/examples/erc721/src/lib.rs
+++ b/examples/erc721/src/lib.rs
@@ -571,7 +571,7 @@ fn contract_on_erc721_received<A: HasActions>(
 #[receive(contract = "erc721", name = "balanceOf")]
 fn contract_balance_of<A: HasActions>(
     ctx: &impl HasReceiveContext,
-    state: &State,
+    state: &mut State,
 ) -> ContractResult<A> {
     let sender = if let Address::Contract(contract) = ctx.sender() {
         contract
@@ -596,7 +596,7 @@ fn contract_balance_of<A: HasActions>(
 #[receive(contract = "erc721", name = "ownerOf")]
 fn contract_owner_of<A: HasActions>(
     ctx: &impl HasReceiveContext,
-    state: &State,
+    state: &mut State,
 ) -> ContractResult<A> {
     let sender = if let Address::Contract(contract) = ctx.sender() {
         contract
@@ -623,7 +623,7 @@ fn contract_owner_of<A: HasActions>(
 #[receive(contract = "erc721", name = "getApproved")]
 fn contract_get_approved<A: HasActions>(
     ctx: &impl HasReceiveContext,
-    state: &State,
+    state: &mut State,
 ) -> ContractResult<A> {
     let sender = if let Address::Contract(contract) = ctx.sender() {
         contract
@@ -649,7 +649,7 @@ fn contract_get_approved<A: HasActions>(
 #[receive(contract = "erc721", name = "isApprovedForAll")]
 fn contract_is_approved_for_all<A: HasActions>(
     ctx: &impl HasReceiveContext,
-    state: &State,
+    state: &mut State,
 ) -> ContractResult<A> {
     let sender = if let Address::Contract(contract) = ctx.sender() {
         contract

--- a/examples/erc721/src/lib.rs
+++ b/examples/erc721/src/lib.rs
@@ -257,12 +257,10 @@ impl State {
             } else {
                 operators.remove(operator);
             }
-        } else {
-            if approved {
-                let mut operators = Set::default();
-                operators.insert(*operator);
-                self.owner_operators.insert(*owner, operators);
-            }
+        } else if approved {
+            let mut operators = Set::default();
+            operators.insert(*operator);
+            self.owner_operators.insert(*owner, operators);
         }
     }
 }


### PR DESCRIPTION
## Purpose

Add ERC721 example depends on PR https://github.com/Concordium/concordium-contracts-common/pull/22

## Changes

- Add ERC721 smart contract example.
- Update examples README.
- Export `HashMap`/`HashSet` from `contracts_common` in a collections module.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.