### PR TITLE
Cfg not test macro

### DIFF
--- a/concordium-std-derive/CHANGELOG.md
+++ b/concordium-std-derive/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Add `#[concordium_cfg_not_test]` macro, that excludes parts of code for testing.
+
 ## concordium-std-derive 2.0.0 (2022-01-05)
 
 - Update references to token to match token name (CCD).

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -1713,3 +1713,28 @@ pub fn concordium_cfg_test(_attr: TokenStream, item: TokenStream) -> TokenStream
     };
     out.into()
 }
+
+/// If `wasm-test` feature of `concordium-std` is enabled ignore the item,
+/// this usually happens when executing tests with `cargo-concordium` utility.
+/// Otherwise this is equivalent to `#[cfg(not(test))]`. Use as a dual to
+/// `#[concordium_cfg_test]`.
+#[cfg(feature = "wasm-test")]
+#[proc_macro_attribute]
+pub fn concordium_cfg_not_test(_attr: TokenStream, _item: TokenStream) -> TokenStream {
+    TokenStream::new()
+}
+
+/// If `wasm-test` feature of `concordium-std` is enabled ignore the item,
+/// this usually happens when executing tests with `cargo-concordium` utility.
+/// Otherwise this is equivalent to `#[cfg(not(test))]`. Use as a dual to
+/// `#[concordium_cfg_test]`.
+#[cfg(not(feature = "wasm-test"))]
+#[proc_macro_attribute]
+pub fn concordium_cfg_not_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let item = proc_macro2::TokenStream::from(item);
+    let out = quote! {
+        #[cfg(not(test))]
+        #item
+    };
+    out.into()
+}

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -1531,7 +1531,7 @@ fn reject_derive_worker(input: TokenStream) -> syn::Result<TokenStream> {
         }
     };
 
-    let variant_error_conversions = generate_variant_error_conversions(&enum_data, &enum_ident)?;
+    let variant_error_conversions = generate_variant_error_conversions(enum_data, enum_ident)?;
 
     let gen = quote! {
         /// The from implementation maps the first variant to -1, second to -2, etc.
@@ -1621,7 +1621,7 @@ fn parse_attr_and_gen_error_conversions(
                     syn::NestedMeta::Lit(l) => return Err(wrong_from_usage(&l)),
                 }
             }
-            Ok(from_error_token_stream(&from_error_names, &enum_name, variant_name).collect())
+            Ok(from_error_token_stream(&from_error_names, enum_name, variant_name).collect())
         }
         Ok(syn::Meta::NameValue(mnv)) if mnv.path.is_ident("from") => Err(wrong_from_usage(&mnv)),
         _ => Ok(vec![]),


### PR DESCRIPTION
## Purpose

Currently it is not possible without unintuitive workarounds to disable parts of code that are intended for testing only, like mocking or stubbing functions, etc. This PR provides the `#[concordium_cfg_test]` macro counterpart that is intended to allow replacing certain functions exclusively for running tests.

## Changes

`#[concordium_cfg_not_test]` macro added, similar to `#[cfg(not(test))]`, but works with `cargo-concordium`

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
