### PR TITLE
fixed swapped around variables in operatorOf function

### DIFF
--- a/examples/cis2-multi/src/lib.rs
+++ b/examples/cis2-multi/src/lib.rs
@@ -546,7 +546,7 @@ fn contract_operator_of<S: HasStateApi>(
     let mut response = Vec::with_capacity(params.queries.len());
     for query in params.queries {
         // Query the state for address being an operator of owner.
-        let is_operator = host.state().is_operator(&query.owner, &query.address);
+        let is_operator = host.state().is_operator(&query.address, &query.owner);
         response.push(is_operator);
     }
     let result = OperatorOfQueryResponse::from(response);

--- a/examples/cis2-nft/src/lib.rs
+++ b/examples/cis2-nft/src/lib.rs
@@ -500,7 +500,7 @@ fn contract_operator_of<S: HasStateApi>(
     let mut response = Vec::with_capacity(params.queries.len());
     for query in params.queries {
         // Query the state for address being an operator of owner.
-        let is_operator = host.state().is_operator(&query.owner, &query.address);
+        let is_operator = host.state().is_operator(&query.address, &query.owner);
         response.push(is_operator);
     }
     let result = OperatorOfQueryResponse::from(response);

--- a/examples/cis2-wccd/src/lib.rs
+++ b/examples/cis2-wccd/src/lib.rs
@@ -577,7 +577,7 @@ fn contract_operator_of<S: HasStateApi>(
     let mut response = Vec::with_capacity(params.queries.len());
     for query in params.queries {
         // Query the state for address being an operator of owner.
-        let is_operator = host.state().is_operator(&query.owner, &query.address);
+        let is_operator = host.state().is_operator(&query.address, &query.owner);
         response.push(is_operator);
     }
     let result = OperatorOfQueryResponse::from(response);


### PR DESCRIPTION
## Purpose
When querying the operator then the `owner` and `address` variables were swapped around. This means that the ‘OperatorOf’ function returned a wrong value. This is fixed now.

closes #135

## Changes

- Fixed cis2-nft, cis2-multi, and cis2-wccd smart contract

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.