### PR TITLE
Update to CIS-1 draft 3: TokenMetadata query and no ContractOnly error

### DIFF
--- a/concordium-cis1/src/lib.rs
+++ b/concordium-cis1/src/lib.rs
@@ -817,6 +817,48 @@ impl<T: IsTokenId> AsRef<[BalanceOfQueryResult<T>]> for BalanceOfQueryResponse<T
     fn as_ref(&self) -> &[BalanceOfQueryResult<T>] { &self.0 }
 }
 
+/// A query for the operator of a given address for a given token.
+// Note: For the serialization to be derived according to the CIS1
+// specification, the order of the fields cannot be changed.
+#[derive(Debug, Serialize, SchemaType)]
+pub struct OperatorOfQuery {
+    /// The ID of the token for which to query the balance of.
+    pub owner:   Address,
+    /// The address for which to check for being an operator of the owner.
+    pub address: Address,
+}
+
+/// The parameter type for the contract function `operatorOf`.
+// Note: For the serialization to be derived according to the CIS1
+// specification, the order of the fields cannot be changed.
+#[derive(Debug, Serialize, SchemaType)]
+pub struct OperatorOfQueryParams {
+    /// The contract to trigger with the results of the queries.
+    pub result_contract: ContractAddress,
+    /// The contract function to trigger with the results of the queries.
+    pub result_function: OwnedReceiveName,
+    /// List of operatorOf queries.
+    #[concordium(size_length = 2)]
+    pub queries:         Vec<OperatorOfQuery>,
+}
+
+/// OperatorOf query with the result of the query.
+pub type OperatorOfQueryResult = (OperatorOfQuery, bool);
+
+/// The response which is sent back when calling the contract function
+/// `operatorOf`.
+/// It consists of the list of queries paired with their corresponding result.
+#[derive(Debug, Serialize, SchemaType)]
+pub struct OperatorOfQueryResponse(#[concordium(size_length = 2)] Vec<OperatorOfQueryResult>);
+
+impl From<Vec<OperatorOfQueryResult>> for OperatorOfQueryResponse {
+    fn from(results: Vec<OperatorOfQueryResult>) -> Self { OperatorOfQueryResponse(results) }
+}
+
+impl AsRef<[OperatorOfQueryResult]> for OperatorOfQueryResponse {
+    fn as_ref(&self) -> &[OperatorOfQueryResult] { &self.0 }
+}
+
 /// The parameter type for the contract function `tokenMetadata`.
 // Note: For the serialization to be derived according to the CIS1
 // specification, the order of the fields cannot be changed.

--- a/concordium-cis1/src/lib.rs
+++ b/concordium-cis1/src/lib.rs
@@ -578,11 +578,8 @@ pub enum Cis1Error<R> {
     /// The balance of the token owner is insufficient for the transfer (Error
     /// code: -42000002).
     InsufficientFunds,
-    /// Sender is neither the token owner or an operator of the owner for this
-    /// token (Error code: -42000003).
+    /// Sender is unauthorized to call this function (Error code: -42000003).
     Unauthorized,
-    /// Only contracts can send to this function (Error code: -42000004).
-    ContractOnly,
     /// Custom error
     Custom(R),
 }
@@ -591,7 +588,6 @@ pub enum Cis1Error<R> {
 /// - InvalidTokenId: -42000001
 /// - InsufficientFunds: -42000002
 /// - Unauthorized: -42000003
-/// - ContractOnly: -42000004
 impl<R: Into<Reject>> From<Cis1Error<R>> for Reject {
     fn from(err: Cis1Error<R>) -> Self {
         let error_code = match err {
@@ -602,7 +598,6 @@ impl<R: Into<Reject>> From<Cis1Error<R>> for Reject {
                 crate::num::NonZeroI32::new_unchecked(-42000002)
             },
             Cis1Error::Unauthorized => unsafe { crate::num::NonZeroI32::new_unchecked(-42000003) },
-            Cis1Error::ContractOnly => unsafe { crate::num::NonZeroI32::new_unchecked(-42000004) },
             Cis1Error::Custom(reject) => reject.into().error_code,
         };
         Self {
@@ -790,17 +785,17 @@ pub struct BalanceOfQuery<T: IsTokenId> {
 }
 
 /// The parameter type for the contract function `balanceOf`.
-/// This is contract function can only be called by another contract instance,
-/// and there is no reason to derive a SchemaType for this example.
 // Note: For the serialization to be derived according to the CIS1
 // specification, the order of the fields cannot be changed.
 #[derive(Debug, Serialize, SchemaType)]
 pub struct BalanceOfQueryParams<T: IsTokenId> {
+    /// The contract to trigger with the results of the queries.
+    pub result_contract: ContractAddress,
     /// The contract function to trigger with the results of the queries.
-    pub callback: OwnedReceiveName,
+    pub result_function: OwnedReceiveName,
     /// List of balance queries.
     #[concordium(size_length = 2)]
-    pub queries:  Vec<BalanceOfQuery<T>>,
+    pub queries:         Vec<BalanceOfQuery<T>>,
 }
 
 /// BalanceOf query with the result of the query.
@@ -820,6 +815,41 @@ impl<T: IsTokenId> From<Vec<BalanceOfQueryResult<T>>> for BalanceOfQueryResponse
 
 impl<T: IsTokenId> AsRef<[BalanceOfQueryResult<T>]> for BalanceOfQueryResponse<T> {
     fn as_ref(&self) -> &[BalanceOfQueryResult<T>] { &self.0 }
+}
+
+/// The parameter type for the contract function `tokenMetadata`.
+// Note: For the serialization to be derived according to the CIS1
+// specification, the order of the fields cannot be changed.
+#[derive(Debug, Serialize, SchemaType)]
+pub struct TokenMetadataQueryParams<T: IsTokenId> {
+    /// The contract to trigger with the results of the queries.
+    pub result_contract: ContractAddress,
+    /// The contract function to trigger with the results of the queries.
+    pub result_function: OwnedReceiveName,
+    /// List of balance queries.
+    #[concordium(size_length = 2)]
+    pub queries:         Vec<T>,
+}
+
+/// TokenMetadata query with the result of the query.
+pub type TokenMetadataQueryResult<T> = (T, MetadataUrl);
+
+/// The response which is sent back when calling the contract function
+/// `tokenMetadata`.
+/// It consists of the list of queries paired with their corresponding result.
+#[derive(Debug, Serialize, SchemaType)]
+pub struct TokenMetadataQueryResponse<T: IsTokenId>(
+    #[concordium(size_length = 2)] Vec<TokenMetadataQueryResult<T>>,
+);
+
+impl<T: IsTokenId> From<Vec<TokenMetadataQueryResult<T>>> for TokenMetadataQueryResponse<T> {
+    fn from(results: Vec<TokenMetadataQueryResult<T>>) -> Self {
+        TokenMetadataQueryResponse(results)
+    }
+}
+
+impl<T: IsTokenId> AsRef<[TokenMetadataQueryResult<T>]> for TokenMetadataQueryResponse<T> {
+    fn as_ref(&self) -> &[TokenMetadataQueryResult<T>] { &self.0 }
 }
 
 /// The parameter type for a contract function which receives CIS1 tokens.

--- a/examples/cis1-multi/src/lib.rs
+++ b/examples/cis1-multi/src/lib.rs
@@ -428,6 +428,36 @@ fn contract_balance_of<A: HasActions>(
     ))
 }
 
+/// Takes a list of queries. Each query is an owner address and some address to
+/// check as an operator of the owner address. It takes a contract address plus
+/// contract function to invoke with the result.
+///
+/// It rejects if:
+/// - It fails to parse the parameter.
+/// - Message sent back with the result rejects.
+#[receive(contract = "CIS1-Multi", name = "operatorOf", parameter = "OperatorOfQueryParams")]
+fn contract_operator_of<A: HasActions>(
+    ctx: &impl HasReceiveContext,
+    state: &mut State,
+) -> ContractResult<A> {
+    // Parse the parameter.
+    let params: OperatorOfQueryParams = ctx.parameter_cursor().get()?;
+    // Build the response.
+    let mut response = Vec::with_capacity(params.queries.len());
+    for query in params.queries {
+        // Query the state for address being an operator of owner.
+        let is_operator = state.is_operator(&query.owner, &query.address);
+        response.push((query, is_operator));
+    }
+    // Send back the response.
+    Ok(send(
+        &params.result_contract,
+        params.result_function.as_ref(),
+        Amount::zero(),
+        &OperatorOfQueryResponse::from(response),
+    ))
+}
+
 /// Parameter type for the CIS-1 function `tokenMetadata` specialized to the
 /// subset of TokenIDs used by this contract.
 type ContractTokenMetadataQueryParams = TokenMetadataQueryParams<ContractTokenId>;

--- a/examples/cis1-multi/src/lib.rs
+++ b/examples/cis1-multi/src/lib.rs
@@ -394,10 +394,11 @@ fn contract_update_operator<A: HasActions>(
     Ok(A::accept())
 }
 
-#[allow(dead_code)]
+/// Parameter type for the CIS-1 function `balanceOf` specialized to the subset
+/// of TokenIDs used by this contract.
 type ContractBalanceOfQueryParams = BalanceOfQueryParams<ContractTokenId>;
 
-/// Get the balance of given token IDs and addresses, and it takes a contract
+/// Get the balance of given token IDs and addresses. It takes a contract
 /// address plus contract function to invoke with the result.
 ///
 /// It rejects if:
@@ -410,7 +411,7 @@ fn contract_balance_of<A: HasActions>(
     state: &mut State,
 ) -> ContractResult<A> {
     // Parse the parameter.
-    let params: BalanceOfQueryParams<ContractTokenId> = ctx.parameter_cursor().get()?;
+    let params: ContractBalanceOfQueryParams = ctx.parameter_cursor().get()?;
     // Build the response.
     let mut response = Vec::with_capacity(params.queries.len());
     for query in params.queries {
@@ -427,10 +428,11 @@ fn contract_balance_of<A: HasActions>(
     ))
 }
 
-#[allow(dead_code)]
+/// Parameter type for the CIS-1 function `tokenMetadata` specialized to the
+/// subset of TokenIDs used by this contract.
 type ContractTokenMetadataQueryParams = TokenMetadataQueryParams<ContractTokenId>;
 
-/// Get the token metadata URLs and checksums given a list of token IDs and it
+/// Get the token metadata URLs and checksums given a list of token IDs. It
 /// takes a contract address plus contract function to invoke with the result.
 ///
 /// It rejects if:
@@ -447,7 +449,7 @@ fn contract_token_metadata<A: HasActions>(
     state: &mut State,
 ) -> ContractResult<A> {
     // Parse the parameter.
-    let params: TokenMetadataQueryParams<ContractTokenId> = ctx.parameter_cursor().get()?;
+    let params: ContractTokenMetadataQueryParams = ctx.parameter_cursor().get()?;
     // Build the response.
     let mut response = Vec::with_capacity(params.queries.len());
     for token_id in params.queries {

--- a/examples/cis1-nft/src/lib.rs
+++ b/examples/cis1-nft/src/lib.rs
@@ -393,10 +393,11 @@ fn contract_update_operator<A: HasActions>(
     Ok(A::accept())
 }
 
-#[allow(dead_code)]
+/// Parameter type for the CIS-1 function `balanceOf` specialized to the subset
+/// of TokenIDs used by this contract.
 type ContractBalanceOfQueryParams = BalanceOfQueryParams<ContractTokenId>;
 
-/// Get the balance of given token IDs and addresses, and it takes a contract
+/// Get the balance of given token IDs and addresses. It takes a contract
 /// address plus contract function to invoke with the result.
 ///
 /// It rejects if:
@@ -409,7 +410,7 @@ fn contract_balance_of<A: HasActions>(
     state: &mut State,
 ) -> ContractResult<A> {
     // Parse the parameter.
-    let params: BalanceOfQueryParams<ContractTokenId> = ctx.parameter_cursor().get()?;
+    let params: ContractBalanceOfQueryParams = ctx.parameter_cursor().get()?;
     // Build the response.
     let mut response = Vec::with_capacity(params.queries.len());
     for query in params.queries {
@@ -426,10 +427,11 @@ fn contract_balance_of<A: HasActions>(
     ))
 }
 
-#[allow(dead_code)]
+/// Parameter type for the CIS-1 function `tokenMetadata` specialized to the
+/// subset of TokenIDs used by this contract.
 type ContractTokenMetadataQueryParams = TokenMetadataQueryParams<ContractTokenId>;
 
-/// Get the token metadata URLs and checksums given a list of token IDs and it
+/// Get the token metadata URLs and checksums given a list of token IDs. It
 /// takes a contract address plus contract function to invoke with the result.
 ///
 /// It rejects if:
@@ -446,7 +448,7 @@ fn contract_token_metadata<A: HasActions>(
     state: &mut State,
 ) -> ContractResult<A> {
     // Parse the parameter.
-    let params: TokenMetadataQueryParams<ContractTokenId> = ctx.parameter_cursor().get()?;
+    let params: ContractTokenMetadataQueryParams = ctx.parameter_cursor().get()?;
     // Build the response.
     let mut response = Vec::with_capacity(params.queries.len());
     for token_id in params.queries {

--- a/examples/cis1-nft/src/lib.rs
+++ b/examples/cis1-nft/src/lib.rs
@@ -124,6 +124,12 @@ impl State {
         Ok(())
     }
 
+    /// Check that the token ID currently exists in this contract.
+    #[inline(always)]
+    fn contains_token(&self, token_id: &ContractTokenId) -> bool {
+        self.all_tokens.contains(token_id)
+    }
+
     /// Get the current balance of a given token ID for a given address.
     /// Results in an error if the token ID does not exist in the state.
     /// Since this contract only contains NFTs, the balance will always be
@@ -133,7 +139,7 @@ impl State {
         token_id: &ContractTokenId,
         address: &Address,
     ) -> ContractResult<TokenAmount> {
-        ensure!(self.all_tokens.contains(token_id), ContractError::InvalidTokenId);
+        ensure!(self.contains_token(token_id), ContractError::InvalidTokenId);
         let balance = self
             .state
             .get(address)
@@ -166,7 +172,7 @@ impl State {
         from: &Address,
         to: &Address,
     ) -> ContractResult<()> {
-        ensure!(self.all_tokens.contains(token_id), ContractError::InvalidTokenId);
+        ensure!(self.contains_token(token_id), ContractError::InvalidTokenId);
         // A zero transfer does not modify the state.
         if amount == 0 {
             return Ok(());
@@ -203,6 +209,14 @@ impl State {
     fn remove_operator(&mut self, owner: &Address, operator: &Address) {
         self.state.get_mut(owner).map(|address_state| address_state.operators.remove(operator));
     }
+}
+
+/// Build a string from TOKEN_METADATA_BASE_URL appended with the token ID
+/// encoded as hex.
+fn build_token_metadata_url(token_id: &ContractTokenId) -> String {
+    let mut token_metadata_url = String::from(TOKEN_METADATA_BASE_URL);
+    token_metadata_url.push_str(&token_id.to_string());
+    token_metadata_url
 }
 
 // Contract functions
@@ -258,12 +272,10 @@ fn contract_mint<A: HasActions>(
         }))?;
 
         // Metadata URL for the NFT.
-        let mut token_metadata_url = String::from(TOKEN_METADATA_BASE_URL);
-        token_metadata_url.push_str(&token_id.to_string());
         logger.log(&Cis1Event::TokenMetadata(TokenMetadataEvent {
             token_id,
             metadata_url: MetadataUrl {
-                url:  token_metadata_url,
+                url:  build_token_metadata_url(&token_id),
                 hash: None,
             },
         }))?;
@@ -381,26 +393,21 @@ fn contract_update_operator<A: HasActions>(
     Ok(A::accept())
 }
 
-/// Get the balance of given token IDs and addresses and callback contract
-/// function on sender with the result. Will only succeed if sender is a smart
-/// contract.
+#[allow(dead_code)]
+type ContractBalanceOfQueryParams = BalanceOfQueryParams<ContractTokenId>;
+
+/// Get the balance of given token IDs and addresses, and it takes a contract
+/// address plus contract function to invoke with the result.
 ///
 /// It rejects if:
-/// - Sender is not a contract.
 /// - It fails to parse the parameter.
 /// - Any of the queried `token_id` does not exist.
 /// - Message sent back with the result rejects.
-#[receive(contract = "CIS1-NFT", name = "balanceOf")]
+#[receive(contract = "CIS1-NFT", name = "balanceOf", parameter = "ContractBalanceOfQueryParams")]
 fn contract_balance_of<A: HasActions>(
     ctx: &impl HasReceiveContext,
     state: &mut State,
 ) -> ContractResult<A> {
-    // Ensure the sender is a contract.
-    let sender = if let Address::Contract(contract) = ctx.sender() {
-        contract
-    } else {
-        bail!(ContractError::ContractOnly)
-    };
     // Parse the parameter.
     let params: BalanceOfQueryParams<ContractTokenId> = ctx.parameter_cursor().get()?;
     // Build the response.
@@ -412,10 +419,52 @@ fn contract_balance_of<A: HasActions>(
     }
     // Send back the response.
     Ok(send(
-        &sender,
-        params.callback.as_ref(),
+        &params.result_contract,
+        params.result_function.as_ref(),
         Amount::zero(),
         &BalanceOfQueryResponse::from(response),
+    ))
+}
+
+#[allow(dead_code)]
+type ContractTokenMetadataQueryParams = TokenMetadataQueryParams<ContractTokenId>;
+
+/// Get the token metadata URLs and checksums given a list of token IDs and it
+/// takes a contract address plus contract function to invoke with the result.
+///
+/// It rejects if:
+/// - It fails to parse the parameter.
+/// - Any of the queried `token_id` does not exist.
+/// - Message sent back with the result rejects.
+#[receive(
+    contract = "CIS1-NFT",
+    name = "tokenMetadata",
+    parameter = "ContractTokenMetadataQueryParams"
+)]
+fn contract_token_metadata<A: HasActions>(
+    ctx: &impl HasReceiveContext,
+    state: &mut State,
+) -> ContractResult<A> {
+    // Parse the parameter.
+    let params: TokenMetadataQueryParams<ContractTokenId> = ctx.parameter_cursor().get()?;
+    // Build the response.
+    let mut response = Vec::with_capacity(params.queries.len());
+    for token_id in params.queries {
+        // Check the token exists.
+        ensure!(state.contains_token(&token_id), ContractError::InvalidTokenId);
+
+        let metadata_url = MetadataUrl {
+            url:  build_token_metadata_url(&token_id),
+            hash: None,
+        };
+        response.push((token_id, metadata_url));
+    }
+    // Send back the response.
+    Ok(send(
+        &params.result_contract,
+        params.result_function.as_ref(),
+        Amount::zero(),
+        &TokenMetadataQueryResponse::from(response),
     ))
 }
 

--- a/examples/cis1-wgtu/src/lib.rs
+++ b/examples/cis1-wgtu/src/lib.rs
@@ -508,6 +508,36 @@ fn contract_balance_of<A: HasActions>(
     ))
 }
 
+/// Takes a list of queries. Each query is an owner address and some address to
+/// check as an operator of the owner address. It takes a contract address plus
+/// contract function to invoke with the result.
+///
+/// It rejects if:
+/// - It fails to parse the parameter.
+/// - Message sent back with the result rejects.
+#[receive(contract = "CIS1-wGTU", name = "operatorOf", parameter = "OperatorOfQueryParams")]
+fn contract_operator_of<A: HasActions>(
+    ctx: &impl HasReceiveContext,
+    state: &mut State,
+) -> ContractResult<A> {
+    // Parse the parameter.
+    let params: OperatorOfQueryParams = ctx.parameter_cursor().get()?;
+    // Build the response.
+    let mut response = Vec::with_capacity(params.queries.len());
+    for query in params.queries {
+        // Query the state for address being an operator of owner.
+        let is_operator = state.is_operator(&query.owner, &query.address);
+        response.push((query, is_operator));
+    }
+    // Send back the response.
+    Ok(send(
+        &params.result_contract,
+        params.result_function.as_ref(),
+        Amount::zero(),
+        &OperatorOfQueryResponse::from(response),
+    ))
+}
+
 /// Parameter type for the CIS-1 function `tokenMetadata` specialized to the
 /// subset of TokenIDs used by this contract.
 // This type is pub to silence the dead_code warning, as this type is only used

--- a/examples/cis1-wgtu/src/lib.rs
+++ b/examples/cis1-wgtu/src/lib.rs
@@ -463,10 +463,13 @@ fn contract_update_operator<A: HasActions>(
     Ok(A::accept())
 }
 
-#[allow(dead_code)]
-type ContractBalanceOfQueryParams = BalanceOfQueryParams<ContractTokenId>;
+/// Parameter type for the CIS-1 function `balanceOf` specialized to the subset
+/// of TokenIDs used by this contract.
+// This type is pub to silence the dead_code warning, as this type is only used
+// for when generating the schema.
+pub type ContractBalanceOfQueryParams = BalanceOfQueryParams<ContractTokenId>;
 
-/// Get the balance of given token IDs and addresses, and it takes a contract
+/// Get the balance of given token IDs and addresses. It takes a contract
 /// address plus contract function to invoke with the result.
 ///
 /// It rejects if:
@@ -505,10 +508,13 @@ fn contract_balance_of<A: HasActions>(
     ))
 }
 
-#[allow(dead_code)]
-type ContractTokenMetadataQueryParams = TokenMetadataQueryParams<ContractTokenId>;
+/// Parameter type for the CIS-1 function `tokenMetadata` specialized to the
+/// subset of TokenIDs used by this contract.
+// This type is pub to silence the dead_code warning, as this type is only used
+// for when generating the schema.
+pub type ContractTokenMetadataQueryParams = TokenMetadataQueryParams<ContractTokenId>;
 
-/// Get the token metadata URLs and checksums given a list of token IDs and it
+/// Get the token metadata URLs and checksums given a list of token IDs. It
 /// takes a contract address plus contract function to invoke with the result.
 ///
 /// It rejects if:


### PR DESCRIPTION
## Purpose

Update cis1 library and examples with the changes in https://github.com/Concordium/concordium-update-proposals/pull/14.

## Changes

For `concordium-cis1`
- Introduce parameter type for new `tokenMetadata` query
- Extend `balanceOf` parameter with contract address for receiving the result.

For CIS-1 examples:
- Send query results to the contract address from the parameter.
- Add CIS1 contract function `tokenMetadata`.
- Remove check for sender being a contract address for queries.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
