### PR TITLE
Make the payable error code consistent with other library-defined ones.

### DIFF
--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -521,7 +521,7 @@ fn contract_function_optional_args_tokens<'a, I: Copy + IntoIterator<Item = &'a 
     } else {
         setup_fn_args.extend(quote! {
             if #amount_ident.micro_gtu != 0 {
-                return -1;
+                return concordium_std::Reject::from(concordium_std::NotPayableError).error_code.get();
             }
         });
     };

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
 ## Unreleased changes
-- Added error codes for the new cases in NewContractNameError and NewReceiveNameError:
+- Add error codes for the new cases in NewContractNameError and NewReceiveNameError:
   - `NewContractNameError::ContainsDot` is mapped to `i32::MIN + 9`
   - `NewContractNameError::InvalidCharacters` is mapped to `i32::MIN + 10`
   - `NewReceiveNameError::InvalidCharacters` is mapped to `i32::MIN + 11`
+- Change error code for when a contract that was not marked as payable received
+  tokens. The error code is now `i32::MIN + 12`, changed from the previous `-1`.
 - Export `HashMap` and `HashSet` from `contract-common` in `collections` module.
 - Bump minimum supported Rust version to 1.51.
 

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -92,6 +92,16 @@ impl From<NewReceiveNameError> for Reject {
     }
 }
 
+/// The error code is i32::MIN + 12
+impl From<NotPayableError> for Reject {
+    #[inline(always)]
+    fn from(_: NotPayableError) -> Self {
+        Self {
+            error_code: unsafe { crate::num::NonZeroI32::new_unchecked(i32::MIN + 12) },
+        }
+    }
+}
+
 /// # Contract state trait implementations.
 impl Seek for ContractState {
     type Err = ();

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -84,7 +84,7 @@
 //! - [HasParameter](./trait.HasParameter.html) for accessing the contract
 //!   parameter
 //! - [HasCommonData](./trait.HasCommonData.html) for accessing the data that is
-//!   common to both init and receive methodss
+//!   common to both init and receive methods
 //! - [HasInitContext](./trait.HasInitContext.html) for all the context data
 //!   available to the init functions (note that this includes all the common
 //!   data)
@@ -108,6 +108,49 @@
 //! [test_infrastructure](./test_infrastructure/index.html) module, and is
 //! intended to be used for unit-testing together with the `concordium_test`
 //! infrastructure.
+//!
+//! # Signalling errors
+//! On the Wasm level Contracts can signal errors by returning a negative i32
+//! value as a result of either initialization or invocation of the receive
+//! method. To make error handling more pleasant we provide the
+//! [Reject](./struct.Reject.html) structure. The result type of a contract init
+//! or a receive method is assumed to be of the form `Result<_, E>` where
+//! `Reject: From<E>`.
+//!
+//! The intention is that smart contract writers will write their own custom,
+//! precise, error types and either manually implement `Reject: From<E>` for
+//! their type `E`, or use the [Reject macro](./derive.Reject.html) which
+//! supports the common use cases.
+//!
+//! In addition to the custom errors that signal contract-specific error
+//! conditions this library provides some common error cases that most contracts
+//! will have to handle and their conversions to [Reject](./struct.Reject.html).
+//! These are
+//!
+//! | Variant | Error code |
+//! |---------|------------|
+//! | [()](https://doc.rust-lang.org/std/primitive.unit.html) | [i32::MIN](https://doc.rust-lang.org/std/primitive.i32.html#associatedconstant.MIN) + 1 (`-2147483647`) |
+//! | [ParseError](./struct.ParseError.html) | [i32::MIN] + 2 (`-2147483646`) |
+//! | [LogError::Full](./enum.LogError.html#variant.Full) | [i32::MIN] + 3
+//! (`-2147483645`) | | [LogError::Malformed](./enum.LogError.html#variant.
+//! Malformed) | [i32::MIN] + 4 (`-2147483644`) | | [NewContractNameError::
+//! MissingInitPrefix](./enum.LogError.html#variant.Malformed) | [i32::MIN] + 5
+//! (`-2147483643`) | | [NewContractNameError::TooLong](./enum.
+//! NewContractNameError.html#variant.TooLong) | [i32::MIN] + 6 (`-2147483642`)
+//! | | [NewContractNameError::ContainsDot](./enum.NewContractNameError.html#
+//! variant.ContainsDot) | [i32::MIN] + 9 (`-2147483639`) |
+//! | [NewContractNameError::InvalidCharacters](./enum.NewContractNameError.
+//! html#variant.InvalidCharacters) | [i32::MIN] + 10 (`-2147483638`) |
+//! | [NewReceiveNameError::MissingDotSeparator](./enum.NewReceiveNameError.
+//! html#variant.MissingDotSeparator) | [i32::MIN] + 7 (`-2147483641`) |
+//! | [NewReceiveNameError::TooLong](./enum.NewReceiveNameError.html#variant.
+//! TooLong) | [i32::MIN] + 8 (`-2147483640`) | | [NewReceiveNameError::
+//! InvalidCharacters](./enum.NewReceiveNameError.html#variant.
+//! InvalidCharacters) | [i32::MIN] + 11 (`-2147483637`) | | [NotPayableError](.
+//! /struct.NotPayableError.html) | [i32::MIN] + 12 (`-2147483636`) |
+//!
+//! Other error codes may be added in the future and custom error codes should
+//! not use the range `i32::MIN` to `i32::MIN + 100`.
 #![cfg_attr(not(feature = "std"), no_std, feature(alloc_error_handler, core_intrinsics))]
 
 #[cfg(not(feature = "std"))]

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -37,6 +37,11 @@ pub enum LogError {
     Malformed,
 }
 
+/// Error triggered when a non-zero amount of GTU is sent to a contract
+/// init or receive function that is not marked as `payable`.
+#[derive(Clone, Copy, Debug)]
+pub struct NotPayableError;
+
 /// Actions that can be produced at the end of a contract execution. This
 /// type is deliberately not cloneable so that we can enforce that
 /// `and_then` and `or_else` can only be used when more than one event is


### PR DESCRIPTION
## Purpose

Closes #56 

## Changes

- Add documentation for error codes to the library header.
- Change the error code generated for the "non-payable" contract that receives non-zero tokens.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

