### PR TITLE
Support the `upgrade` host function

### DIFF
--- a/concordium-cis2/CHANGELOG.md
+++ b/concordium-cis2/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Add `From` implementation from types implementing `From<UpgradeError>` to `Cis2Error`.
+
 ## concordium-cis2 1.2.0 (2022-09-01)
 
 - Add `TokenAmountU256`

--- a/concordium-cis2/src/lib.rs
+++ b/concordium-cis2/src/lib.rs
@@ -960,6 +960,15 @@ where
     fn from(err: TransferError) -> Self { Cis2Error::Custom(X::from(err)) }
 }
 
+impl<X> From<UpgradeError> for Cis2Error<X>
+where
+    X: From<UpgradeError>,
+{
+    #[inline]
+    /// Converts the error by wrapping it in [Self::Custom].
+    fn from(err: UpgradeError) -> Self { Cis2Error::Custom(X::from(err)) }
+}
+
 impl<X> From<NewReceiveNameError> for Cis2Error<X>
 where
     X: From<NewReceiveNameError>,

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Add `upgrade` host function for upgrading a smart contract instance to use a new smart contract module.
+- Support mocking `upgrade` calls in `TestHost`. An `upgrade` is mocked by specifying a module reference and a `UpgradeResult` as the outcome of upgrading to this module.
+
 ## concordium-std 4.0.0 (2022-08-24)
 
 - Add rollback functionality to the `TestHost`.

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Add `upgrade` host function for upgrading a smart contract instance to use a new smart contract module.
+- Add `upgrade` method to `HasHost` for upgrading a smart contract instance to use a new smart contract module.
 - Support mocking `upgrade` calls in `TestHost`. An `upgrade` is mocked by specifying a module reference and a `UpgradeResult` as the outcome of upgrading to this module.
 
 ## concordium-std 4.0.0 (2022-08-24)

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1822,16 +1822,17 @@ fn parse_transfer_response_code(code: u64) -> TransferResult {
 ///
 /// The response is encoded as follows.
 /// - success is encoded as 0.
-/// - failed because of missing module is 1.
-/// - failed because of module is missing contract with the same name is 2.
-/// - failed because of module being an unsupported version is 3.
+/// - failed because of missing module is 0x07_0000_0000.
+/// - failed because of module is missing contract with the same name is
+///   0x08_0000_0000.
+/// - failed because of module being an unsupported version is 0x09_0000_0000.
 #[inline(always)]
 fn parse_upgrade_response_code(code: u64) -> UpgradeResult {
     match code {
         0 => Ok(()),
-        1 => Err(UpgradeError::MissingModule),
-        2 => Err(UpgradeError::MissingContract),
-        3 => Err(UpgradeError::UnsupportedModuleVersion),
+        0x07_0000_0000 => Err(UpgradeError::MissingModule),
+        0x08_0000_0000 => Err(UpgradeError::MissingContract),
+        0x09_0000_0000 => Err(UpgradeError::UnsupportedModuleVersion),
         _ => crate::trap(),
     }
 }

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1818,14 +1818,14 @@ fn parse_transfer_response_code(code: u64) -> TransferResult {
     }
 }
 
-/// Decode the the response code.
+/// Decode the response code from calling upgrade.
 ///
 /// The response is encoded as follows.
 /// - success is encoded as 0.
-/// - failed because of missing module is 0x07_0000_0000.
-/// - failed because of module is missing contract with the same name is
+/// - failure because of missing module is 0x07_0000_0000.
+/// - failure because of module is missing contract with the same name is
 ///   0x08_0000_0000.
-/// - failed because of module being an unsupported version is 0x09_0000_0000.
+/// - failure because of module being an unsupported version is 0x09_0000_0000.
 #[inline(always)]
 fn parse_upgrade_response_code(code: u64) -> UpgradeResult {
     match code {

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -144,6 +144,26 @@ impl<T> From<CallContractError<T>> for Reject {
     }
 }
 
+/// MissingModule is i32::MIN + 22,
+/// MissingContract is i32::MIN + 23,
+/// UnsupportedModuleVersion is i32::MIN + 24.
+impl From<UpgradeError> for Reject {
+    #[inline(always)]
+    fn from(te: UpgradeError) -> Self {
+        match te {
+            UpgradeError::MissingModule => unsafe {
+                crate::num::NonZeroI32::new_unchecked(i32::MIN + 22).into()
+            },
+            UpgradeError::MissingContract => unsafe {
+                crate::num::NonZeroI32::new_unchecked(i32::MIN + 23).into()
+            },
+            UpgradeError::UnsupportedModuleVersion => unsafe {
+                crate::num::NonZeroI32::new_unchecked(i32::MIN + 24).into()
+            },
+        }
+    }
+}
+
 /// Return values are intended to be produced by writing to the
 /// [ExternReturnValue] buffer, either in a high-level interface via
 /// serialization, or in a low-level interface by manually using the [Write]

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -174,6 +174,9 @@
 //! | [NotPayableError] | `-2147483636` |
 //! | [TransferError::AmountTooLarge] | `-2147483635` |
 //! | [TransferError::MissingAccount] | `-2147483634` |
+//! | [UpgradeError::MissingModule] | `-2147483633` |
+//! | [UpgradeError::MissingContract] | `-2147483632` |
+//! | [UpgradeError::UnsupportedModuleVersion] | `-2147483631` |
 //! | [CallContractError::AmountTooLarge] | `-2147483633` |
 //! | [CallContractError::MissingAccount] | `-2147483632` |
 //! | [CallContractError::MissingContract] | `-2147483631` |

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -174,9 +174,9 @@
 //! | [NotPayableError] | `-2147483636` |
 //! | [TransferError::AmountTooLarge] | `-2147483635` |
 //! | [TransferError::MissingAccount] | `-2147483634` |
-//! | [UpgradeError::MissingModule] | `-2147483633` |
-//! | [UpgradeError::MissingContract] | `-2147483632` |
-//! | [UpgradeError::UnsupportedModuleVersion] | `-2147483631` |
+//! | [UpgradeError::MissingModule] | `-2147483626` |
+//! | [UpgradeError::MissingContract] | `-2147483625` |
+//! | [UpgradeError::UnsupportedModuleVersion] | `-2147483624` |
 //! | [CallContractError::AmountTooLarge] | `-2147483633` |
 //! | [CallContractError::MissingAccount] | `-2147483632` |
 //! | [CallContractError::MissingContract] | `-2147483631` |

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -59,7 +59,7 @@ extern "C" {
     ///   found.
     /// - `0x08_0000_0000` means the upgrade failed: The new module did not
     ///   contain a contract with the same name.
-    /// - `0x09_0000_0000` means the upgrade failed: The new module is a
+    /// - `0x09_0000_0000` means the upgrade failed: The new module is an
     ///   unsupported smart contract module version.
     pub fn upgrade(module_ref: *const u8) -> u64;
     /// Get the size of the `i`-th parameter to the call. 0-th parameter is

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -50,6 +50,17 @@ extern "C" {
     ///
     /// The return value indicates how many bytes were written.
     pub fn write_output(start: *const u8, length: u32, offset: u32) -> u32;
+    /// Upgrade the smart contract module to a provided module.
+    /// The only argument is a pointer to 32 bytes for the module reference to
+    /// become the new smart contract module of this instance.
+    /// A return value of:
+    /// - `0` means the upgrade succeeded.
+    /// - `1` means the upgrade failed: The provided module was not found.
+    /// - `2` means the upgrade failed: The new module did not contain a
+    ///   contract with the same name.
+    /// - `3` means the upgrade failed: The new module is a unsupported smart
+    ///   contract module version.
+    pub fn upgrade(module_ref: *const u8) -> u64;
     /// Get the size of the `i`-th parameter to the call. 0-th parameter is
     /// always the original parameter that the method was invoked with,
     /// invoking a contract adds additional parameters to the stack. Returns

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -55,11 +55,12 @@ extern "C" {
     /// become the new smart contract module of this instance.
     /// A return value of:
     /// - `0` means the upgrade succeeded.
-    /// - `1` means the upgrade failed: The provided module was not found.
-    /// - `2` means the upgrade failed: The new module did not contain a
-    ///   contract with the same name.
-    /// - `3` means the upgrade failed: The new module is a unsupported smart
-    ///   contract module version.
+    /// - `0x07_0000_0000` means the upgrade failed: The provided module was not
+    ///   found.
+    /// - `0x08_0000_0000` means the upgrade failed: The new module did not
+    ///   contain a contract with the same name.
+    /// - `0x09_0000_0000` means the upgrade failed: The new module is a
+    ///   unsupported smart contract module version.
     pub fn upgrade(module_ref: *const u8) -> u64;
     /// Get the size of the `i`-th parameter to the call. 0-th parameter is
     /// always the original parameter that the method was invoked with,

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -1270,7 +1270,7 @@ impl<State> MockFn<State> {
 /// A map from contract address and entrypoints to mocking functions.
 type MockFnMap<State> = BTreeMap<(ContractAddress, OwnedEntrypointName), MockFn<State>>;
 
-/// A map from module references to the result to mock.
+/// A map from module references to the mocked result.
 type MockUpgradeMap = BTreeMap<ModuleReference, UpgradeResult>;
 
 /// A [`Host`](HasHost) implementation used for unit testing smart contracts.
@@ -1293,8 +1293,8 @@ pub struct TestHost<State> {
     /// The contract balance. This is updated during execution based on contract
     /// invocations, e.g., a successful transfer from the contract decreases it.
     contract_balance: RefCell<Amount>,
-    /// Map from module reference to the results to mock for upgrading to this
-    /// perticular module.
+    /// Map from module references to the mocked results of upgrading to this
+    /// particular module.
     mocking_upgrades: RefCell<MockUpgradeMap>,
     /// StateBuilder for the state.
     state_builder:    StateBuilder<TestStateApi>,
@@ -1468,7 +1468,7 @@ impl<State: Serial + DeserialWithState<TestStateApi> + StateClone<TestStateApi>>
             result.to_owned()
         } else {
             fail!(
-                "Mocking has not been set up for upgrading to this perticular module reference: \
+                "Mocking has not been set up for upgrading to this particular module reference: \
                  {:?}",
                 module
             )
@@ -1547,7 +1547,7 @@ impl<State: Serial + DeserialWithState<TestStateApi>> TestHost<State> {
         self.mocking_fns.borrow_mut().insert((to, method), handler);
     }
 
-    /// Set up a mock for upgrading to a perticular module.
+    /// Set up a mock for upgrading to a particular module.
     ///
     /// If multiple mocks are setup for the same module, the latest will be
     /// used.

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -287,7 +287,7 @@ pub trait HasHost<State>: Sized {
     ///
     /// This will fail if:
     /// - The supplied module is not deployed.
-    /// - The supplied module is does not contain a smart contract with a name
+    /// - The supplied module does not contain a smart contract with a name
     ///   matching this instance.
     /// - The supplied module is a version 0 smart contract module.
     fn upgrade(&mut self, module: ModuleReference) -> UpgradeResult;

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -281,6 +281,9 @@ pub trait HasHost<State>: Sized {
 
     /// Upgrade the module for this instance to a given module. The new module
     /// must contain a smart contract with a matching name.
+    /// Invocations of this instance after the point of a successful upgrade,
+    /// will use the new smart contract module. The remaining code after a
+    /// successful upgrade in the same invokation is executed as normal.
     ///
     /// This will fail if:
     /// - The supplied module is not deployed.

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -8,7 +8,7 @@ use crate::{
     types::{LogError, StateError},
     CallContractResult, EntryRaw, HashKeccak256, HashSha2256, HashSha3256, Key, OccupiedEntryRaw,
     PublicKeyEcdsaSecp256k1, PublicKeyEd25519, ReadOnlyCallContractResult, SignatureEcdsaSecp256k1,
-    SignatureEd25519, StateBuilder, TransferResult, VacantEntryRaw,
+    SignatureEd25519, StateBuilder, TransferResult, UpgradeResult, VacantEntryRaw,
 };
 use concordium_contracts_common::*;
 
@@ -278,6 +278,16 @@ pub trait HasHost<State>: Sized {
         let param = to_bytes(parameter);
         self.invoke_contract_raw(to, Parameter(&param), method, amount)
     }
+
+    /// Upgrade the module for this instance to a given module. The new module
+    /// must contain a smart contract with a matching name.
+    ///
+    /// This will fail if:
+    /// - The supplied module is not deployed.
+    /// - The supplied module is does not contain a smart contract with a name
+    ///   matching this instance.
+    /// - The supplied module is a version 0 smart contract module.
+    fn upgrade(&mut self, module: ModuleReference) -> UpgradeResult;
 
     /// Invoke a given method of a contract with the amount and parameter
     /// provided. If invocation succeeds **and the state of the contract

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -617,6 +617,18 @@ pub enum TransferError {
     MissingAccount,
 }
 
+#[repr(i32)]
+#[derive(Debug, Clone)]
+/// Errors that may occur when upgrading the smart contract module.
+pub enum UpgradeError {
+    /// Provided module does not exist.
+    MissingModule,
+    /// Provided module does not contain a smart contract with a matching name.
+    MissingContract,
+    /// Provided module is a version 0 smart contract module.
+    UnsupportedModuleVersion,
+}
+
 /// A wrapper around [Result] that fixes the error variant to
 /// [CallContractError], and the result to `(bool, Option<A>)`.
 /// If the result is `Ok` then the boolean indicates whether the state was
@@ -633,6 +645,10 @@ pub type ReadOnlyCallContractResult<A> = Result<Option<A>, CallContractError<A>>
 /// A wrapper around [Result] that fixes the error variant to [TransferError]
 /// and result to [()](https://doc.rust-lang.org/std/primitive.unit.html).
 pub type TransferResult = Result<(), TransferError>;
+
+/// A wrapper around [Result] that fixes the error variant to [UpgradeError]
+/// and result to [()](https://doc.rust-lang.org/std/primitive.unit.html).
+pub type UpgradeResult = Result<(), UpgradeError>;
 
 /// A type representing the attributes, lazily acquired from the host.
 #[derive(Clone, Copy, Default)]

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -629,24 +629,24 @@ pub enum UpgradeError {
     UnsupportedModuleVersion,
 }
 
-/// A wrapper around [Result] that fixes the error variant to
-/// [CallContractError], and the result to `(bool, Option<A>)`.
+/// A wrapper around [`Result`] that fixes the error variant to
+/// [`CallContractError`], and the result to `(bool, Option<A>)`.
 /// If the result is `Ok` then the boolean indicates whether the state was
 /// modified or not, and the second item is the actual return value, which is
 /// present (i.e., [`Some`]) if and only if a `V1` contract was invoked.
 pub type CallContractResult<A> = Result<(bool, Option<A>), CallContractError<A>>;
 
-/// A wrapper around [Result] that fixes the error variant to
-/// [CallContractError], and the result to [`Option<A>`](Option)
+/// A wrapper around [`Result`] that fixes the error variant to
+/// [`CallContractError`], and the result to [`Option<A>`](Option)
 /// If the result is `Ok` then the value is [`None`] if a `V0` contract was
 /// invoked, and a return value returned by a `V1` contract otherwise.
 pub type ReadOnlyCallContractResult<A> = Result<Option<A>, CallContractError<A>>;
 
-/// A wrapper around [Result] that fixes the error variant to [TransferError]
-/// and result to [()](https://doc.rust-lang.org/std/primitive.unit.html).
+/// A wrapper around [`Result`] that fixes the error variant to
+/// [`TransferError`] and result to [()](https://doc.rust-lang.org/std/primitive.unit.html).
 pub type TransferResult = Result<(), TransferError>;
 
-/// A wrapper around [Result] that fixes the error variant to [UpgradeError]
+/// A wrapper around [`Result`] that fixes the error variant to [`UpgradeError`]
 /// and result to [()](https://doc.rust-lang.org/std/primitive.unit.html).
 pub type UpgradeResult = Result<(), UpgradeError>;
 

--- a/examples/cis2-wccd/src/lib.rs
+++ b/examples/cis2-wccd/src/lib.rs
@@ -1146,12 +1146,10 @@ mod tests {
         let mut state_builder = TestStateBuilder::new();
         let state = initial_state(&mut state_builder);
         let mut host = TestHost::new(state, state_builder);
-        // Make ACCOUNT_1 missing such that transfers to it will fail.
 
         host.setup_mock_upgrade(new_module_ref, Err(UpgradeError::MissingModule));
 
-        // Call the contract function. Note the use of `with_rollback`.
-        let result: ContractResult<()> = host.with_rollback(|host| contract_upgrade(&ctx, host));
+        let result: ContractResult<()> = contract_upgrade(&ctx, &mut host);
 
         claim_eq!(
             result,

--- a/examples/cis2-wccd/src/lib.rs
+++ b/examples/cis2-wccd/src/lib.rs
@@ -110,6 +110,17 @@ struct SetImplementorsParams {
     implementors: Vec<ContractAddress>,
 }
 
+/// The parameter type for the contract function `upgrade`.
+/// Takes the new module and optionally a migration function to call in the new
+/// module after the upgrade.
+#[derive(Debug, Serialize, SchemaType)]
+struct UpgradeParams {
+    /// The new module reference.
+    module:  ModuleReference,
+    /// Migration function in the new module.
+    migrate: Option<(OwnedEntrypointName, Vec<u8>)>,
+}
+
 /// The different errors the contract can produce.
 #[derive(Serialize, Debug, PartialEq, Eq, Reject, SchemaType)]
 enum CustomContractError {
@@ -124,6 +135,14 @@ enum CustomContractError {
     InvokeContractError,
     /// Failed to invoke a transfer.
     InvokeTransferError,
+    /// Upgrade failed because the new module does not exist.
+    FailedUpgradeMissingModule,
+    /// Upgrade failed because the new module does not contain a contract with a
+    /// matching name.
+    FailedUpgradeMissingContract,
+    /// Upgrade failed because the smart contract version of the module is not
+    /// supported.
+    FailedUpgradeUnsupportedModuleVersion,
 }
 
 type ContractError = Cis2Error<CustomContractError>;
@@ -148,6 +167,17 @@ impl<T> From<CallContractError<T>> for CustomContractError {
 /// Mapping errors related to contract invocations to CustomContractError.
 impl From<TransferError> for CustomContractError {
     fn from(_te: TransferError) -> Self { Self::InvokeTransferError }
+}
+
+/// Mapping errors related to contract upgrades to CustomContractError.
+impl From<UpgradeError> for CustomContractError {
+    fn from(ue: UpgradeError) -> Self {
+        match ue {
+            UpgradeError::MissingModule => Self::FailedUpgradeMissingModule,
+            UpgradeError::MissingContract => Self::FailedUpgradeMissingContract,
+            UpgradeError::UnsupportedModuleVersion => Self::FailedUpgradeUnsupportedModuleVersion,
+        }
+    }
 }
 
 /// Mapping CustomContractError to ContractError
@@ -726,6 +756,35 @@ fn contract_set_implementor<S: HasStateApi>(
     Ok(())
 }
 
+#[receive(
+    contract = "CIS2-wCCD",
+    name = "upgrade",
+    parameter = "UpgradeParams",
+    error = "ContractError",
+    mutable
+)]
+fn contract_upgrade<S: HasStateApi>(
+    ctx: &impl HasReceiveContext,
+    host: &mut impl HasHost<State<S>, StateApiType = S>,
+) -> ContractResult<()> {
+    // Authorize the sender.
+    ensure!(ctx.sender().matches_account(&ctx.owner()), ContractError::Unauthorized);
+    // Parse the parameter.
+    let params: UpgradeParams = ctx.parameter_cursor().get()?;
+    // Trigger the upgrade.
+    host.upgrade(params.module)?;
+    // Call the migration function if provided.
+    if let Some((func, parameters)) = params.migrate {
+        host.invoke_contract_raw(
+            &ctx.self_address(),
+            Parameter(&parameters),
+            func.as_entrypoint_name(),
+            Amount::zero(),
+        )?;
+    }
+    Ok(())
+}
+
 // Tests
 
 #[concordium_cfg_test]
@@ -1065,5 +1124,38 @@ mod tests {
         // The balance should still be 400 due to the rollback after rejecting.
         claim_eq!(host.state().balance(&TOKEN_ID_WCCD, &ADDRESS_0), Ok(400u64.into()));
         claim!(host.get_transfers().is_empty());
+    }
+
+    #[concordium_test]
+    fn test_upgradability_rejects() {
+        // Setup the context
+        let mut ctx = TestReceiveContext::empty();
+        ctx.set_sender(ADDRESS_0);
+        ctx.set_owner(ACCOUNT_0);
+
+        let new_module_ref = ModuleReference::from([0u8; 32]);
+
+        // and parameter.
+        let parameter = UpgradeParams {
+            module:  new_module_ref,
+            migrate: None,
+        };
+        let parameter_bytes = to_bytes(&parameter);
+        ctx.set_parameter(&parameter_bytes);
+
+        let mut state_builder = TestStateBuilder::new();
+        let state = initial_state(&mut state_builder);
+        let mut host = TestHost::new(state, state_builder);
+        // Make ACCOUNT_1 missing such that transfers to it will fail.
+
+        host.setup_mock_upgrade(new_module_ref, Err(UpgradeError::MissingModule));
+
+        // Call the contract function. Note the use of `with_rollback`.
+        let result: ContractResult<()> = host.with_rollback(|host| contract_upgrade(&ctx, host));
+
+        claim_eq!(
+            result,
+            Err(ContractError::Custom(CustomContractError::FailedUpgradeMissingModule))
+        );
     }
 }


### PR DESCRIPTION
## Purpose

Add support for the upcoming `upgrade` contract host function.
Closes #175.

## Changes

`concordium-std`:
- Add `upgrade` host function for upgrading a smart contract instance to use a new smart contract module.
- Support mocking `upgrade` calls in `TestHost`. An `upgrade` is mocked by specifying a module reference and a `UpgradeResult` as the outcome of upgrading to this module.

`concordium-cis2`:
- Add From implementation from types implementing `From<UpgradeError>` to `Cis2Error`.

`examples/cis2-wccd`:
- Introduce an endpoint for upgrading an instance only authorized by the contract owner. Optionally, a migration function can be provided.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.