### PR TITLE
Update contracts-common dep and rust version in CI

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.45.2
+          toolchain: 1.53
           target: ${{ matrix.target }}
           override: true
           components: clippy
@@ -112,7 +112,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.45.2
+          toolchain: 1.53
           target: ${{ matrix.target }}
           override: true
           components: clippy
@@ -219,7 +219,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.45.2
+          toolchain: 1.53
           target: ${{ matrix.target }}
           override: true
           components: clippy
@@ -255,7 +255,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.45.2
+          toolchain: 1.53
           target: ${{ matrix.target }}
           override: true
 

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -6,6 +6,7 @@
   - `NewContractNameError::InvalidCharacters` is mapped to `i32::MIN + 10`
   - `NewReceiveNameError::InvalidCharacters` is mapped to `i32::MIN + 11`
 - Export `HashMap` and `HashSet` from `contract-common` in `collections` module.
+- Bump minimum supported Rust version to 1.51.
 
 ## concordium-std 0.5.0 (2021-05-12)
 


### PR DESCRIPTION
## Purpose/Changes

First see https://github.com/Concordium/concordium-contracts-common/pull/28.
Update to a newer version of contracts-common which uses const generics, and setting the CI rust version to 1.53

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
