### PR TITLE
Ensure that there are no redundant attributes in annotations, and no duplicates.

### DIFF
--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -88,7 +88,7 @@ impl ParsedAttributes {
         self.values.remove(&key)
     }
 
-    /// Remove an attribute return whether it was present.
+    /// Remove an attribute and return whether it was present.
     pub(crate) fn extract_flag(&mut self, key: &str) -> bool {
         // This is not clean, constructing a new identifier with a call_site span.
         // But the only alternative I see is iterating over the map and locating the key
@@ -399,14 +399,14 @@ pub fn init(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 fn init_worker(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> {
+    let ast: syn::ItemFn =
+        attach_error(syn::parse(item), "#[init] can only be applied to functions.")?;
+
     let attrs = Punctuated::<Meta, Token![,]>::parse_terminated.parse(attr)?;
 
     let init_attributes = parse_init_attributes(&attrs)?;
 
     let contract_name = init_attributes.contract;
-
-    let ast: syn::ItemFn =
-        attach_error(syn::parse(item), "#[init] can only be applied to functions.")?;
 
     let fn_name = &ast.sig.ident;
     let rust_export_fn_name = format_ident!("export_{}", fn_name);
@@ -592,10 +592,10 @@ pub fn receive(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 fn receive_worker(attr: TokenStream, item: TokenStream) -> syn::Result<TokenStream> {
-    let attrs = Punctuated::<Meta, Token![,]>::parse_terminated.parse(attr)?;
-
     let ast: syn::ItemFn =
         attach_error(syn::parse(item), "#[receive] can only be applied to functions.")?;
+
+    let attrs = Punctuated::<Meta, Token![,]>::parse_terminated.parse(attr)?;
 
     let receive_attributes = parse_receive_attributes(&attrs)?;
 

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -215,39 +215,53 @@ struct ContractStateAttributes {
 }
 
 #[cfg(feature = "build-schema")]
+// Attribute names for the contract_state macro.
+const CONTRACT_STATE_ATTRIBUTE_CONTRACT: &str = "contract";
+
+#[cfg(feature = "build-schema")]
 /// Parse nested attributes to the `contract_state` attribute.
 fn parse_contract_state_attributes<'a, I: IntoIterator<Item = &'a Meta>>(
     attrs: I,
 ) -> syn::Result<ContractStateAttributes> {
     let mut attributes = parse_attributes(attrs)?;
-    let contract = attributes.extract_value("contract").ok_or_else(|| {
-        syn::Error::new(
-            Span::call_site(),
-            "A name for the contract must be provided, using the 'contract' attribute.\n\nFor \
-             example, #[contract_state(contract = \"my-contract\")]",
-        )
-    })?;
+    let contract =
+        attributes.extract_value(CONTRACT_STATE_ATTRIBUTE_CONTRACT).ok_or_else(|| {
+            syn::Error::new(
+                Span::call_site(),
+                "A name for the contract must be provided, using the 'contract' attribute.\n\nFor \
+                 example, #[contract_state(contract = \"my-contract\")]",
+            )
+        })?;
     attributes.report_all_attributes()?;
     Ok(ContractStateAttributes {
         contract,
     })
 }
 
+// Supported attributes for the init methods.
+
+const INIT_ATTRIBUTE_PARAMETER: &str = "parameter";
+const INIT_ATTRIBUTE_CONTRACT: &str = "contract";
+const INIT_ATTRIBUTE_PAYABLE: &str = "payable";
+const INIT_ATTRIBUTE_ENABLE_LOGGER: &str = "enable_logger";
+const INIT_ATTRIBUTE_LOW_LEVEL: &str = "low_level";
+
 fn parse_init_attributes<'a, I: IntoIterator<Item = &'a Meta>>(
     attrs: I,
 ) -> syn::Result<InitAttributes> {
     let mut attributes = parse_attributes(attrs)?;
-    let contract: syn::LitStr = attributes.extract_value("contract").ok_or_else(|| {
-        syn::Error::new(
-            Span::call_site(),
-            "A name for the contract must be provided, using the 'contract' attribute.\n\nFor \
-             example, #[init(contract = \"my-contract\")]",
-        )
-    })?;
-    let parameter: Option<syn::LitStr> = attributes.extract_value("parameter");
-    let payable = attributes.extract_flag("payable");
-    let enable_logger = attributes.extract_flag("enable_logger");
-    let low_level = attributes.extract_flag("low_level");
+    let contract: syn::LitStr =
+        attributes.extract_value(INIT_ATTRIBUTE_CONTRACT).ok_or_else(|| {
+            syn::Error::new(
+                Span::call_site(),
+                "A name for the contract must be provided, using the 'contract' attribute.\n\nFor \
+                 example, #[init(contract = \"my-contract\")]",
+            )
+        })?;
+    let parameter: Option<syn::LitStr> = attributes.extract_value(INIT_ATTRIBUTE_PARAMETER);
+    let payable = attributes.extract_flag(INIT_ATTRIBUTE_PAYABLE);
+    let enable_logger = attributes.extract_flag(INIT_ATTRIBUTE_ENABLE_LOGGER);
+    let low_level = attributes.extract_flag(INIT_ATTRIBUTE_LOW_LEVEL);
     // Make sure that there are no unrecognized attributes. These would typically be
     // there due to an error. An improvement would be to find the nearest valid one
     // for each of them and report that in the error.
@@ -263,17 +277,26 @@ fn parse_init_attributes<'a, I: IntoIterator<Item = &'a Meta>>(
     })
 }
 
+// Supported attributes for the receive methods.
+
+const RECEIVE_ATTRIBUTE_PARAMETER: &str = "parameter";
+const RECEIVE_ATTRIBUTE_CONTRACT: &str = "contract";
+const RECEIVE_ATTRIBUTE_NAME: &str = "name";
+const RECEIVE_ATTRIBUTE_PAYABLE: &str = "payable";
+const RECEIVE_ATTRIBUTE_ENABLE_LOGGER: &str = "enable_logger";
+const RECEIVE_ATTRIBUTE_LOW_LEVEL: &str = "low_level";
+
 fn parse_receive_attributes<'a, I: IntoIterator<Item = &'a Meta>>(
     attrs: I,
 ) -> syn::Result<ReceiveAttributes> {
     let mut attributes = parse_attributes(attrs)?;
 
-    let contract = attributes.extract_value("contract");
-    let name = attributes.extract_value("name");
-    let parameter: Option<syn::LitStr> = attributes.extract_value("parameter");
-    let payable = attributes.extract_flag("payable");
-    let enable_logger = attributes.extract_flag("enable_logger");
-    let low_level = attributes.extract_flag("low_level");
+    let contract = attributes.extract_value(RECEIVE_ATTRIBUTE_CONTRACT);
+    let name = attributes.extract_value(RECEIVE_ATTRIBUTE_NAME);
+    let parameter: Option<syn::LitStr> = attributes.extract_value(RECEIVE_ATTRIBUTE_PARAMETER);
+    let payable = attributes.extract_flag(RECEIVE_ATTRIBUTE_PAYABLE);
+    let enable_logger = attributes.extract_flag(RECEIVE_ATTRIBUTE_ENABLE_LOGGER);
+    let low_level = attributes.extract_flag(RECEIVE_ATTRIBUTE_LOW_LEVEL);
     // Make sure that there are no unrecognized attributes. These would typically be
     // there due to an error. An improvement would be to find the nearest valid one
     // for each of them and report that in the error.


### PR DESCRIPTION
## Purpose

Closes #40 

## Changes

There should be no changes for valid uses of the macros.

In case of incorrect use compilation errors will be issued.

![Screenshot from 2021-09-27 10-10-14](https://user-images.githubusercontent.com/105212/134869662-9d6f5a50-26d6-4e1d-9810-f1d43caab28a.png)

There are some remaining improvements that we could do.

Currently if you have something like
```rust
#init(parameter = "foo", parameter)
```
the error will be that the second parameter is "unrecognized", but it could be argued that a more descriptive error would be that parameter is already set.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
