### PR TITLE
Enabled to use newest cargo generate version with the templates

### DIFF
--- a/templates/cis2-nft/cargo-generate.toml
+++ b/templates/cis2-nft/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = "0.16.0"
+cargo_generate_version = ">= 0.16.0, < 0.18.0"
 
 [placeholders]
 description = { type="string", prompt="Description for the project?" }

--- a/templates/default/cargo-generate.toml
+++ b/templates/default/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = "0.16.0"
+cargo_generate_version = ">= 0.16.0, < 0.18.0"
 
 [placeholders]
 description = { type="string", prompt="Description for the project?" }


### PR DESCRIPTION
## Purpose

`cargo-generate` is now at a version above 0.17.x:
If users generate our templates via `cargo-concordium` using the newest `cargo-generate` crate, they run into the following error (especially non-tech people did not understand that they need to downgrade to 0.16.x to get it to work).

> Errr: :no_entry:   Required cargo-generate version not met. Required: ^0.16.0  was: 0.17.2
> Error: Could not create a new Concordium smart contract project.
>

https://github.com/Concordium/concordium-rust-smart-contracts/blob/main/templates/default/cargo-generate.toml#L2 (edited) 

It was tested that our templates work with the new `cargo-generate` version 0.17.2. This pull request extends the version.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
