### PR TITLE
proc macro for deriving `Deletable`

### DIFF
--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -2000,19 +2000,10 @@ pub fn deletable_derive(input: TokenStream) -> TokenStream {
     unwrap_or_report(impl_deletable(&ast))
 }
 
-fn impl_deletable_field(
-    field: &syn::Field,
-    ident: &proc_macro2::TokenStream,
-) -> syn::Result<proc_macro2::TokenStream> {
-    let concordium_attributes = get_concordium_attributes(&field.attrs, false)?;
-    let state_parameter = contains_attribute(&concordium_attributes, "state_parameter");
-    if state_parameter {
-        Ok(quote!({
-            #ident.delete();
-        }))
-    } else {
-        Ok(quote!({}))
-    }
+fn impl_deletable_field(ident: &proc_macro2::TokenStream) -> syn::Result<proc_macro2::TokenStream> {
+    Ok(quote!({
+        #ident.delete();
+    }))
 }
 
 fn impl_deletable(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
@@ -2035,7 +2026,7 @@ fn impl_deletable(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
                         .map(|field| {
                             let field_ident = field.ident.clone().unwrap(); // safe since named fields.
                             let field_ident = quote!(self.#field_ident);
-                            impl_deletable_field(field, &field_ident)
+                            impl_deletable_field(&field_ident)
                         })
                         .collect::<syn::Result<_>>()?
                 }
@@ -2043,10 +2034,10 @@ fn impl_deletable(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
                     .fields
                     .iter()
                     .enumerate()
-                    .map(|(i, field)| {
+                    .map(|(i, _)| {
                         let i = syn::LitInt::new(i.to_string().as_str(), Span::call_site());
                         let field_ident = quote!(self.#i);
-                        impl_deletable_field(field, &field_ident)
+                        impl_deletable_field(&field_ident)
                     })
                     .collect::<syn::Result<_>>()?,
                 syn::Fields::Unit => proc_macro2::TokenStream::new(),
@@ -2081,7 +2072,7 @@ fn impl_deletable(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
                 let field_tokens: proc_macro2::TokenStream = field_names
                     .iter()
                     .zip(variant.fields.iter())
-                    .map(|(name, field)| impl_deletable_field(field, &quote!(#name)))
+                    .map(|(name, _)| impl_deletable_field(&quote!(#name)))
                     .collect::<syn::Result<_>>()?;
                 let variant_ident = &variant.ident;
 

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -2008,16 +2008,10 @@ pub fn concordium_cfg_test(_attr: TokenStream, item: TokenStream) -> TokenStream
 ///
 /// # Example
 /// ``` ignore
-/// #[derive(Serial, DeserialWithState)]
-/// #[concordium(state_parameter = "S")]
-/// struct MyState<S> {
-///    my_state_map: StateMap<SomeType, MyNonTrivialStateType<S>, S>,
-/// }
-///
 /// #[derive(Serial, DeserialWithState, Deletable)]
 /// #[concordium(state_parameter = "S")]
-/// struct MyNonTrivialStateType<S> {
-///    my_state_set: StateSet<SomeOtherType, S>,
+/// struct MyState<S> {
+///    my_state_map: StateMap<SomeType, SomeOtherType, S>,
 /// }
 /// ```
 #[proc_macro_derive(Deletable)]

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -1986,12 +1986,14 @@ pub fn concordium_cfg_test(_attr: TokenStream, item: TokenStream) -> TokenStream
     out.into()
 }
 
-/// Derive the `Deletable` trait for a type.
-/// impl<S: HasStateApi> Deletable for Foo<S>
-///      where S: HasStateApi
+/// Derive the `Deletable` trait.
+/// ``` ignore
+/// #[derive(Deletable)]
+/// struct Foo<S: HasStateApi>
 /// {
-///    fn delete(self) { self.bars.delete(); }
+///    bars: StateSet<Baz, S>,
 /// }
+/// ```
 #[proc_macro_derive(Deletable)]
 pub fn deletable_derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input);

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -1986,13 +1986,38 @@ pub fn concordium_cfg_test(_attr: TokenStream, item: TokenStream) -> TokenStream
     out.into()
 }
 
-/// Derive the `Deletable` trait.
+/// Derive the Deletable trait.
+/// See the documentation of
+/// [`derive(Deletable)`](./derive.Deletable.html) for details and limitations.
 ///
+/// The trait should be derived for types which have not implemented the
+/// `Serialize` trait. That is, Deletable should be derived for types with a
+/// non-trivial state.
+/// Non-trivial state here means when you have a type `MyState` which has one or
+/// more fields comprised of
+/// [`StateBox`](../concordium_std/struct.StateBox.html),
+/// [`StateSet`](../concordium_std/struct.StateSet.html), or
+/// [`StateMap`](../concordium_std/struct.StateMap.html).
+///
+/// Please note that it is
+/// necessary to specify the generic parameter name for the
+/// [`HasStateApi`](../concordium_std/trait.HasStateApi.html) generic parameter.
+/// To do so, use the `#[concordium(state_parameter =
+/// "NameOfGenericParameter")]` attribute on the type you are deriving
+/// `Deletable` for.
+///
+/// # Example
 /// ``` ignore
-/// #[derive(Deletable)]
+/// #[derive(Serial, DeserialWithState)]
 /// #[concordium(state_parameter = "S")]
 /// struct MyState<S> {
-///    my_set: StateSet<MyType, S>,
+///    my_state_map: StateMap<SomeType, MyNonTrivialStateType<S>, S>,
+/// }
+///
+/// #[derive(Serial, DeserialWithState, Deletable)]
+/// #[concordium(state_parameter = "S")]
+/// struct MyNonTrivialStateType<S> {
+///    my_state_set: StateSet<SomeOtherType, S>,
 /// }
 /// ```
 #[proc_macro_derive(Deletable)]

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -2035,7 +2035,7 @@ fn impl_deletable(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
                     .fields
                     .iter()
                     .enumerate()
-                    .map(|(i, _)| {
+                    .map(|(i, _field)| {
                         let i = syn::LitInt::new(i.to_string().as_str(), Span::call_site());
                         let field_ident = quote!(self.#i);
                         impl_deletable_field(&field_ident)
@@ -2081,7 +2081,7 @@ fn impl_deletable(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
 
                 matches_tokens.extend(quote! {
                     #data_name::#variant_ident#pattern => {
-                        #idx_lit.delete()?;
+                        #idx_lit.delete();
                         #field_tokens
                     },
                 })

--- a/examples/cis1-multi/src/lib.rs
+++ b/examples/cis1-multi/src/lib.rs
@@ -51,7 +51,7 @@ struct MintParams {
 }
 
 /// The state for each address.
-#[derive(Serial, DeserialWithState)]
+#[derive(Serial, DeserialWithState, Deletable)]
 #[concordium(state_parameter = "S")]
 struct AddressState<S> {
     /// The amount of tokens owned by this address.
@@ -66,13 +66,6 @@ impl<S: HasStateApi> AddressState<S> {
             balances:  state_builder.new_map(),
             operators: state_builder.new_set(),
         }
-    }
-}
-
-impl<S: HasStateApi> Deletable for AddressState<S> {
-    fn delete(self) {
-        self.balances.delete();
-        self.operators.delete();
     }
 }
 

--- a/examples/cis1-nft/src/lib.rs
+++ b/examples/cis1-nft/src/lib.rs
@@ -47,7 +47,7 @@ struct MintParams {
 }
 
 /// The state for each address.
-#[derive(Serial, DeserialWithState)]
+#[derive(Serial, DeserialWithState, Deletable)]
 #[concordium(state_parameter = "S")]
 struct AddressState<S> {
     /// The tokens owned by this address.
@@ -62,13 +62,6 @@ impl<S: HasStateApi> AddressState<S> {
             owned_tokens: state_builder.new_set(),
             operators:    state_builder.new_set(),
         }
-    }
-}
-
-impl<S: HasStateApi> Deletable for AddressState<S> {
-    fn delete(self) {
-        self.owned_tokens.delete();
-        self.operators.delete();
     }
 }
 

--- a/examples/cis1-single-nft/src/lib.rs
+++ b/examples/cis1-single-nft/src/lib.rs
@@ -26,7 +26,7 @@ const TOKEN_ID: ContractTokenId = TokenIdUnit();
 type ContractTokenId = TokenIdUnit;
 
 /// The state for each address.
-#[derive(Serial, DeserialWithState)]
+#[derive(Serial, DeserialWithState, Deletable)]
 #[concordium(state_parameter = "S")]
 struct AddressState<S> {
     /// The address which are currently enabled as operators for this address.
@@ -39,10 +39,6 @@ impl<S: HasStateApi> AddressState<S> {
             operators: state_builder.new_set(),
         }
     }
-}
-
-impl<S: HasStateApi> Deletable for AddressState<S> {
-    fn delete(self) { self.operators.delete(); }
 }
 
 /// The contract state.

--- a/examples/cis1-wccd/src/lib.rs
+++ b/examples/cis1-wccd/src/lib.rs
@@ -42,7 +42,7 @@ const TOKEN_METADATA_URL: &str = "https://some.example/token/wccd";
 type ContractTokenId = TokenIdUnit;
 
 /// The state tracked for each address.
-#[derive(Serial, DeserialWithState)]
+#[derive(Serial, DeserialWithState, Deletable)]
 #[concordium(state_parameter = "S")]
 struct AddressState<S> {
     /// The number of tokens owned by this address.
@@ -50,13 +50,6 @@ struct AddressState<S> {
     /// The address which are currently enabled as operators for this token and
     /// this address.
     operators: StateSet<Address, S>,
-}
-
-impl<S: HasStateApi> Deletable for AddressState<S> {
-    fn delete(self) {
-        self.balance.delete();
-        self.operators.delete();
-    }
 }
 
 /// The contract state,


### PR DESCRIPTION
## Purpose

Allow users to `#[derive(Deletable)]` for `State` types. 

## Changes

Introduced a proc macro for deriving the `Deletable` trait.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

