### PR TITLE
Support non-shape-preserving migration.

### DIFF
--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -287,7 +287,7 @@ extern "C" {
 }
 
 // For every external function, we must provide a dummy function.
-// This is nescessary to compile to x86_64 during unit tests on Windows and OSX.
+// This is necessary to compile to x86_64 during unit tests on Windows and OSX.
 #[cfg(not(target_arch = "wasm32"))]
 mod host_dummy_functions {
     #[no_mangle]

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -225,6 +225,13 @@ pub trait HasStateApi: Clone {
     /// See the [`iterator`][HasStateApi::iterator] method for why this is
     /// necessary.
     fn delete_iterator(&mut self, iter: Self::IterType);
+
+    /// Read and deserialize the state stored at the root of the state trie.
+    /// If such a state does not exist, or cannot be deserialized into the
+    /// provided type, then this returns an error.
+    fn read_root<A: DeserialWithState<Self>>(&self) -> ParseResult<A> {
+        A::deserial_with_state(self, &mut self.lookup_entry(&[]).ok_or(ParseError {})?)
+    }
 }
 
 /// A type that can serve as the host, meaning that it supports interactions


### PR DESCRIPTION
## Purpose

Addresses #199 

## Changes

Make the upgrade `low_level`. This makes it not do automatic state saves which allows the migration function to make incompatible state changes.

This also removes the upgrade tests. The problem with those is that we don't have good support for low-level TestHost so they would be more trouble than they are worth. We should have tests using the new integration testing library.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
