### PR TITLE
Improve `claim_eq` and `claim_ne` macros

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 - Update references to token to match token name (CCD).
+- Improve `claim_eq` and `claim_ne` macros such that:
+  - Arguments are only evaluated once.
+  - Type inference works as you would expect.
 
 ## concordium-std 1.0.0 (2021-10-05)
 

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -221,11 +221,16 @@ macro_rules! claim {
 /// reports an error. Used only in testing.
 #[macro_export]
 macro_rules! claim_eq {
-    ($left:expr, $right:expr) => {
-        $crate::claim!($left == $right, "left and right are not equal\nleft: {:?}\nright: {:?}", $left, $right)
-    };
-    ($left:expr, $right:expr,) => {
-        $crate::claim_eq!($left, $right)
+    ($left:expr, $right:expr $(,)?) => {
+        // Use match to ensure that the values are only evaluated once,
+        // and to ensure that type inference works correctly when printing.
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    $crate::fail!("left and right are not equal\nleft: {:?}\nright: {:?}\n", left_val, right_val);
+                }
+            }
+        }
     };
     ($left:expr, $right:expr, $($arg:tt),+) => {
         $crate::claim!($left == $right, $($arg),+)
@@ -237,11 +242,16 @@ macro_rules! claim_eq {
 /// Used only in testing.
 #[macro_export]
 macro_rules! claim_ne {
-    ($left:expr, $right:expr) => {
-        $crate::claim!($left != $right)
-    };
-    ($left:expr, $right:expr,) => {
-        $crate::claim!($left != $right)
+    ($left:expr, $right:expr $(,)?) => {
+        // Use match to ensure that the values are only evaluated once,
+        // and to ensure that type inference works correctly when printing.
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if *left_val == *right_val {
+                    $crate::fail!("left and right are equal\nleft: {:?}\nright: {:?}\n", left_val, right_val);
+                }
+            }
+        }
     };
     ($left:expr, $right:expr, $($arg:tt),+) => {
         $crate::claim!($left != $right, $($arg),+)


### PR DESCRIPTION
## Purpose

Improves the `claim_eq` and `claim_ne` macros:
 - The operands are now only evaluated once.
    - This was a especially a problem when the evaluation had a side-effect.
 - Type inference now works as you would expect (see example of a typical problem):
    ```rust
    // Prior to this PR,
    claim_eq!(my_result, Ok(0));
    // Was turned into:
    claim!(my_result == Ok(0), "left and right are not equal\nleft: {:?} right{:?}", my_result, Ok(0));
    // Result type inferred-^                                 Cannot infer the Result type here --^
    ```

## Changes

- Use `match` in the macros such that the operands are only evaluated once. This also fixes the type inference.
   - Heavily inspired by the `assert_eq!` macro implementation ;) 
- Merge the trailing-comma case into the regular case by using `$(,)?`
- Add a newline after the error message.
- Write an actual error message for `claim_ne!`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.