### PR TITLE
Add event schema to templates

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -187,8 +187,8 @@ jobs:
         run: |
           mv $PROJECT_NAME ${{ runner.temp }}/
           sed -i "s/root/Concordium <developers@concordium.com>/g" ${{ runner.temp }}/$PROJECT_NAME/Cargo.toml
-          sed -i "s/\"4.0.0\"/{path = \"..\/..\/concordium-std\", default-features = false}/g" ${{ runner.temp }}/$PROJECT_NAME/Cargo.toml
-          sed -i "s/\"1.2.0\"/{path = \"..\/..\/concordium-cis2\", default-features = false}/g" ${{ runner.temp }}/$PROJECT_NAME/Cargo.toml
+          sed -i "s/\"5.0.0\"/{path = \"..\/..\/concordium-std\", default-features = false}/g" ${{ runner.temp }}/$PROJECT_NAME/Cargo.toml
+          sed -i "s/\"2.0.0\"/{path = \"..\/..\/concordium-cis2\", default-features = false}/g" ${{ runner.temp }}/$PROJECT_NAME/Cargo.toml
           diff ${{ runner.temp }}/$PROJECT_NAME/Cargo.toml examples/cis2-nft/Cargo.toml
           diff ${{ runner.temp }}/$PROJECT_NAME/src/lib.rs examples/cis2-nft/src/lib.rs
 

--- a/examples/cis2-nft/src/lib.rs
+++ b/examples/cis2-nft/src/lib.rs
@@ -294,7 +294,7 @@ fn build_token_metadata_url(token_id: &ContractTokenId) -> String {
 // Contract functions
 
 /// Initialize contract instance with no token types initially.
-#[init(contract = "cis2_nft")]
+#[init(contract = "cis2_nft", event = "Cis2Event<ContractTokenId, ContractTokenAmount>")]
 fn contract_init<S: HasStateApi>(
     _ctx: &impl HasInitContext,
     state_builder: &mut StateBuilder<S>,

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,6 +1,6 @@
 # Concordium Smart Contract Templates
 
-This repository helps you to get a new Concordium smart contract project up and running quickly by leveraging the pre-existing templates in it. There are several smart contract templates available in this repository (currently a `default` template and a `cis2-nft` template). For generating the smart contracts from the templates, you need the `cargo-concordium` tool version 2.2.0 or greater. `Cargo-concordium` can be installed as described in the following guide:
+This repository helps you to get a new Concordium smart contract project up and running quickly by leveraging the pre-existing templates in it. There are several smart contract templates available in this repository (currently a `default` template and a `cis2-nft` template). For generating the smart contracts from the templates, you need the `cargo-concordium` tool version 2.4.0 or greater. `Cargo-concordium` can be installed as described in the following guide:
 
 [Cargo-concordium setup](https://developer.concordium.software/en/mainnet/smart-contracts/guides/setup-tools.html#setup-tools)
 

--- a/templates/cis2-nft/Cargo.toml
+++ b/templates/cis2-nft/Cargo.toml
@@ -11,8 +11,8 @@ default = ["std"]
 std = ["concordium-std/std", "concordium-cis2/std"]
 
 [dependencies]
-concordium-std = "4.0.0"
-concordium-cis2 = "1.2.0"
+concordium-std = "5.0.0"
+concordium-cis2 = "2.0.0"
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/templates/cis2-nft/src/lib.rs
+++ b/templates/cis2-nft/src/lib.rs
@@ -294,7 +294,7 @@ fn build_token_metadata_url(token_id: &ContractTokenId) -> String {
 // Contract functions
 
 /// Initialize contract instance with no token types initially.
-#[init(contract = "{{crate_name}}")]
+#[init(contract = "{{crate_name}}", event = "Cis2Event<ContractTokenId, ContractTokenAmount>")]
 fn contract_init<S: HasStateApi>(
     _ctx: &impl HasInitContext,
     state_builder: &mut StateBuilder<S>,


### PR DESCRIPTION
## Purpose

After the new version of the cis2 library is published on `crate.io`, we can update the templates with the new event schema.

## Changes

Add event schemas to cis2-nft template example

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
