### PR TITLE
Implement CIS0 in CIS2 examples

### DIFF
--- a/concordium-cis2/src/lib.rs
+++ b/concordium-cis2/src/lib.rs
@@ -33,6 +33,18 @@ use std::{fmt, ops};
 
 use convert::TryFrom;
 
+/// The standard identifier for the CIS-0: Standard Detection.
+pub const CIS0_STANDARD_IDENTIFIER: StandardIdentifier<'static> =
+    StandardIdentifier::new_unchecked("CIS-0");
+
+/// The standard identifier for the CIS-1: Concordium Token Standard
+pub const CIS1_STANDARD_IDENTIFIER: StandardIdentifier<'static> =
+    StandardIdentifier::new_unchecked("CIS-1");
+
+/// The standard identifier for the CIS-2: Concordium Token Standard 2
+pub const CIS2_STANDARD_IDENTIFIER: StandardIdentifier<'static> =
+    StandardIdentifier::new_unchecked("CIS-2");
+
 /// Tag for the CIS2 Transfer event.
 pub const TRANSFER_EVENT_TAG: u8 = u8::MAX;
 /// Tag for the CIS2 Mint event.
@@ -1087,7 +1099,7 @@ impl<T: IsTokenId> schema::SchemaType for TokenMetadataQueryParams<T> {
 
 /// The response which is sent back when calling the contract function
 /// `tokenMetadata`.
-/// It consists of the list of queries paired with their corresponding result.
+/// It consists of the list of results corresponding to the list of queries.
 #[derive(Debug, Serialize)]
 pub struct TokenMetadataQueryResponse(#[concordium(size_length = 2)] pub Vec<MetadataUrl>);
 
@@ -1118,6 +1130,150 @@ pub struct OnReceivingCis2Params<T: IsTokenId, A: IsTokenAmount> {
     pub from:     Address,
     /// Some extra information which where sent as part of the transfer.
     pub data:     AdditionalData,
+}
+
+/// Identifier for a smart contract standard.
+#[derive(Debug, Serial, PartialEq, Eq)]
+pub struct StandardIdentifier<'a> {
+    #[concordium(size_length = 1)]
+    id: &'a str,
+}
+
+/// String is invalid as standard identifier. Ensure the length is less than 256
+/// and it only contains ASCII characters.
+#[derive(Default)]
+pub struct InvalidStandardIdentifierError;
+
+impl<'a> StandardIdentifier<'a> {
+    /// Validate and construct a standard identifier.
+    pub fn new(id: &'a str) -> Result<Self, InvalidStandardIdentifierError> {
+        if id.len() > 255 || !id.is_ascii() {
+            Err(InvalidStandardIdentifierError)
+        } else {
+            Ok(Self {
+                id,
+            })
+        }
+    }
+
+    /// Construct a standard identifier without validation.
+    pub const fn new_unchecked(id: &'a str) -> Self {
+        Self {
+            id,
+        }
+    }
+
+    /// Convert to owned standard identifier.
+    pub fn to_owned(&self) -> StandardIdentifierOwned {
+        StandardIdentifierOwned::new_unchecked(self.id.to_string())
+    }
+}
+
+/// Owned identifier for a smart contract standard.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct StandardIdentifierOwned {
+    #[concordium(size_length = 1)]
+    id: String,
+}
+
+impl schema::SchemaType for StandardIdentifierOwned {
+    fn get_type() -> schema::Type { schema::Type::String(schema::SizeLength::U8) }
+}
+
+impl StandardIdentifierOwned {
+    /// Validate and construct a standard identifier.
+    pub fn new(id: String) -> Result<Self, InvalidStandardIdentifierError> {
+        if id.len() > 255 || !id.is_ascii() {
+            Err(InvalidStandardIdentifierError)
+        } else {
+            Ok(Self {
+                id,
+            })
+        }
+    }
+
+    /// Construct a standard identifier without validation.
+    pub fn new_unchecked(id: String) -> Self {
+        Self {
+            id,
+        }
+    }
+
+    /// Convert to standard identifier.
+    pub fn as_standard_identifier(&self) -> StandardIdentifier {
+        StandardIdentifier::new_unchecked(&self.id)
+    }
+}
+
+/// The parameter type for the contract function `supports`.
+#[derive(Debug, Serialize)]
+pub struct SupportsQueryParams {
+    /// The list of support queries.
+    #[concordium(size_length = 2)]
+    pub queries: Vec<StandardIdentifierOwned>,
+}
+
+impl schema::SchemaType for SupportsQueryParams {
+    fn get_type() -> schema::Type {
+        schema::Type::List(schema::SizeLength::U16, Box::new(StandardIdentifierOwned::get_type()))
+    }
+}
+
+/// The query result type for whether a smart contract supports a standard.
+// Note: For the serialization to be derived according to the CIS0
+// specification, the order of the variants and their fields cannot be changed.
+#[derive(Debug, Serialize)]
+pub enum SupportResult {
+    /// The standard is not supported.
+    NoSupport,
+    /// The standard is supported by the current contract address.
+    Support,
+    /// The standard is supported by using another contract address.
+    SupportBy(#[concordium(size_length = 1)] Vec<ContractAddress>),
+}
+
+impl schema::SchemaType for SupportResult {
+    fn get_type() -> schema::Type {
+        schema::Type::Enum(vec![
+            ("NoSupport".to_string(), schema::Fields::None),
+            ("Support".to_string(), schema::Fields::None),
+            (
+                "SupportBy".to_string(),
+                schema::Fields::Unnamed(vec![schema::Type::List(
+                    schema::SizeLength::U8,
+                    Box::new(ContractAddress::get_type()),
+                )]),
+            ),
+        ])
+    }
+}
+
+/// The response which is sent back when calling the contract function
+/// `supports`. It consists of a list of results corresponding to the list of
+/// queries.
+#[derive(Debug, Serialize)]
+pub struct SupportsQueryResponse {
+    /// List of support results corresponding to the list of queries.
+    #[concordium(size_length = 2)]
+    pub results: Vec<SupportResult>,
+}
+
+impl schema::SchemaType for SupportsQueryResponse {
+    fn get_type() -> schema::Type {
+        schema::Type::List(schema::SizeLength::U16, Box::new(SupportResult::get_type()))
+    }
+}
+
+impl From<Vec<SupportResult>> for SupportsQueryResponse {
+    fn from(results: Vec<SupportResult>) -> Self {
+        SupportsQueryResponse {
+            results,
+        }
+    }
+}
+
+impl AsRef<[SupportResult]> for SupportsQueryResponse {
+    fn as_ref(&self) -> &[SupportResult] { &self.results }
 }
 
 #[cfg(test)]

--- a/examples/cis2-multi/src/lib.rs
+++ b/examples/cis2-multi/src/lib.rs
@@ -33,6 +33,10 @@ use concordium_std::*;
 /// encoding before emitted in the TokenMetadata event.
 const TOKEN_METADATA_BASE_URL: &str = "https://some.example/token/";
 
+/// List of supported standards by this contract address.
+const SUPPORTS_STANDARDS: [StandardIdentifier<'static>; 2] =
+    [CIS0_STANDARD_IDENTIFIER, CIS2_STANDARD_IDENTIFIER];
+
 // Types
 
 /// Contract token ID type.
@@ -51,6 +55,17 @@ struct MintParams {
     owner:  Address,
     /// A collection of tokens to mint.
     tokens: collections::BTreeMap<ContractTokenId, ContractTokenAmount>,
+}
+
+/// The paramter type for the contract function `setImplementors`.
+/// Takes a standard identifier and list of contract addresses providing
+/// implementations of this standard.
+#[derive(Debug, Serialize, SchemaType)]
+struct SetImplementorsParams {
+    /// The identifier for the standard.
+    id:           StandardIdentifierOwned,
+    /// The addresses of the implementors of the standard.
+    implementors: Vec<ContractAddress>,
 }
 
 /// The state for each address.
@@ -80,9 +95,12 @@ impl<S: HasStateApi> AddressState<S> {
 #[concordium(state_parameter = "S")]
 struct State<S> {
     /// The state of addresses.
-    state:  StateMap<Address, AddressState<S>, S>,
+    state:        StateMap<Address, AddressState<S>, S>,
     /// All of the token IDs
-    tokens: StateSet<ContractTokenId, S>,
+    tokens:       StateSet<ContractTokenId, S>,
+    /// Map with contract addresses providing implementations of additional
+    /// standards.
+    implementors: StateMap<StandardIdentifierOwned, Vec<ContractAddress>, S>,
 }
 
 /// The different errors the contract can produce.
@@ -139,8 +157,9 @@ impl<S: HasStateApi> State<S> {
     /// Construct a state with no tokens
     fn empty(state_builder: &mut StateBuilder<S>) -> Self {
         State {
-            state:  state_builder.new_map(),
-            tokens: state_builder.new_set(),
+            state:        state_builder.new_map(),
+            tokens:       state_builder.new_set(),
+            implementors: state_builder.new_map(),
         }
     }
 
@@ -244,6 +263,24 @@ impl<S: HasStateApi> State<S> {
         self.state.entry(*owner).and_modify(|address_state| {
             address_state.operators.remove(operator);
         });
+    }
+
+    /// Check if state contains any implementors for a given standard.
+    fn have_implementors(&self, std_id: &StandardIdentifierOwned) -> SupportResult {
+        if let Some(addresses) = self.implementors.get(std_id) {
+            SupportResult::SupportBy(addresses.to_vec())
+        } else {
+            SupportResult::NoSupport
+        }
+    }
+
+    /// Set implementors for a given standard.
+    fn set_implementors(
+        &mut self,
+        std_id: StandardIdentifierOwned,
+        implementors: Vec<ContractAddress>,
+    ) {
+        self.implementors.insert(std_id, implementors);
     }
 }
 
@@ -644,6 +681,62 @@ fn contract_on_cis2_received<S: HasStateApi>(
         EntrypointName::new("transfer")?,
         Amount::zero(),
     )?;
+    Ok(())
+}
+
+/// Get the supported standards or addresses for a implementation given list of
+/// standard identifiers.
+///
+/// It rejects if:
+/// - It fails to parse the parameter.
+#[receive(
+    contract = "CIS2-Multi",
+    name = "supports",
+    parameter = "SupportsQueryParams",
+    return_value = "SupportsQueryResponse"
+)]
+fn contract_supports<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &impl HasHost<State<S>, StateApiType = S>,
+) -> ContractResult<SupportsQueryResponse> {
+    // Parse the parameter.
+    let params: SupportsQueryParams = ctx.parameter_cursor().get()?;
+
+    // Build the response.
+    let mut response = Vec::with_capacity(params.queries.len());
+    for std_id in params.queries {
+        if SUPPORTS_STANDARDS.contains(&std_id.as_standard_identifier()) {
+            response.push(SupportResult::Support);
+        } else {
+            response.push(host.state().have_implementors(&std_id));
+        }
+    }
+    let result = SupportsQueryResponse::from(response);
+    Ok(result)
+}
+
+/// Set the addresses for an implementation given a standard identifier and a
+/// list of contract addresses.
+///
+/// It rejects if:
+/// - Sender is not the owner of the contract instance.
+/// - It fails to parse the parameter.
+#[receive(
+    contract = "CIS2-Multi",
+    name = "setImplementors",
+    parameter = "SetImplementorsParams",
+    mutable
+)]
+fn contract_set_implementor<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &mut impl HasHost<State<S>, StateApiType = S>,
+) -> ContractResult<()> {
+    // Authorize the sender.
+    ensure!(ctx.sender().matches_account(&ctx.owner()), ContractError::Unauthorized);
+    // Parse the parameter.
+    let params: SetImplementorsParams = ctx.parameter_cursor().get()?;
+    // Update the implementors in the state
+    host.state_mut().set_implementors(params.id, params.implementors);
     Ok(())
 }
 

--- a/examples/cis2-wccd/src/lib.rs
+++ b/examples/cis2-wccd/src/lib.rs
@@ -33,6 +33,10 @@ const TOKEN_ID_WCCD: ContractTokenId = TokenIdUnit();
 /// The metadata url for the wCCD token.
 const TOKEN_METADATA_URL: &str = "https://some.example/token/wccd";
 
+/// List of supported standards by this contract address.
+const SUPPORTS_STANDARDS: [StandardIdentifier<'static>; 2] =
+    [CIS0_STANDARD_IDENTIFIER, CIS2_STANDARD_IDENTIFIER];
+
 // Types
 
 /// Contract token ID type.
@@ -62,7 +66,10 @@ struct AddressState<S> {
 #[concordium(state_parameter = "S")]
 struct State<S> {
     /// The state the one token.
-    token: StateMap<Address, AddressState<S>, S>,
+    token:        StateMap<Address, AddressState<S>, S>,
+    /// Map with contract addresses providing implementations of additional
+    /// standards.
+    implementors: StateMap<StandardIdentifierOwned, Vec<ContractAddress>, S>,
 }
 
 /// The parameter type for the contract function `unwrap`.
@@ -90,6 +97,17 @@ struct WrapParams {
     to:   Receiver,
     /// Some additional bytes to include in a transfer.
     data: AdditionalData,
+}
+
+/// The paramter type for the contract function `setImplementors`.
+/// Takes a standard identifier and list of contract addresses providing
+/// implementations of this standard.
+#[derive(Debug, Serialize, SchemaType)]
+struct SetImplementorsParams {
+    /// The identifier for the standard.
+    id:           StandardIdentifierOwned,
+    /// The addresses of the implementors of the standard.
+    implementors: Vec<ContractAddress>,
 }
 
 /// The different errors the contract can produce.
@@ -141,7 +159,8 @@ impl<S: HasStateApi> State<S> {
     /// Creates a new state with no one owning any tokens by default.
     fn new(state_builder: &mut StateBuilder<S>) -> Self {
         State {
-            token: state_builder.new_map(),
+            token:        state_builder.new_map(),
+            implementors: state_builder.new_map(),
         }
     }
 
@@ -255,6 +274,24 @@ impl<S: HasStateApi> State<S> {
         from_state.balance -= amount;
 
         Ok(())
+    }
+
+    /// Check if state contains any implementors for a given standard.
+    fn have_implementors(&self, std_id: &StandardIdentifierOwned) -> SupportResult {
+        if let Some(addresses) = self.implementors.get(std_id) {
+            SupportResult::SupportBy(addresses.to_vec())
+        } else {
+            SupportResult::NoSupport
+        }
+    }
+
+    /// Set implementors for a given standard.
+    fn set_implementors(
+        &mut self,
+        std_id: StandardIdentifierOwned,
+        implementors: Vec<ContractAddress>,
+    ) {
+        self.implementors.insert(std_id, implementors);
     }
 }
 
@@ -622,6 +659,62 @@ fn contract_token_metadata<S: HasStateApi>(
     }
     let result = TokenMetadataQueryResponse::from(response);
     Ok(result)
+}
+
+/// Get the supported standards or addresses for a implementation given list of
+/// standard identifiers.
+///
+/// It rejects if:
+/// - It fails to parse the parameter.
+#[receive(
+    contract = "CIS2-wCCD",
+    name = "supports",
+    parameter = "SupportsQueryParams",
+    return_value = "SupportsQueryResponse"
+)]
+fn contract_supports<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &impl HasHost<State<S>, StateApiType = S>,
+) -> ContractResult<SupportsQueryResponse> {
+    // Parse the parameter.
+    let params: SupportsQueryParams = ctx.parameter_cursor().get()?;
+
+    // Build the response.
+    let mut response = Vec::with_capacity(params.queries.len());
+    for std_id in params.queries {
+        if SUPPORTS_STANDARDS.contains(&std_id.as_standard_identifier()) {
+            response.push(SupportResult::Support);
+        } else {
+            response.push(host.state().have_implementors(&std_id));
+        }
+    }
+    let result = SupportsQueryResponse::from(response);
+    Ok(result)
+}
+
+/// Set the addresses for an implementation given a standard identifier and a
+/// list of contract addresses.
+///
+/// It rejects if:
+/// - Sender is not the owner of the contract instance.
+/// - It fails to parse the parameter.
+#[receive(
+    contract = "CIS2-wCCD",
+    name = "setImplementors",
+    parameter = "SetImplementorsParams",
+    mutable
+)]
+fn contract_set_implementor<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &mut impl HasHost<State<S>, StateApiType = S>,
+) -> ContractResult<()> {
+    // Authorize the sender.
+    ensure!(ctx.sender().matches_account(&ctx.owner()), ContractError::Unauthorized);
+    // Parse the parameter.
+    let params: SetImplementorsParams = ctx.parameter_cursor().get()?;
+    // Update the implementors in the state
+    host.state_mut().set_implementors(params.id, params.implementors);
+    Ok(())
 }
 
 // Tests


### PR DESCRIPTION
## Purpose

Implement CIS-0 in CIS-2 smart contract examples.
Closes #138.

## Changes

- Add CIS0 types in `concordium-cis2` crate.
- Implement CIS0 in the CIS2 examples.
  - Add `supports` endpoint from CIS0.
  - Only authorize the smart contract instance to add standard implementors.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

