### PR TITLE
Add a simple contract to support the memo feature.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,6 +24,7 @@ jobs:
           - examples/piggy-bank/part2/Cargo.toml
           - examples/auction/Cargo.toml
           - examples/erc721/Cargo.toml
+          - examples/memo/Cargo.toml
 
     steps:
       - name: Checkout sources

--- a/README.md
+++ b/README.md
@@ -24,15 +24,6 @@ the logic of the contract is reasonable, or safe.
 
 **Do not use these contracts as-is for anything other then experimenting.**
 
-The list of contracts is as follows
-- [two-step-transfer](./examples/two-step-transfer) A contract that acts like an
- account (can send, store and accept GTU), but requires n > 1 ordained accounts
- to agree to the sending of GTU before it is accepted.
-- [memo](./examples/memo/) An extremely minimal contract that can be used to
-  mimic the memo feature. Normally a transfer between accounts cannot add any
-  information other than the amount being transferred. Making transfers to this
-  intermediate contract instead works around this limitation.
-
 ## Submodules
 
 The repository has

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The list of contracts is as follows
 - [two-step-transfer](./examples/two-step-transfer) A contract that acts like an
  account (can send, store and accept GTU), but requires n > 1 ordained accounts
  to agree to the sending of GTU before it is accepted.
+- [memo](./examples/memo/) An extremely minimal contract that can be used to
+  mimic the memo feature. Normally a transfer between accounts cannot add any
+  information other than the amount being transferred. Making transfers to this
+  intermediate contract instead works around this limitation.
 
 ## Submodules
 

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -164,7 +164,7 @@ macro_rules! fail {
         {
             let msg = format!($($arg),+);
             $crate::test_infrastructure::report_error(&msg, file!(), line!(), column!());
-            panic!(msg)
+            panic!("{}", msg)
         }
     };
 }
@@ -185,7 +185,7 @@ macro_rules! fail {
         {
             let msg = &$crate::alloc::format!($($arg),+);
             $crate::test_infrastructure::report_error(&msg, file!(), line!(), column!());
-            panic!(msg)
+            panic!("{}", msg)
         }
     };
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,3 +13,7 @@ The list of contracts is as follows
 - [auction](./auction) A contract implementing an simple auction.
 - [piggy-bank](./piggy-bank) The smart contract created as part of the Piggy Bank tutorial.
 - [ERC721](./erc721) A simple example implementation of the ERC721 non-fungible token standard.
+- [memo](./memo/) An extremely minimal contract that can be used to
+  mimic the memo feature. Normally a transfer between accounts cannot add any
+  information other than the amount being transferred. Making transfers to this
+  intermediate contract instead works around this limitation.

--- a/examples/memo/Cargo.toml
+++ b/examples/memo/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "memo-proxy-contract"
+version = "0.1.0"
+authors = ["Concordium <developers@concordium.com>"]
+edition = "2018"
+license = "MPL-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# concordium-std = "*"
+concordium-std = {path = "../../concordium-std"}
+
+[features]
+default = ["std"]
+std = ["concordium-std/std"]
+
+[lib]
+crate-type=["cdylib", "rlib"]
+
+
+[profile.release]
+opt-level = 3
+panic = "abort"

--- a/examples/memo/src/lib.rs
+++ b/examples/memo/src/lib.rs
@@ -3,6 +3,13 @@ use core::fmt::Debug;
 
 /// # Implementation of a smart contract that can receive transfers with a memo
 /// message and forward them to the owner account.
+/// All this contract does is expose a single `receive` method which checks that
+///
+/// - it is being invoked by an account
+/// - the message it is receiving is 32 bytes long
+///
+/// And if both of these are valid it forwards the amount it received to the
+/// owner account.
 
 /// The contract has no state.
 #[derive(Debug, Serialize, SchemaType)]

--- a/examples/memo/src/lib.rs
+++ b/examples/memo/src/lib.rs
@@ -1,5 +1,4 @@
 use concordium_std::*;
-use core::fmt::Debug;
 
 /// # Implementation of a smart contract that can receive transfers with a memo
 /// message and forward them to the owner account.
@@ -10,10 +9,6 @@ use core::fmt::Debug;
 ///
 /// And if both of these are valid it forwards the amount it received to the
 /// owner account.
-
-/// The contract has no state.
-#[derive(Debug, Serialize, SchemaType)]
-struct MemoState;
 
 #[derive(Serialize, SchemaType)]
 /// The contract has no initialization parameters.

--- a/examples/memo/src/lib.rs
+++ b/examples/memo/src/lib.rs
@@ -1,0 +1,38 @@
+use concordium_std::*;
+use core::fmt::Debug;
+
+/// # Implementation of a smart contract that can receive transfers with a memo
+/// message and forward them to the owner account.
+
+/// The contract has no state.
+#[derive(Debug, Serialize, SchemaType)]
+struct MemoState;
+
+#[derive(Serialize, SchemaType)]
+/// The contract has no initialization parameters.
+struct InitParameter;
+
+/// Init function that creates a new contract.
+#[init(contract = "memo", parameter = "InitParameter", low_level)]
+fn memo_init(_ctx: &impl HasInitContext, _state: &mut impl HasContractState) -> InitResult<()> {
+    Ok(())
+}
+
+const EXPECTED_PARAMETER_SIZE: u32 = 32;
+
+pub type ReceiveParameter = [u8; 32];
+
+/// Receive a transaction with a message. This ensures that the message is 32
+/// bytes and that the sender of the message is an account.
+#[receive(contract = "memo", name = "receive", parameter = "ReceiveParameter", payable, low_level)]
+fn memo_receive<A: HasActions>(
+    ctx: &impl HasReceiveContext,
+    amount: Amount,
+    _state: &mut impl HasContractState,
+) -> ReceiveResult<A> {
+    matches!(ctx.sender(), Address::Account(..));
+    ensure!(ctx.parameter_cursor().size() == EXPECTED_PARAMETER_SIZE);
+    // Forward the received funds to the owner of the contract.
+    let act = A::simple_transfer(&ctx.owner(), amount);
+    Ok(act)
+}

--- a/examples/memo/src/lib.rs
+++ b/examples/memo/src/lib.rs
@@ -32,7 +32,7 @@ fn memo_receive<A: HasActions>(
     amount: Amount,
     _state: &mut impl HasContractState,
 ) -> ReceiveResult<A> {
-    matches!(ctx.sender(), Address::Account(..));
+    ensure!(matches!(ctx.sender(), Address::Account(..)));
     ensure!(ctx.parameter_cursor().size() == EXPECTED_PARAMETER_SIZE);
     // Forward the received funds to the owner of the contract.
     let act = A::simple_transfer(&ctx.owner(), amount);


### PR DESCRIPTION
## Purpose

Add an example contract that can support a "memo" feature.

Also fixes #33 

## Changes

Add a new example smart contract.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
