### PR TITLE
Add Seek requirement for HasParameter

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 - Change SchemaType implementation for cryptographic primitives to ByteArray, meaning that the primitives(e.g., hashes and signatures) are now supplied as hex strings in JSON.
+- Add `Seek` requirement for `HasParameter`.
+- Implement `Seek` for `ExternParameter`.
 
 ## concordium-std 3.0.0 (2022-05-17)
 - Remove support for v0 smart contracts and add support for v1:

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Change SchemaType implementation for cryptographic primitives to ByteArray, meaning that the primitives(e.g., hashes and signatures) are now supplied as hex strings in JSON.
 - Add `Seek` requirement for `HasParameter`.
 - Implement `Seek` for `ExternParameter`.
+- Add wrapper type `TestParameterCursor` instead of exposing `Cursor` directly, when using `TestContext`. This is changing the type returned by `parameter_cursor` for `TestContext`, but provides the same interface.
 
 ## concordium-std 3.0.0 (2022-05-17)
 - Remove support for v0 smart contracts and add support for v1:

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1548,7 +1548,6 @@ impl HasSize for ExternParameterDataPlaceholder {
 
 impl HasSize for ExternParameter {
     #[inline(always)]
-    // parameter 0 always exists so this is correct
     fn size(&self) -> u32 { self.cursor.data.size() }
 }
 

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -311,16 +311,19 @@ impl<'a> TestParameterCursor<'a> {
 }
 
 impl<'a> AsRef<[u8]> for TestParameterCursor<'a> {
+    #[inline(always)]
     fn as_ref(&self) -> &[u8] { self.cursor.as_ref() }
 }
 
 impl<'a> Seek for TestParameterCursor<'a> {
     type Err = ();
 
+    #[inline(always)]
     fn seek(&mut self, seek: SeekFrom) -> Result<u32, Self::Err> { self.cursor.seek(seek) }
 }
 
 impl<'a> Read for TestParameterCursor<'a> {
+    #[inline(always)]
     fn read(&mut self, buf: &mut [u8]) -> ParseResult<usize> { self.cursor.read(buf) }
 }
 

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -295,6 +295,37 @@ pub struct TestReceiveOnlyData {
     pub(crate) named_entrypoint: Option<OwnedEntrypointName>,
 }
 
+/// Test parameter cursor.
+/// Should not be constructed directly, use [TestReceiveContext] or
+/// [TestInitContext].
+pub struct TestParameterCursor<'a> {
+    cursor: Cursor<&'a [u8]>,
+}
+
+impl<'a> TestParameterCursor<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        TestParameterCursor {
+            cursor: Cursor::new(data),
+        }
+    }
+}
+
+impl<'a> AsRef<[u8]> for TestParameterCursor<'a> {
+    fn as_ref(&self) -> &[u8] { self.cursor.as_ref() }
+}
+
+impl<'a> Seek for TestParameterCursor<'a> {
+    type Err = ();
+
+    fn seek(&mut self, seek: SeekFrom) -> Result<u32, Self::Err> { self.cursor.seek(seek) }
+}
+
+impl<'a> Read for TestParameterCursor<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> ParseResult<usize> { self.cursor.read(buf) }
+}
+
+impl<'a> HasParameter for TestParameterCursor<'a> {}
+
 // Setters for testing-context
 impl TestChainMeta {
     /// Create an `TestChainMeta` where every field is unset, and getting any of
@@ -426,12 +457,12 @@ impl HasPolicy for TestPolicy {
 
 impl<'a, C> HasCommonData for TestContext<'a, C> {
     type MetadataType = TestChainMeta;
-    type ParamType = Cursor<&'a [u8]>;
+    type ParamType = TestParameterCursor<'a>;
     type PolicyIteratorType = crate::vec::IntoIter<TestPolicy>;
     type PolicyType = TestPolicy;
 
     fn parameter_cursor(&self) -> Self::ParamType {
-        Cursor::new(unwrap_ctx_field(self.common.parameter, "parameter"))
+        TestParameterCursor::new(unwrap_ctx_field(self.common.parameter, "parameter"))
     }
 
     fn metadata(&self) -> &Self::MetadataType { &self.common.metadata }
@@ -469,10 +500,6 @@ impl<'a> HasReceiveContext for TestReceiveContext<'a> {
     fn named_entrypoint(&self) -> OwnedEntrypointName {
         unwrap_ctx_field(self.custom.named_entrypoint.clone(), "named_entrypoint")
     }
-}
-
-impl<'a> HasParameter for Cursor<&'a [u8]> {
-    fn size(&self) -> u32 { self.data.len() as u32 }
 }
 
 /// A logger that simply accumulates all the logged items to be inspected at the

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -19,7 +19,7 @@ use concordium_contracts_common::*;
 ///
 /// The reuse of `Read` methods is the reason for the slightly strange choice of
 /// methods of this trait.
-pub trait HasParameter: Read {
+pub trait HasParameter: Read + Seek {
     /// Get the size of the parameter to the method.
     fn size(&self) -> u32;
 }

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -19,10 +19,7 @@ use concordium_contracts_common::*;
 ///
 /// The reuse of `Read` methods is the reason for the slightly strange choice of
 /// methods of this trait.
-pub trait HasParameter: Read + Seek {
-    /// Get the size of the parameter to the method.
-    fn size(&self) -> u32;
-}
+pub trait HasParameter: Read + Seek + HasSize {}
 
 /// Objects which can access call responses from contract invocations.
 ///

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -1,4 +1,6 @@
-use crate::{cell::UnsafeCell, marker::PhantomData, num::NonZeroU32, HasStateApi, Serial, Vec};
+use crate::{
+    cell::UnsafeCell, marker::PhantomData, num::NonZeroU32, Cursor, HasStateApi, Serial, Vec,
+};
 
 #[derive(Debug)]
 /// A high-level map based on the low-level key-value store, which is the
@@ -528,12 +530,16 @@ pub enum Entry<'a, K, V: Serial, S: HasStateApi> {
     Occupied(OccupiedEntry<'a, K, V, S>),
 }
 
-#[derive(Default)]
+/// Zero-sized placeholder for the parameter data, only used internally by
+/// [ExternParameter].
+#[doc(hidden)]
+pub(crate) struct ExternParameterDataPlaceholder {}
+
 /// A type representing the parameter to init and receive methods.
 /// Its trait implementations are backed by host functions.
 #[doc(hidden)]
 pub struct ExternParameter {
-    pub(crate) current_position: u32,
+    pub(crate) cursor: Cursor<ExternParameterDataPlaceholder>,
 }
 
 /// A type representing the return value of contract invocation.


### PR DESCRIPTION
## Purpose

Require `Seek` for `HasParameter`.
Closes #64.
Should be merged after https://github.com/Concordium/concordium-contracts-common/pull/45.

## Changes

- Add `Seek` requirement to the `HasParameter` trait.
- Update `concordium-contracts-common`.
- Implement `Seek` for `ExternParameter`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

