### PR TITLE
fix balance in auction example

### DIFF
--- a/examples/auction/src/lib.rs
+++ b/examples/auction/src/lib.rs
@@ -158,9 +158,10 @@ fn view<'a, 'b, S: HasStateApi>(
     Ok(host.state())
 }
 
-/// ViewBalance function that returns the balance of the contract
-#[receive(contract = "auction", name = "viewBalance", return_value = "Amount")]
-fn view_balance<S: HasStateApi>(
+/// ViewHighestBid function that returns the highest bid which is the balance of
+/// the contract
+#[receive(contract = "auction", name = "viewHighestBid", return_value = "Amount")]
+fn view_highest_bid<S: HasStateApi>(
     _ctx: &impl HasReceiveContext,
     host: &impl HasHost<State, StateApiType = S>,
 ) -> ReceiveResult<Amount> {


### PR DESCRIPTION
## Purpose

The auction example was written by setting the self_balance in the TestHost to the smart contract balance instead of the smart contract + amount balance as described [here](https://docs.rs/concordium-std/latest/concordium_std/test_infrastructure/struct.TestHost.html#method.set_self_balance)

As a result, also the balance logic in the smart contract was written assuming that self_balance does not account for the amount which is a wrong assumption as can be seen [here](https://docs.rs/concordium-std/latest/concordium_std/trait.HasHost.html#tymethod.self_balance)

## Changes
- setting the self_balance in the TestHost to the smart contract + amount balance

 - updating balance logic in smart contract

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
