### PR TITLE
Use LEB128 schema type for token amounts

### DIFF
--- a/concordium-cis2/src/lib.rs
+++ b/concordium-cis2/src/lib.rs
@@ -104,9 +104,7 @@ pub struct TokenIdVec(#[concordium(size_length = 1)] pub Vec<u8>);
 impl IsTokenId for TokenIdVec {}
 
 impl schema::SchemaType for TokenIdVec {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U8, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U8) }
 }
 
 /// Display the token ID as a uppercase hex string
@@ -199,9 +197,7 @@ pub struct TokenIdU64(pub u64);
 impl IsTokenId for TokenIdU64 {}
 
 impl schema::SchemaType for TokenIdU64 {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U8, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U8) }
 }
 
 impl From<u64> for TokenIdU64 {
@@ -257,9 +253,7 @@ pub struct TokenIdU32(pub u32);
 impl IsTokenId for TokenIdU32 {}
 
 impl schema::SchemaType for TokenIdU32 {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U8, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U8) }
 }
 
 impl From<u32> for TokenIdU32 {
@@ -315,9 +309,7 @@ pub struct TokenIdU16(pub u16);
 impl IsTokenId for TokenIdU16 {}
 
 impl schema::SchemaType for TokenIdU16 {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U8, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U8) }
 }
 
 impl From<u16> for TokenIdU16 {
@@ -373,9 +365,7 @@ pub struct TokenIdU8(pub u8);
 impl IsTokenId for TokenIdU8 {}
 
 impl schema::SchemaType for TokenIdU8 {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U8, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U8) }
 }
 
 impl From<u8> for TokenIdU8 {
@@ -431,9 +421,7 @@ pub struct TokenIdUnit();
 impl IsTokenId for TokenIdUnit {}
 
 impl schema::SchemaType for TokenIdUnit {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U8, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U8) }
 }
 
 /// The `TokenIdUnit` is serialized with one byte with the value 0.

--- a/concordium-cis2/src/lib.rs
+++ b/concordium-cis2/src/lib.rs
@@ -513,8 +513,7 @@ macro_rules! token_amount_wrapper {
         impl IsTokenAmount for $name {}
 
         impl schema::SchemaType for $name {
-            // TODO Fix the schema when supporting LEB128
-            fn get_type() -> schema::Type { schema::Type::Array($size, Box::new(schema::Type::U8)) }
+            fn get_type() -> schema::Type { schema::Type::ULeb128(37) }
         }
 
         impl Serial for $name {


### PR DESCRIPTION
## Purpose

Use the new ULeb128 schema type for token amounts

## Changes

- Use ULeb128 for token amounts in concordium-cis2.
- Use bytelist schema type for token ID.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.