### PR TITLE
Expose the primitive imports for users who really want this.

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -18,6 +18,7 @@
     - Add new traits for the low-level state interaction: `HasStateApi` and `HasStateEntry`.
   - The Seek trait now works with i32 instead of i64. This is more efficient,
     and sufficient for the target architecture.
+- Expose the module of primitive host functions with an unsafe API.
 
 ## concordium-std 2.0.0 (2022-01-05)
 

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -1,5 +1,16 @@
 //! This module provides the primitive interface to the chain.
 //! Functions here should be wrapped in safer wrappers when used from contracts.
+//! **This module is provided for expert users who wish to optimize their smart
+//! contract to the utmost for space and size, and should not be used by the
+//! majority of users.**
+//!
+//! The functions in this module are inherently unsafe, and if preconditions
+//! that they state are not ensured then strange behaviour will occur. The
+//! behaviour is well-defined on the compiled Wasm by the semantics of the
+//! chain, but it is essentially impossible to predict since it is affected by
+//! memory layout decided by the compiler and the allocator, and other Rust
+//! implementation details. Consequences can range from accidental memory
+//! corruption to program termination.
 
 // Interface to the chain. These functions are assumed to be instantiated by
 // the scheduler with relevant primitives.
@@ -30,7 +41,7 @@ extern "C" {
     ///   - if it is 5 then sending a message to V0 contract failed.
     ///   - if it is 6 then invoking a contract failed with a runtime error
     ///   - no other values are possible
-    pub(crate) fn invoke(tag: u32, start: *const u8, length: u32) -> u64;
+    pub fn invoke(tag: u32, start: *const u8, length: u32) -> u64;
     /// Write to the return value of the contract. The parameters are
     ///
     /// - `start` the pointer to the location in memory where the data resides
@@ -38,50 +49,45 @@ extern "C" {
     /// - `offset` where in the return value to write the data
     ///
     /// The return value indicates how many bytes were written.
-    pub(crate) fn write_output(start: *const u8, length: u32, offset: u32) -> u32;
+    pub fn write_output(start: *const u8, length: u32, offset: u32) -> u32;
     /// Get the size of the `i`-th parameter to the call. 0-th parameter is
     /// always the original parameter that the method was invoked with,
     /// invoking a contract adds additional parameters to the stack. Returns
     /// `-1` if the given parameter does not exist.
-    pub(crate) fn get_parameter_size(i: u32) -> i32;
+    pub fn get_parameter_size(i: u32) -> i32;
     /// Write a section of the `i`-th parameter to the given location. Return
     /// the number of bytes written or `-1` if the parameter does not exist.
     /// The location is assumed to contain enough memory to
     /// write the requested length into.
-    pub(crate) fn get_parameter_section(
-        i: u32,
-        param_bytes: *mut u8,
-        length: u32,
-        offset: u32,
-    ) -> i32;
+    pub fn get_parameter_section(i: u32, param_bytes: *mut u8, length: u32, offset: u32) -> i32;
     /// Write a section of the policy to the given location. Return the number
     /// of bytes written. The location is assumed to contain enough memory to
     /// write the requested length into.
-    pub(crate) fn get_policy_section(policy_bytes: *mut u8, length: u32, offset: u32) -> u32;
+    pub fn get_policy_section(policy_bytes: *mut u8, length: u32, offset: u32) -> u32;
     /// Add a log item. Return values are
     /// - -1 if logging failed due to the message being too long
     /// - 0 if the log is already full
     /// - 1 if data was successfully logged.
-    pub(crate) fn log_event(start: *const u8, length: u32) -> i32;
+    pub fn log_event(start: *const u8, length: u32) -> i32;
 
     /// Lookup an entry with the given key. The return value is either
     /// u64::MAX if the entry at the given key does not exist, or else
     /// the first bit of the result is 0, and the remaining bits
     /// are an entry identifier that may be used in subsequent calls.
-    pub(crate) fn state_lookup_entry(key_start: *const u8, key_length: u32) -> u64;
+    pub fn state_lookup_entry(key_start: *const u8, key_length: u32) -> u64;
 
     /// Create an empty entry with the given key. The return value is either
     /// u64::MAX if creating the entry failed because of an iterator lock on
     /// the part of the tree, or else the first bit is 0, and the remaining
     /// bits are an entry identifier that maybe used in subsequent calls.
     /// If an entry at that key already exists it is set to the empty entry.
-    pub(crate) fn state_create_entry(key_start: *const u8, key_length: u32) -> u64;
+    pub fn state_create_entry(key_start: *const u8, key_length: u32) -> u64;
 
     /// Delete the entry. Returns one of
     /// - 0 if the part of the tree this entry was in is locked
     /// - 1 if the entry did not exist
     /// - 2 if the entry was deleted as a result of this call.
-    pub(crate) fn state_delete_entry(key_start: *const u8, key_length: u32) -> u32;
+    pub fn state_delete_entry(key_start: *const u8, key_length: u32) -> u32;
 
     /// Delete a prefix in the tree, that is, delete all parts of the tree that
     /// have the given key as prefix. Returns
@@ -89,7 +95,7 @@ extern "C" {
     /// - 1 if the tree **was not locked**, but the key points to an empty part
     ///   of the tree
     /// - 2 if a part of the tree was successfully deleted
-    pub(crate) fn state_delete_prefix(key_start: *const u8, key_length: u32) -> u32;
+    pub fn state_delete_prefix(key_start: *const u8, key_length: u32) -> u32;
 
     /// Construct an iterator over a part of the tree. This **locks the part of
     /// the tree that has the given prefix**. Locking means that no
@@ -101,7 +107,7 @@ extern "C" {
     /// - otherwise the first bit is 0, and the remaining bits are the iterator
     ///   identifier
     /// that may be used in subsequent calls to advance it, or to get its key.
-    pub(crate) fn state_iterate_prefix(prefix_start: *const u8, prefix_length: u32) -> u64;
+    pub fn state_iterate_prefix(prefix_start: *const u8, prefix_length: u32) -> u64;
 
     /// Return the next entry along the iterator, and advance the iterator.
     /// The return value is
@@ -113,19 +119,19 @@ extern "C" {
     /// is deleted.
     /// - otherwise the first bit is 0, and the remaining bits encode an entry
     ///   identifier that can be passed to any of the entry methods.
-    pub(crate) fn state_iterator_next(iterator: u64) -> u64;
+    pub fn state_iterator_next(iterator: u64) -> u64;
 
     /// Delete the iterator, unlocking the subtree. Returns
     /// - u64::MAX if the iterator does not exist.
     /// - 0 if the iterator was already deleted
     /// - 1 if the iterator was successfully deleted as a result of this call.
-    pub(crate) fn state_iterator_delete(iterator: u64) -> u32;
+    pub fn state_iterator_delete(iterator: u64) -> u32;
 
     /// Get the size of the key that the iterator is currently pointing at.
     /// Returns
     /// - u32::MAX if the iterator does not exist
     /// - otherwise the length of the key in bytes.
-    pub(crate) fn state_iterator_key_size(iterator: u64) -> u32;
+    pub fn state_iterator_key_size(iterator: u64) -> u32;
 
     /// Read a section of the key the iterator is currently pointing at. Returns
     /// either
@@ -137,12 +143,7 @@ extern "C" {
     /// [state_iterator_next] returns (the encoding of) [None] this method
     /// returns (sections of) the key at the first node returned by the
     /// iterator.
-    pub(crate) fn state_iterator_key_read(
-        iterator: u64,
-        start: *mut u8,
-        length: u32,
-        offset: u32,
-    ) -> u32;
+    pub fn state_iterator_key_read(iterator: u64, start: *mut u8, length: u32, offset: u32) -> u32;
 
     // Operations on the entry.
 
@@ -155,7 +156,7 @@ extern "C" {
     /// - u32::MAX if the entry does not exist (has been invalidated, or never
     /// existed). In this case no data is written.
     /// - amount of data that was read. This is never more than length.
-    pub(crate) fn state_entry_read(entry: u64, start: *mut u8, length: u32, offset: u32) -> u32;
+    pub fn state_entry_read(entry: u64, start: *mut u8, length: u32, offset: u32) -> u32;
 
     /// Write a part of the entry. The arguments are
     /// entry ... entry id returned by state_iterator_next or state_create_entry
@@ -166,48 +167,48 @@ extern "C" {
     /// - u32::MAX if the entry does not exist (has been invalidated, or never
     /// existed). In this case no data is written.
     /// - amount of data that was written. This is never more than length.
-    pub(crate) fn state_entry_write(entry: u64, start: *const u8, length: u32, offset: u32) -> u32;
+    pub fn state_entry_write(entry: u64, start: *const u8, length: u32, offset: u32) -> u32;
 
     /// Return the current size of the entry in bytes.
     /// The return value is either
     /// - u32::MAX if the entry does not exist (has been invalidated, or never
     /// existed). In this case no data is written.
     /// - or the size of the entry.
-    pub(crate) fn state_entry_size(entry: u64) -> u32;
+    pub fn state_entry_size(entry: u64) -> u32;
 
     /// Resize the entry to the given size. Returns
     /// - u32::MAX if the entry has already been invalidated
     /// - 0 if the attempt was unsuccessful because new_size exceeds maximum
     ///   entry size
     /// - 1 if the entry was successfully resized.
-    pub(crate) fn state_entry_resize(entry: u64, new_size: u32) -> u32;
+    pub fn state_entry_resize(entry: u64, new_size: u32) -> u32;
 
     // Getter for the init context.
     /// Address of the sender, 32 bytes
-    pub(crate) fn get_init_origin(start: *mut u8);
+    pub fn get_init_origin(start: *mut u8);
 
     // Getters for the receive context
     /// Invoker of the top-level transaction, AccountAddress.
-    pub(crate) fn get_receive_invoker(start: *mut u8);
+    pub fn get_receive_invoker(start: *mut u8);
     /// Address of the contract itself, ContractAddress.
-    pub(crate) fn get_receive_self_address(start: *mut u8);
+    pub fn get_receive_self_address(start: *mut u8);
     /// Self-balance of the contract, returns the amount
-    pub(crate) fn get_receive_self_balance() -> u64;
+    pub fn get_receive_self_balance() -> u64;
     /// Immediate sender of the message (either contract or account).
-    pub(crate) fn get_receive_sender(start: *mut u8);
+    pub fn get_receive_sender(start: *mut u8);
     /// Owner of the contract, AccountAddress.
-    pub(crate) fn get_receive_owner(start: *mut u8);
+    pub fn get_receive_owner(start: *mut u8);
 
     /// Get the size of the entrypoint that was named.
-    pub(crate) fn get_receive_entrypoint_size() -> u32;
+    pub fn get_receive_entrypoint_size() -> u32;
 
     /// Write the receive entrypoint name into the given location.
     /// It is assumed that the location contains enough space to write the name.
-    pub(crate) fn get_receive_entrypoint(start: *mut u8);
+    pub fn get_receive_entrypoint(start: *mut u8);
 
     // Getters for the chain meta data
     /// Slot time (in milliseconds) from chain meta data
-    pub(crate) fn get_slot_time() -> u64;
+    pub fn get_slot_time() -> u64;
 
     #[cfg(all(feature = "wasm-test", target_arch = "wasm32"))]
     /// Reporting back an error, only exists in debug mode


### PR DESCRIPTION
## Purpose

There have been some requests to expose the primitive imports by users who wish to squeeze out all the performance they can.

## Changes

Make primitive host functions public.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.