### PR TITLE
Release version 1.

### DIFF
--- a/concordium-cis1/Cargo.toml
+++ b/concordium-cis1/Cargo.toml
@@ -11,7 +11,7 @@ readme = "./README.md"
 
 [dependencies.concordium-std]
 path = "../concordium-std"
-version = "=0.5"
+version = "1.0"
 default-features = false
 
 [features]

--- a/concordium-std-derive/CHANGELOG.md
+++ b/concordium-std-derive/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased changes
+
+## concordium-std-derive 1.0.0 (2021-10-05)
+
 - Validate contract and receive names
 - Improve precision of error locations in init and receive_workers
 - Improve precision of error locations for `size_length`

--- a/concordium-std-derive/Cargo.toml
+++ b/concordium-std-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-std-derive"
-version = "0.5.0"
+version = "1.0.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"
@@ -17,7 +17,7 @@ proc-macro2 = "1.0"
 
 [dependencies.concordium-contracts-common]
 path = "../concordium-contracts-common"
-version = "0.4.1"
+version = "1.0"
 default-features = false
 
 [lib]

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased changes
+
+## concordium-std 1.0.0 (2021-10-05)
+
 - Add error codes for the new cases in NewContractNameError and NewReceiveNameError:
   - `NewContractNameError::ContainsDot` is mapped to `i32::MIN + 9`
   - `NewContractNameError::InvalidCharacters` is mapped to `i32::MIN + 10`

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-std"
-version = "0.5.0"
+version = "1.0.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"
@@ -16,11 +16,11 @@ wee_alloc="0.4.5"
 
 [dependencies.concordium-std-derive]
 path = "../concordium-std-derive"
-version = "=0.5"
+version = "1.0"
 
 [dependencies.concordium-contracts-common]
 path = "../concordium-contracts-common"
-version = "=0.4"
+version = "1.0"
 default-features = false
 
 [features]

--- a/examples/piggy-bank/part1/Cargo.toml
+++ b/examples/piggy-bank/part1/Cargo.toml
@@ -17,7 +17,7 @@ default = ["std"]
 std = ["concordium-std/std"]
 
 [dependencies.concordium-std]
-version = "0.5"
+version = "1.0"
 path = "../../../concordium-std"
 default-features = false
 

--- a/examples/piggy-bank/part2/Cargo.toml
+++ b/examples/piggy-bank/part2/Cargo.toml
@@ -17,7 +17,7 @@ default = ["std"]
 std = ["concordium-std/std"]
 
 [dependencies.concordium-std]
-version = "0.5"
+version = "1.0"
 path = "../../../concordium-std"
 default-features = false
 

--- a/examples/two-step-transfer/Cargo.toml
+++ b/examples/two-step-transfer/Cargo.toml
@@ -20,7 +20,7 @@ byteorder = "1.3"
 [dependencies.concordium-std]
 # git = "https://github.com/Concordium/concordium-std.git"
 # branch = "main"
-version = "0.5"
+version = "1.0"
 path = "../../concordium-std"
 default-features = false
 


### PR DESCRIPTION
## Purpose
Release version 1 of concordium-std and concordium-std-derive.

## Changes

- Bump version of concordium-contracts-common.
- Update changelog to reflect release.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
