### PR TITLE
Use new schema types for crypto-primitives and CIS-2 lib

### DIFF
--- a/concordium-cis2/src/lib.rs
+++ b/concordium-cis2/src/lib.rs
@@ -498,6 +498,8 @@ macro_rules! token_amount_wrapper {
 
         impl IsTokenAmount for $name {}
 
+        /// Uses the ULeb128 encoding with up to 37 bytes for the encoding as
+        /// according to CIS-2 specification.
         impl schema::SchemaType for $name {
             fn get_type() -> schema::Type { schema::Type::ULeb128(37) }
         }

--- a/concordium-cis2/src/lib.rs
+++ b/concordium-cis2/src/lib.rs
@@ -104,9 +104,7 @@ pub struct TokenIdVec(#[concordium(size_length = 1)] pub Vec<u8>);
 impl IsTokenId for TokenIdVec {}
 
 impl schema::SchemaType for TokenIdVec {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U8, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U8) }
 }
 
 /// Display the token ID as a uppercase hex string
@@ -137,9 +135,7 @@ pub struct TokenIdFixed<const N: usize>(pub [u8; N]);
 impl<const N: usize> IsTokenId for TokenIdFixed<N> {}
 
 impl<const N: usize> schema::SchemaType for TokenIdFixed<N> {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U8, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U8) }
 }
 
 impl<const N: usize> From<[u8; N]> for TokenIdFixed<N> {
@@ -199,9 +195,7 @@ pub struct TokenIdU64(pub u64);
 impl IsTokenId for TokenIdU64 {}
 
 impl schema::SchemaType for TokenIdU64 {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U8, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U8) }
 }
 
 impl From<u64> for TokenIdU64 {
@@ -257,9 +251,7 @@ pub struct TokenIdU32(pub u32);
 impl IsTokenId for TokenIdU32 {}
 
 impl schema::SchemaType for TokenIdU32 {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U8, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U8) }
 }
 
 impl From<u32> for TokenIdU32 {
@@ -315,9 +307,7 @@ pub struct TokenIdU16(pub u16);
 impl IsTokenId for TokenIdU16 {}
 
 impl schema::SchemaType for TokenIdU16 {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U8, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U8) }
 }
 
 impl From<u16> for TokenIdU16 {
@@ -373,9 +363,7 @@ pub struct TokenIdU8(pub u8);
 impl IsTokenId for TokenIdU8 {}
 
 impl schema::SchemaType for TokenIdU8 {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U8, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U8) }
 }
 
 impl From<u8> for TokenIdU8 {
@@ -431,9 +419,7 @@ pub struct TokenIdUnit();
 impl IsTokenId for TokenIdUnit {}
 
 impl schema::SchemaType for TokenIdUnit {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U8, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U8) }
 }
 
 /// The `TokenIdUnit` is serialized with one byte with the value 0.
@@ -455,7 +441,7 @@ impl Deserial for TokenIdUnit {
 }
 
 macro_rules! token_amount_wrapper {
-    ($name:ident, $wrapped:ty, $size:literal) => {
+    ($name:ident, $wrapped:ty) => {
         #[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Default)]
         #[repr(transparent)]
         pub struct $name(pub $wrapped);
@@ -513,8 +499,7 @@ macro_rules! token_amount_wrapper {
         impl IsTokenAmount for $name {}
 
         impl schema::SchemaType for $name {
-            // TODO Fix the schema when supporting LEB128
-            fn get_type() -> schema::Type { schema::Type::Array($size, Box::new(schema::Type::U8)) }
+            fn get_type() -> schema::Type { schema::Type::ULeb128(37) }
         }
 
         impl Serial for $name {
@@ -561,11 +546,11 @@ macro_rules! token_amount_wrapper {
     };
 }
 
-token_amount_wrapper!(TokenAmountU128, u128, 19);
-token_amount_wrapper!(TokenAmountU64, u64, 10);
-token_amount_wrapper!(TokenAmountU32, u32, 5);
-token_amount_wrapper!(TokenAmountU16, u16, 3);
-token_amount_wrapper!(TokenAmountU8, u8, 2);
+token_amount_wrapper!(TokenAmountU128, u128);
+token_amount_wrapper!(TokenAmountU64, u64);
+token_amount_wrapper!(TokenAmountU32, u32);
+token_amount_wrapper!(TokenAmountU16, u16);
+token_amount_wrapper!(TokenAmountU8, u8);
 
 /// An untagged event of a transfer of some amount of tokens from one address to
 /// another. For a tagged version, use `Cis2Event`.
@@ -853,9 +838,7 @@ impl From<AccountAddress> for Receiver {
 pub struct AdditionalData(#[concordium(size_length = 2)] Vec<u8>);
 
 impl schema::SchemaType for AdditionalData {
-    fn get_type() -> schema::Type {
-        schema::Type::List(schema::SizeLength::U16, Box::new(schema::Type::U8))
-    }
+    fn get_type() -> schema::Type { schema::Type::ByteList(schema::SizeLength::U16) }
 }
 
 impl AdditionalData {

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- Change SchemaType implementation for cryptographic primitives to ByteArray.
+- Change SchemaType implementation for cryptographic primitives to ByteArray, meaning the primitives are now supplied as hex strings in JSON.
 
 ## concordium-std 3.0.0 (2022-05-17)
 - Remove support for v0 smart contracts and add support for v1:

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- Change SchemaType implementation for cryptographic primitives to ByteArray, meaning the primitives are now supplied as hex strings in JSON.
+- Change SchemaType implementation for cryptographic primitives to ByteArray, meaning that the primitives(e.g., hashes and signatures) are now supplied as hex strings in JSON.
 
 ## concordium-std 3.0.0 (2022-05-17)
 - Remove support for v0 smart contracts and add support for v1:

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Change SchemaType implementation for cryptographic primitives to ByteArray.
+
 ## concordium-std 3.0.0 (2022-05-17)
 - Remove support for v0 smart contracts and add support for v1:
   - Replace message passing with synchronous calls:

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1,5 +1,4 @@
 use crate::{
-    boxed,
     cell::UnsafeCell,
     collections::{BTreeMap, BTreeSet},
     convert::{self, TryInto},
@@ -2679,9 +2678,7 @@ impl Deserial for PublicKeyEd25519 {
 }
 
 impl schema::SchemaType for PublicKeyEd25519 {
-    fn get_type() -> concordium_contracts_common::schema::Type {
-        schema::Type::Array(32, boxed::Box::new(schema::Type::U8))
-    }
+    fn get_type() -> concordium_contracts_common::schema::Type { schema::Type::ByteArray(32) }
 }
 
 impl Serial for PublicKeyEcdsaSecp256k1 {
@@ -2695,9 +2692,7 @@ impl Deserial for PublicKeyEcdsaSecp256k1 {
 }
 
 impl schema::SchemaType for PublicKeyEcdsaSecp256k1 {
-    fn get_type() -> concordium_contracts_common::schema::Type {
-        schema::Type::Array(33, boxed::Box::new(schema::Type::U8))
-    }
+    fn get_type() -> concordium_contracts_common::schema::Type { schema::Type::ByteArray(33) }
 }
 
 impl Serial for SignatureEd25519 {
@@ -2711,9 +2706,7 @@ impl Deserial for SignatureEd25519 {
 }
 
 impl schema::SchemaType for SignatureEd25519 {
-    fn get_type() -> concordium_contracts_common::schema::Type {
-        schema::Type::Array(64, boxed::Box::new(schema::Type::U8))
-    }
+    fn get_type() -> concordium_contracts_common::schema::Type { schema::Type::ByteArray(64) }
 }
 
 impl Serial for SignatureEcdsaSecp256k1 {
@@ -2727,9 +2720,7 @@ impl Deserial for SignatureEcdsaSecp256k1 {
 }
 
 impl schema::SchemaType for SignatureEcdsaSecp256k1 {
-    fn get_type() -> concordium_contracts_common::schema::Type {
-        schema::Type::Array(64, boxed::Box::new(schema::Type::U8))
-    }
+    fn get_type() -> concordium_contracts_common::schema::Type { schema::Type::ByteArray(64) }
 }
 
 impl Serial for HashSha2256 {
@@ -2743,9 +2734,7 @@ impl Deserial for HashSha2256 {
 }
 
 impl schema::SchemaType for HashSha2256 {
-    fn get_type() -> concordium_contracts_common::schema::Type {
-        schema::Type::Array(32, boxed::Box::new(schema::Type::U8))
-    }
+    fn get_type() -> concordium_contracts_common::schema::Type { schema::Type::ByteArray(32) }
 }
 
 impl Serial for HashSha3256 {
@@ -2759,9 +2748,7 @@ impl Deserial for HashSha3256 {
 }
 
 impl schema::SchemaType for HashSha3256 {
-    fn get_type() -> concordium_contracts_common::schema::Type {
-        schema::Type::Array(32, boxed::Box::new(schema::Type::U8))
-    }
+    fn get_type() -> concordium_contracts_common::schema::Type { schema::Type::ByteArray(32) }
 }
 
 impl Serial for HashKeccak256 {
@@ -2775,7 +2762,5 @@ impl Deserial for HashKeccak256 {
 }
 
 impl schema::SchemaType for HashKeccak256 {
-    fn get_type() -> concordium_contracts_common::schema::Type {
-        schema::Type::Array(32, boxed::Box::new(schema::Type::U8))
-    }
+    fn get_type() -> concordium_contracts_common::schema::Type { schema::Type::ByteArray(32) }
 }


### PR DESCRIPTION
## Purpose

Update types to use the new LEB128 and ByteArray when it makes sense.

## Changes

- CIS2 Token IDs are now ByteLists.
- CIS2 Token amounts are now ULEB128 constraint to 37 bytes.
- Crypto primitives are now ByteArrays.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
