### PR TITLE
invoker variable should not be used for authentication in smar…

### DIFF
--- a/examples/proxy/src/lib.rs
+++ b/examples/proxy/src/lib.rs
@@ -83,7 +83,7 @@ fn receive_reconfigure<S: HasStateApi>(
     ctx: &impl HasReceiveContext,
     host: &mut impl HasHost<State, StateApiType = S>,
 ) -> ReceiveResult<()> {
-    claim_eq!(ctx.owner(), ctx.invoker());
+    ensure!(ctx.sender().matches_account(&ctx.owner()));
     *host.state_mut() = ctx.parameter_cursor().get()?;
     Ok(())
 }


### PR DESCRIPTION
## Purpose

`Invoker` variable should not be used for authentication in smart contracts due to phishing attacks.

closes #110 

## Changes

- FIXED: invoker variable should not be used for authentication in smart contracts

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.