### PR TITLE
Allow `#[concordium(state_parameter)]` be type path

### DIFF
--- a/concordium-std-derive/CHANGELOG.md
+++ b/concordium-std-derive/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Allow `#[concordium(state_parameter)]`'s value be not just identifier but any type path
+  for `derive(DeserialWithState)` and `derive(Deletable)` to generate implementations.
+
 ## concordium-std-derive 4.0.0 (2022-08-24)
 
 - Add ability to `derive(Reject)` for enums *with fields*.

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -1277,10 +1277,13 @@ fn find_state_parameter_attribute(
     };
 
     match value {
-        syn::Lit::Str(value) => Ok(Some(value.parse()?)),
-        _ => {
-            Err(syn::Error::new(value.span(), "state_parameter attribute value must be a string."))
-        }
+        syn::Lit::Str(value) => Ok(Some(value.parse().map_err(|err| {
+            syn::Error::new(err.span(), "state_parameter attribute value is not a valid type path")
+        })?)),
+        _ => Err(syn::Error::new(
+            value.span(),
+            "state_parameter attribute value must be a string which describes valid type path",
+        )),
     }
 }
 

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -1270,14 +1270,14 @@ fn find_length_attribute(attributes: &[syn::Attribute]) -> syn::Result<Option<u3
 /// string.
 fn find_state_parameter_attribute(
     attributes: &[syn::Attribute],
-) -> syn::Result<Option<syn::Ident>> {
+) -> syn::Result<Option<syn::TypePath>> {
     let value = match find_attribute_value(attributes, false, "state_parameter")? {
         Some(v) => v,
         None => return Ok(None),
     };
 
     match value {
-        syn::Lit::Str(value) => Ok(Some(syn::Ident::new(&value.value(), value.span()))),
+        syn::Lit::Str(value) => Ok(Some(value.parse()?)),
         _ => {
             Err(syn::Error::new(value.span(), "state_parameter attribute value must be a string."))
         }
@@ -1357,7 +1357,7 @@ fn impl_deserial_with_state_field(
     state_ident: &syn::Ident,
     ident: &syn::Ident,
     source: &syn::Ident,
-    state_parameter: &syn::Ident,
+    state_parameter: &syn::TypePath,
 ) -> syn::Result<proc_macro2::TokenStream> {
     let concordium_attributes = get_concordium_field_attributes(&f.attrs)?;
     let ensure_ordered = contains_attribute(&concordium_attributes, "ensure_ordered");

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- `concordium-std-derive`: allow `#[concordium(state_parameter)]`'s value be not just identifier
+  but any type path for `derive(DeserialWithState)` and `derive(Deletable)` to generate implementations.
+
 ## concordium-std 4.0.0 (2022-08-24)
 
 - Add rollback functionality to the `TestHost`.

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -43,7 +43,7 @@ crate-type = ["rlib"]
 opt-level = "s"
 
 [dev-dependencies]
-trybuild = "1.0.71"
+trybuild = "1.0"
 # Don't unwind on panics, just trap.
 # panic = "abort"
 

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -41,6 +41,9 @@ crate-type = ["rlib"]
 [profile.release]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
+
+[dev-dependencies]
+trybuild = "1.0.71"
 # Don't unwind on panics, just trap.
 # panic = "abort"
 

--- a/concordium-std/tests/derive-deletable/success-assoc-type.rs
+++ b/concordium-std/tests/derive-deletable/success-assoc-type.rs
@@ -1,4 +1,4 @@
-use concordium_std::{Deletable, StateMap, HasStateApi};
+use concordium_std::{Deletable, HasStateApi, StateMap};
 
 pub trait ProxyTrait {
     type State: HasStateApi;
@@ -10,4 +10,4 @@ pub struct TestDeserial<T: ProxyTrait> {
     pub test_map: StateMap<u32, String, T::State>,
 }
 
-fn main() { }
+fn main() {}

--- a/concordium-std/tests/derive-deletable/success-assoc-type.rs
+++ b/concordium-std/tests/derive-deletable/success-assoc-type.rs
@@ -1,0 +1,13 @@
+use concordium_std::{Deletable, StateMap, HasStateApi};
+
+pub trait ProxyTrait {
+    type State: HasStateApi;
+}
+
+#[derive(Deletable)]
+#[concordium(state_parameter = "T::State")]
+pub struct TestDeserial<T: ProxyTrait> {
+    pub test_map: StateMap<u32, String, T::State>,
+}
+
+fn main() { }

--- a/concordium-std/tests/derive-deletable/success-assoc-type.rs
+++ b/concordium-std/tests/derive-deletable/success-assoc-type.rs
@@ -1,3 +1,6 @@
+//! Ensure that `derive(Deletable)` can generate trait implementation
+//! when `#[concordium(state_parameter)]` attribute value is not just
+//! a type identifier but a type path to trait's associated type  
 use concordium_std::{Deletable, HasStateApi, StateMap};
 
 pub trait ProxyTrait {

--- a/concordium-std/tests/derive-deletable/success-ident-param.rs
+++ b/concordium-std/tests/derive-deletable/success-ident-param.rs
@@ -1,3 +1,5 @@
+//! Ensure `derive(Deletable)` generates code successfully for the simplest
+//! case when `#[concordium(state_parameter)]` is just a type identifier
 use concordium_std::{Deletable, HasStateApi, StateMap};
 
 #[derive(Deletable)]

--- a/concordium-std/tests/derive-deletable/success-ident-param.rs
+++ b/concordium-std/tests/derive-deletable/success-ident-param.rs
@@ -1,4 +1,4 @@
-use concordium_std::{Deletable, StateMap, HasStateApi};
+use concordium_std::{Deletable, HasStateApi, StateMap};
 
 #[derive(Deletable)]
 #[concordium(state_parameter = "S")]
@@ -6,4 +6,4 @@ pub struct TestDeserial<S: HasStateApi> {
     pub test_map: StateMap<u32, String, S>,
 }
 
-fn main() { }
+fn main() {}

--- a/concordium-std/tests/derive-deletable/success-ident-param.rs
+++ b/concordium-std/tests/derive-deletable/success-ident-param.rs
@@ -1,0 +1,9 @@
+use concordium_std::{Deletable, StateMap, HasStateApi};
+
+#[derive(Deletable)]
+#[concordium(state_parameter = "S")]
+pub struct TestDeserial<S: HasStateApi> {
+    pub test_map: StateMap<u32, String, S>,
+}
+
+fn main() { }

--- a/concordium-std/tests/derive-deserial-with-state/success-assoc-type.rs
+++ b/concordium-std/tests/derive-deserial-with-state/success-assoc-type.rs
@@ -1,0 +1,13 @@
+use concordium_std::{ParseResult, Read, DeserialWithState, StateMap, HasStateApi};
+
+pub trait ProxyTrait {
+    type State: HasStateApi;
+}
+
+#[derive(DeserialWithState)]
+#[concordium(state_parameter = "T::State")]
+pub struct TestDeserial<T: ProxyTrait> {
+    pub test_map: StateMap<u32, String, T::State>,
+}
+
+fn main() { }

--- a/concordium-std/tests/derive-deserial-with-state/success-assoc-type.rs
+++ b/concordium-std/tests/derive-deserial-with-state/success-assoc-type.rs
@@ -1,4 +1,4 @@
-use concordium_std::{ParseResult, Read, DeserialWithState, StateMap, HasStateApi};
+use concordium_std::{DeserialWithState, HasStateApi, ParseResult, Read, StateMap};
 
 pub trait ProxyTrait {
     type State: HasStateApi;
@@ -10,4 +10,4 @@ pub struct TestDeserial<T: ProxyTrait> {
     pub test_map: StateMap<u32, String, T::State>,
 }
 
-fn main() { }
+fn main() {}

--- a/concordium-std/tests/derive-deserial-with-state/success-assoc-type.rs
+++ b/concordium-std/tests/derive-deserial-with-state/success-assoc-type.rs
@@ -1,3 +1,6 @@
+//! Ensure that `derive(DeserialWithState)` can generate trait implementation
+//! when `#[concordium(state_parameter)]` attribute value is not just
+//! a type identifier but a type path to trait's associated type  
 use concordium_std::{DeserialWithState, HasStateApi, ParseResult, Read, StateMap};
 
 pub trait ProxyTrait {

--- a/concordium-std/tests/derive-deserial-with-state/success-ident-param.rs
+++ b/concordium-std/tests/derive-deserial-with-state/success-ident-param.rs
@@ -1,3 +1,6 @@
+//! Ensure `derive(DeserialWithState)` generates code successfully for the
+//! simplest case when `#[concordium(state_parameter)]` is just a type
+//! identifier
 use concordium_std::{DeserialWithState, HasStateApi, ParseResult, Read, StateMap};
 
 #[derive(DeserialWithState)]

--- a/concordium-std/tests/derive-deserial-with-state/success-ident-param.rs
+++ b/concordium-std/tests/derive-deserial-with-state/success-ident-param.rs
@@ -1,0 +1,9 @@
+use concordium_std::{ParseResult, Read, DeserialWithState, StateMap, HasStateApi};
+
+#[derive(DeserialWithState)]
+#[concordium(state_parameter = "S")]
+pub struct TestDeserial<S: HasStateApi> {
+    pub test_map: StateMap<u32, String, S>,
+}
+
+fn main() { }

--- a/concordium-std/tests/derive-deserial-with-state/success-ident-param.rs
+++ b/concordium-std/tests/derive-deserial-with-state/success-ident-param.rs
@@ -1,4 +1,4 @@
-use concordium_std::{ParseResult, Read, DeserialWithState, StateMap, HasStateApi};
+use concordium_std::{DeserialWithState, HasStateApi, ParseResult, Read, StateMap};
 
 #[derive(DeserialWithState)]
 #[concordium(state_parameter = "S")]
@@ -6,4 +6,4 @@ pub struct TestDeserial<S: HasStateApi> {
     pub test_map: StateMap<u32, String, S>,
 }
 
-fn main() { }
+fn main() {}

--- a/concordium-std/tests/derives.rs
+++ b/concordium-std/tests/derives.rs
@@ -1,0 +1,13 @@
+#[test]
+fn deserial_with_state() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/derive-deserial-with-state/success-ident-param.rs");
+    t.pass("tests/derive-deserial-with-state/success-assoc-type.rs");
+}
+
+#[test]
+fn deletable() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/derive-deletable/success-ident-param.rs");
+    t.pass("tests/derive-deletable/success-assoc-type.rs");
+}

--- a/concordium-std/tests/derives.rs
+++ b/concordium-std/tests/derives.rs
@@ -1,13 +1,14 @@
+//! Test correct functioning of trait deriving macros from
+//! `concordium-std-derive` package. Test cases presented here check successful
+//! (or failed) compilation for the code which uses macros, not its functioning.
 #[test]
 fn deserial_with_state() {
     let t = trybuild::TestCases::new();
-    t.pass("tests/derive-deserial-with-state/success-ident-param.rs");
-    t.pass("tests/derive-deserial-with-state/success-assoc-type.rs");
+    t.pass("tests/derive-deserial-with-state/success-*.rs");
 }
 
 #[test]
 fn deletable() {
     let t = trybuild::TestCases::new();
-    t.pass("tests/derive-deletable/success-ident-param.rs");
-    t.pass("tests/derive-deletable/success-assoc-type.rs");
+    t.pass("tests/derive-deletable/success-*.rs");
 }


### PR DESCRIPTION
## Purpose

Allow state parameter be arbitrary type path. This allows passing state type parameter not just as direct type parameter of type in question, but as any type derived from them, like trait's associated type.

## Changes

1. Replace return type `syn::Result<Option<syn::Ident>>` of `find_state_parameter_attribute` with `syn::Result<Option<syn::TypePath>>` and adjust all usage spots.
1. Add compilation tests to `concordium-std` which ensure changes work for affected traits, namely `DeserialWithState` and `Deletable`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
