### PR TITLE
template improvements

### DIFF
--- a/templates/cis2-nft/cargo-generate.toml
+++ b/templates/cis2-nft/cargo-generate.toml
@@ -2,5 +2,5 @@
 cargo_generate_version = "0.16.0"
 
 [placeholders]
-description = { type="string", prompt="Description for the crate?" }
+description = { type="string", prompt="Description for the project?" }
 tokenMetadataBaseURL= { type="string", prompt="Token metadata base URL of the token?", default='https://some.example/token/' }

--- a/templates/default/cargo-generate.toml
+++ b/templates/default/cargo-generate.toml
@@ -2,4 +2,4 @@
 cargo_generate_version = "0.16.0"
 
 [placeholders]
-description = { type="string", prompt="Description for the crate?" }
+description = { type="string", prompt="Description for the project?" }


### PR DESCRIPTION
## Purpose
closes #172 

Rename `crate` to `project` because people who are new to Rust might not know what a `crate` is.
