### PR TITLE
Bump versions of std and std-derive for release.

### DIFF
--- a/concordium-std-derive/CHANGELOG.md
+++ b/concordium-std-derive/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
  
 ## Unreleased changes
+
+## concordium-std-derive 5.1.0 (2022-12-14)
+
 - Add a `#[concordium_quickcheck]` macro that re-exports a customized QuickCheck function
   `test_infrastructure::concordium_qc` as a `#[concordium_test]` function.
   It is enabled by the `concordium-quickcheck` feature.

--- a/concordium-std-derive/Cargo.toml
+++ b/concordium-std-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-std-derive"
-version = "5.0.0"
+version = "5.1.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+## concordium-std 5.1.0 (2022-12-14)
+
 - Add a new primitive `get_random` for generating random numbers in Wasm code testing; `get_random` can be used in tests only, not available for smart contracts on the chain.
 - Fix a linking issue when compiling contracts to native code on Windows and OSX.
 

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-std"
-version = "5.0.0"
+version = "5.1.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"
@@ -22,11 +22,11 @@ getrandom = { version = "0.2", features = ["custom"], optional = true }
 
 [dependencies.concordium-std-derive]
 path = "../concordium-std-derive"
-version = "5.0"
+version = "5.1"
 
 [dependencies.concordium-contracts-common]
 path = "../concordium-contracts-common/concordium-contracts-common"
-version = "5.0"
+version = "5.1"
 default-features = false
 
 [features]


### PR DESCRIPTION
## Purpose

Release concordium-std and concordium-std-derive 5.1.0.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.