### PR TITLE
Add DerefMut to OccupiedEntry and StateRefMut.

### DIFF
--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -108,7 +108,7 @@ pub struct StateSetIter<'a, T, S: HasStateApi> {
 ///
 /// The type parameter `T` is the type stored in the box. The type parameter `S`
 /// is the state.
-pub struct StateBox<T, S: HasStateApi> {
+pub struct StateBox<T: Serial, S: HasStateApi> {
     pub(crate) state_api: S,
     pub(crate) inner:     UnsafeCell<StateBoxInner<T, S>>,
 }
@@ -116,8 +116,9 @@ pub struct StateBox<T, S: HasStateApi> {
 pub(crate) enum StateBoxInner<T, S: HasStateApi> {
     /// Value is loaded in memory, and we have a backing entry.
     Loaded {
-        entry: S::EntryType,
-        value: T,
+        entry:    S::EntryType,
+        modified: bool,
+        value:    T,
     },
     /// We only have the memory location at which the value is stored.
     Reference {
@@ -253,9 +254,9 @@ pub struct VacantEntry<'a, K, V, S> {
 /// that the value is properly stored in the contract state maintained by the
 /// node.
 ///
-/// Differs from [`OccupiedEntryRaw`] in that this automatically handles
+/// This differs from [`OccupiedEntryRaw`] in that this automatically handles
 /// serialization and provides convenience methods for modifying the value via
-/// the [`DerefMut`](crate::ops::DerefMut).
+/// the [`DerefMut`](crate::ops::DerefMut) implementation.
 pub struct OccupiedEntry<'a, K, V: Serial, S: HasStateApi> {
     pub(crate) key:              K,
     pub(crate) value:            V,

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -1,4 +1,4 @@
-use crate::{cell::UnsafeCell, marker::PhantomData, num::NonZeroU32, HasStateApi, Vec};
+use crate::{cell::UnsafeCell, marker::PhantomData, num::NonZeroU32, HasStateApi, Serial, Vec};
 
 #[derive(Debug)]
 /// A map based on a [Trie](https://en.wikipedia.org/wiki/Trie) in the state.
@@ -155,23 +155,20 @@ impl<'a, V> crate::ops::Deref for StateRef<'a, V> {
 }
 
 #[derive(Debug)]
-/// The [`StateRefMut<_, V, _>`] behaves like `&mut V` except that values cannot
-/// be directly mutated, that is, it does not implement
-/// [`DerefMut`](crate::ops::DerefMut) since that would allow updates that would
-/// not be properly reflected in contract state. Instead the
-/// [`update`](StateRefMut::update) or [`set`](StateRefMut::set) methods should
-/// be used.
-///
-/// The type does implement [`Deref`](crate::ops::Deref) however, so immutable
-/// borrows are convenient.
-pub struct StateRefMut<'a, V, S: HasStateApi> {
+/// The [`StateRefMut<_, V, _>`] behaves like `&mut V`, by analogy with other
+/// standard library RAII guards like [`RefMut`](std::cell::RefMut).
+/// The type implements [`DerefMut`](crate::ops::DerefMut) which allows the
+/// value to be mutated. Additionally, the [`Drop`](Drop) implementation ensures
+/// that the value is properly stored in the contract state maintained by the
+/// node.
+pub struct StateRefMut<'a, V: Serial, S: HasStateApi> {
     pub(crate) entry:            UnsafeCell<S::EntryType>,
     pub(crate) state_api:        S,
     pub(crate) lazy_value:       UnsafeCell<Option<V>>,
     pub(crate) _marker_lifetime: PhantomData<&'a mut V>,
 }
 
-impl<'a, V, S: HasStateApi> StateRefMut<'a, V, S> {
+impl<'a, V: Serial, S: HasStateApi> StateRefMut<'a, V, S> {
     #[inline(always)]
     pub(crate) fn new(entry: S::EntryType, state_api: S) -> Self {
         Self {
@@ -251,20 +248,47 @@ pub struct VacantEntry<'a, K, V, S> {
 /// [`StateMap::entry`] method. This allows looking up or modifying the value at
 /// a give key in-place.
 ///
+/// The type implements [`DerefMut`](crate::ops::DerefMut) which allows the
+/// value to be mutated. The [`Drop`](Drop) implementation ensures
+/// that the value is properly stored in the contract state maintained by the
+/// node.
+///
 /// Differs from [`OccupiedEntryRaw`] in that this automatically handles
-/// serialization.
-pub struct OccupiedEntry<'a, K, V, S: HasStateApi> {
+/// serialization and provides convenience methods for modifying the value via
+/// the [`DerefMut`](crate::ops::DerefMut).
+pub struct OccupiedEntry<'a, K, V: Serial, S: HasStateApi> {
     pub(crate) key:              K,
     pub(crate) value:            V,
+    /// Indicates whether the value should be stored by the drop implementation.
+    /// This is set when deref_mut method is called only, since that is when we
+    /// **might** implicitly mutate the value.
+    pub(crate) modified:         bool,
     pub(crate) state_entry:      S::EntryType,
     pub(crate) _lifetime_marker: PhantomData<&'a mut (K, V)>,
 }
 
-impl<'a, K, V, S: HasStateApi> crate::ops::Deref for OccupiedEntry<'a, K, V, S> {
+impl<'a, K, V: Serial, S: HasStateApi> crate::ops::Deref for OccupiedEntry<'a, K, V, S> {
     type Target = V;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target { &self.value }
+}
+
+impl<'a, K, V: Serial, S: HasStateApi> crate::ops::DerefMut for OccupiedEntry<'a, K, V, S> {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.modified = true;
+        &mut self.value
+    }
+}
+
+impl<'a, K, V: Serial, S: HasStateApi> Drop for OccupiedEntry<'a, K, V, S> {
+    #[inline(always)]
+    fn drop(&mut self) {
+        if self.modified {
+            self.store_value()
+        }
+    }
 }
 
 /// A view into a single entry in a [`StateMap`], which
@@ -272,7 +296,7 @@ impl<'a, K, V, S: HasStateApi> crate::ops::Deref for OccupiedEntry<'a, K, V, S> 
 ///
 /// This `enum` is constructed from the [`entry`][StateMap::entry] method
 /// on a [`StateMap`] type.
-pub enum Entry<'a, K, V, S: HasStateApi> {
+pub enum Entry<'a, K, V: Serial, S: HasStateApi> {
     Vacant(VacantEntry<'a, K, V, S>),
     Occupied(OccupiedEntry<'a, K, V, S>),
 }

--- a/examples/auction/src/lib.rs
+++ b/examples/auction/src/lib.rs
@@ -114,16 +114,12 @@ fn auction_bid<S: HasStateApi>(
         Address::Contract(_) => bail!(BidError::ContractSender),
         Address::Account(account_address) => account_address,
     };
-    let bid_to_update =
-        state.bids.entry(sender_address).or_insert(Amount::zero()).modify(|bid_to_update| {
-            let new_amount = *bid_to_update + amount;
-            *bid_to_update = new_amount;
-            new_amount
-        });
+    let mut bid_to_update = state.bids.entry(sender_address).or_insert(Amount::zero());
+    *bid_to_update += amount;
     // Ensure that the new bid exceeds the highest bid so far
-    ensure!(bid_to_update > state.highest_bid, BidError::BidTooLow);
+    ensure!(*bid_to_update > state.highest_bid, BidError::BidTooLow);
 
-    state.highest_bid = bid_to_update;
+    state.highest_bid = *bid_to_update;
 
     Ok(())
 }


### PR DESCRIPTION
- Update the auction example to use it.

This is not clear-cut since it does have a performance penalty which might be significant.
However it makes for much easier use of nested data structures, without nested closures.

It is unclear whether we want this approach or not since it has a performance penalty, and is additionally really subtle.
In particular it is not entirely clear where rust guarantees that drop will run. I believe it should always run unless there are panics or users make weird loops with circular Rc's or some such. 

## Purpose

Improve ergonomics of map use.

## Changes

As the title states, DerefMut instances were added together with the accompanying `Drop` instances that make sure data is properly stored.