### PR TITLE
Make derived serialization import SerialCtx in a block expression

### DIFF
--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -906,10 +906,10 @@ fn impl_serial_field(
 ) -> syn::Result<proc_macro2::TokenStream> {
     if let Some(size_length) = find_length_attribute(&field.attrs)? {
         let l = format_ident!("U{}", 8 * size_length);
-        Ok(quote! {
+        Ok(quote!({
             use concordium_std::SerialCtx;
             #ident.serial_ctx(concordium_std::schema::SizeLength::#l, #out)?;
-        })
+        }))
     } else {
         Ok(quote! {
             #ident.serial(#out)?;


### PR DESCRIPTION
## Purpose

Fix issue with having two fields with the `size_length` attribute set, for the derived serialization.
It breaks because it would bring the `SerialCtx` into scope for each, resulting in a name collision.

## Changes

- The derived code now imports `SerialCtx` in a block expression.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
