### PR TITLE
Make wee_alloc a feature

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -379,7 +379,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features wee-alloc
+          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features use-wee-alloc
 
   check-no-std-examples:
     name: Build on nightly,
@@ -419,7 +419,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features=${{ matrix.features }} --features wee-alloc
+          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features=${{ matrix.features }} --features use-wee-alloc
 
   check-crypto-examples:
     name: Check crypto examples

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -379,7 +379,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features wee_alloc
+          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features wee-alloc
 
   check-no-std-examples:
     name: Build on nightly,
@@ -419,7 +419,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features=${{ matrix.features }} --features wee_alloc
+          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features=${{ matrix.features }} --features wee-alloc
 
   check-crypto-examples:
     name: Check crypto examples

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -188,8 +188,8 @@ jobs:
         run: |
           mv $PROJECT_NAME ${{ runner.temp }}/
           sed -i "s/root/Concordium <developers@concordium.com>/g" ${{ runner.temp }}/$PROJECT_NAME/Cargo.toml
-          sed -i "s/\"5.1\"/{path = \"..\/..\/concordium-std\", default-features = false}/g" ${{ runner.temp }}/$PROJECT_NAME/Cargo.toml
-          sed -i "s/\"2.0\"/{path = \"..\/..\/concordium-cis2\", default-features = false}/g" ${{ runner.temp }}/$PROJECT_NAME/Cargo.toml
+          sed -i "s/{version = \"6.0\", default-features = false}/{path = \"..\/..\/concordium-std\", default-features = false}/g" ${{ runner.temp }}/$PROJECT_NAME/Cargo.toml
+          sed -i "s/{version = \"3.0\", default-features = false}/{path = \"..\/..\/concordium-cis2\", default-features = false}/g" ${{ runner.temp }}/$PROJECT_NAME/Cargo.toml
           diff ${{ runner.temp }}/$PROJECT_NAME/Cargo.toml examples/cis2-nft/Cargo.toml
           diff ${{ runner.temp }}/$PROJECT_NAME/src/lib.rs examples/cis2-nft/src/lib.rs
 
@@ -379,7 +379,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features wee_alloc
+          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features
 
   check-no-std-examples:
     name: Build on nightly,

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -379,7 +379,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features
+          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features wee_alloc
 
   check-no-std-examples:
     name: Build on nightly,
@@ -419,7 +419,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features=${{ matrix.features }}
+          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features=${{ matrix.features }} --features wee_alloc
 
   check-crypto-examples:
     name: Check crypto examples

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -379,7 +379,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features use-wee-alloc
+          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features wee_alloc
 
   check-no-std-examples:
     name: Build on nightly,
@@ -419,7 +419,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features=${{ matrix.features }} --features use-wee-alloc
+          args: --manifest-path ${{ matrix.crates }} --target=${{ matrix.target }} --no-default-features --features=${{ matrix.features }} --features wee_alloc
 
   check-crypto-examples:
     name: Check crypto examples

--- a/concordium-cis2/CHANGELOG.md
+++ b/concordium-cis2/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Add `use-wee-alloc` feature to enable the `use-wee-alloc` feature of
+  `concordium-std`.
+
 ## concordium-cis2 2.0.0 (2022-11-21)
 
 - Update `concordium-std` to version 5.

--- a/concordium-cis2/CHANGELOG.md
+++ b/concordium-cis2/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Add `use-wee-alloc` feature to enable the `use-wee-alloc` feature of
+- Add `wee_alloc` feature to enable the `wee_alloc` feature of
   `concordium-std`.
 
 ## concordium-cis2 2.0.0 (2022-11-21)

--- a/concordium-cis2/CHANGELOG.md
+++ b/concordium-cis2/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased changes
 
-- Add `wee_alloc` feature to enable the `wee_alloc` feature of
-  `concordium-std`.
+## concordium-cis2 3.0.0 (2023-02-08)
+
+- Update `concordium-std` to version 6.
 
 ## concordium-cis2 2.0.0 (2022-11-21)
 

--- a/concordium-cis2/Cargo.toml
+++ b/concordium-cis2/Cargo.toml
@@ -21,7 +21,7 @@ default-features = false
 [features]
 default = ["std"]
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 u256_amount = []
 
 [lib]

--- a/concordium-cis2/Cargo.toml
+++ b/concordium-cis2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-cis2"
-version = "2.1.0"
+version = "3.0.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"
@@ -11,7 +11,7 @@ readme = "./README.md"
 
 [dependencies.concordium-std]
 path = "../concordium-std"
-version = ">=5.2"
+version = "6"
 default-features = false
 
 [dependencies.primitive-types]
@@ -21,7 +21,6 @@ default-features = false
 [features]
 default = ["std"]
 std = ["concordium-std/std"]
-wee_alloc = ["concordium-std/wee_alloc"]
 u256_amount = []
 
 [lib]

--- a/concordium-cis2/Cargo.toml
+++ b/concordium-cis2/Cargo.toml
@@ -19,8 +19,9 @@ version = "0.11"
 default-features = false
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 u256_amount = []
 
 [lib]

--- a/concordium-cis2/Cargo.toml
+++ b/concordium-cis2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-cis2"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"
@@ -11,7 +11,7 @@ readme = "./README.md"
 
 [dependencies.concordium-std]
 path = "../concordium-std"
-version = "5"
+version = ">=5.2"
 default-features = false
 
 [dependencies.primitive-types]
@@ -19,9 +19,9 @@ version = "0.11"
 default-features = false
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std"]
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 u256_amount = []
 
 [lib]

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased changes
 
-- Wee_alloc is not the default allocator in `concordium-std` anymore but can be enabled as a feature.
+- [`wee_alloc`](https://docs.rs/wee_alloc/latest/wee_alloc/index.html) is no
+  longer set as the allocator in `concordium-std` but can be enabled via the
+  feature `use-wee-alloc`. The consequence is that unless `std` feature is
+  enabled either `use-wee-alloc` must be enabled, or another global allocator
+  must be set in the smart contract. In `std` builds, unless `use-wee-alloc`
+  feature is used, the allocator provided by the Rust standard library is used.
 
 ## concordium-std 5.1.0 (2022-12-14)
 

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 - [`wee_alloc`](https://docs.rs/wee_alloc/latest/wee_alloc/index.html) is no
   longer set as the allocator in `concordium-std` but can be enabled via the
-  feature `use-wee-alloc`. The consequence is that unless `std` feature is
-  enabled either `use-wee-alloc` must be enabled, or another global allocator
-  must be set in the smart contract. In `std` builds, unless `use-wee-alloc`
+  feature `wee_alloc`. The consequence is that unless `std` feature is
+  enabled either `wee_alloc` must be enabled, or another global allocator
+  must be set in the smart contract. In `std` builds, unless `wee_alloc`
   feature is used, the allocator provided by the Rust standard library is used.
 
 ## concordium-std 5.1.0 (2022-12-14)

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Wee_alloc is not the default allocator in `concordium-std` anymore but can be enabled as a feature.
+
 ## concordium-std 5.1.0 (2022-12-14)
 
 - Add a new primitive `get_random` for generating random numbers in Wasm code testing; `get_random` can be used in tests only, not available for smart contracts on the chain.

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+## concordium-std 6.0.0 (2023-02-08)
+
 - [`wee_alloc`](https://docs.rs/wee_alloc/latest/wee_alloc/index.html) is no
   longer set as the allocator in `concordium-std` but can be enabled via the
   feature `wee_alloc`. The consequence is that unless `std` feature is

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -11,7 +11,9 @@ readme = "./README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-dlmalloc = { version = "0.2.4", features = ["global"]}
+# Reduce code size, at the cost of performance in allocation heavy-code.
+wee_alloc= { version = "0.4.5", optional = true}
+dlmalloc = { version = "0.2.4", features = ["global"], optional = true}
 sha2 = { version = "0.10", optional = true }
 sha3 = { version = "0.10", optional = true }
 secp256k1 = { version = "0.22", optional = true }
@@ -30,7 +32,8 @@ default-features = false
 
 [features]
 default = ["std"]
-
+wee-alloc = ["wee_alloc"]
+dl-malloc = ["dlmalloc"]
 std = ["concordium-contracts-common/std"]
 wasm-test = ["concordium-std-derive/wasm-test"]
 build-schema = ["concordium-std-derive/build-schema"]

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -11,8 +11,7 @@ readme = "./README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-# Reduce code size, at the cost of performance in allocation heavy-code.
-wee_alloc="0.4.5"
+dlmalloc = { version = "0.2.4", features = ["global"]}
 sha2 = { version = "0.10", optional = true }
 sha3 = { version = "0.10", optional = true }
 secp256k1 = { version = "0.22", optional = true }

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-std"
-version = "5.2.0"
+version = "6.0.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"
@@ -26,7 +26,7 @@ version = "5.1"
 
 [dependencies.concordium-contracts-common]
 path = "../concordium-contracts-common/concordium-contracts-common"
-version = "5.1"
+version = "5.2"
 default-features = false
 
 [features]

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -31,7 +31,6 @@ default-features = false
 
 [features]
 default = ["std"]
-use-wee-alloc = ["wee_alloc"]
 std = ["concordium-contracts-common/std"]
 wasm-test = ["concordium-std-derive/wasm-test"]
 build-schema = ["concordium-std-derive/build-schema"]

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -13,7 +13,6 @@ readme = "./README.md"
 [dependencies]
 # Reduce code size, at the cost of performance in allocation heavy-code.
 wee_alloc= { version = "0.4.5", optional = true}
-dlmalloc = { version = "0.2.4", features = ["global"], optional = true}
 sha2 = { version = "0.10", optional = true }
 sha3 = { version = "0.10", optional = true }
 secp256k1 = { version = "0.22", optional = true }
@@ -33,7 +32,6 @@ default-features = false
 [features]
 default = ["std"]
 wee-alloc = ["wee_alloc"]
-dl-malloc = ["dlmalloc"]
 std = ["concordium-contracts-common/std"]
 wasm-test = ["concordium-std-derive/wasm-test"]
 build-schema = ["concordium-std-derive/build-schema"]

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-std"
-version = "5.1.0"
+version = "5.2.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"
@@ -31,7 +31,7 @@ default-features = false
 
 [features]
 default = ["std"]
-wee-alloc = ["wee_alloc"]
+use-wee-alloc = ["wee_alloc"]
 std = ["concordium-contracts-common/std"]
 wasm-test = ["concordium-std-derive/wasm-test"]
 build-schema = ["concordium-std-derive/build-schema"]

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -277,6 +277,6 @@ pub use types::*;
 
 extern crate dlmalloc;
 // Use `globalDlmalloc` as the global allocator.
-#[global_allocator]
+#[cfg_attr(not(feature = "std"), global_allocator)]
 static ALLOC: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
 pub mod test_infrastructure;

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -32,7 +32,7 @@
 //! [`build-schema`](#build-schema-build-for-generating-a-module-schema),
 //! [`wasm-test`](#wasm-test-build-for-testing-in-wasm),
 //! [`crypto-primitives`][crypto-feature], and
-//! [`use-wee-alloc`](#use-a-custom-allocator)
+//! [`wee_alloc`](#use-a-custom-allocator)
 //!
 //! [crypto-feature]:
 //! #crypto-primitives-for-testing-crypto-with-actual-implementations
@@ -111,7 +111,7 @@
 //!
 //! In the past `concordium-std` hard-coded the use of [wee_alloc](https://docs.rs/wee_alloc/)
 //! however since version `5.2.0` this is no longer the case.
-//! Instead no allocator is set by default, however there is a `use-wee-alloc`
+//! Instead no allocator is set by default, however there is a `wee_alloc`
 //! feature (disabled by default) that can be enabled which sets the allocator
 //! to `wee_alloc`. This can be used both with and without the `std` feature.
 //!
@@ -294,8 +294,8 @@ pub use traits::*;
 pub use types::*;
 
 // Use `wee_alloc` as the global allocator to reduce code size.
-#[cfg(feature = "use-wee-alloc")]
-#[cfg_attr(feature = "use-wee-alloc", global_allocator)]
+#[cfg(feature = "wee_alloc")]
+#[cfg_attr(feature = "wee_alloc", global_allocator)]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 pub mod test_infrastructure;

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -18,7 +18,16 @@
 //! version 2.1+.
 //!
 //! # Global allocator
-//! DlMalloc is used as the global allocator.
+//! When importing this library either the wee-alloc feature or the dl-malloc
+//! feature should be enabled. We recommend useing the wee-alloc feature as a
+//! standard in your project. The wee-alloc feature sets the allocator to [wee_alloc](https://docs.rs/wee_alloc/)
+//! which is a memory allocator aimed at small code footprint.
+//! This allocator is designed to be used in contexts where there are a few
+//! large allocations up-front, and the memory is afterward used by the program
+//! without many further allocations. Frequent small allocations will have bad
+//! performance, and should be avoided. This allocator is unmaintained at the
+//! moment and produces a security warning. Therefore, the allocator can alternatively be set to [dlmalloc](https://docs.rs/dlmalloc/).
+//! Dlmalloc produces large module sizes.
 //!
 //! In the future it will be possible to opt-out of the global allocator via a
 //! feature.
@@ -268,10 +277,19 @@ pub use impls::*;
 pub use traits::*;
 pub use types::*;
 
+#[cfg(feature = "dl-malloc")]
 extern crate dlmalloc;
 // Use `globalDlmalloc` as the global allocator.
 #[allow(dead_code)]
+#[cfg(feature = "dl-malloc")]
 #[cfg_attr(not(feature = "std"), global_allocator)]
 static ALLOC: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
+
+#[cfg(feature = "wee-alloc")]
+extern crate wee_alloc;
+// Use `wee_alloc` as the global allocator to reduce code size.
+#[global_allocator]
+#[cfg(feature = "wee-alloc")]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 pub mod test_infrastructure;

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -18,12 +18,7 @@
 //! version 2.1+.
 //!
 //! # Global allocator
-//! Importing this library has a side-effect of setting  the allocator to [wee_alloc](https://docs.rs/wee_alloc/)
-//! which is a memory allocator aimed at small code footprint.
-//! This allocator is designed to be used in contexts where there are a few
-//! large allocations up-front, and the memory is afterwards used by the program
-//! without many further allocations. Frequent small allocations will have bad
-//! performance, and should be avoided.
+//! DlMalloc is used as the global allocator.
 //!
 //! In the future it will be possible to opt-out of the global allocator via a
 //! feature.
@@ -190,8 +185,6 @@
 //! [1]: https://doc.rust-lang.org/std/primitive.unit.html
 //! Other error codes may be added in the future and custom error codes should
 //! not use the range `i32::MIN` to `i32::MIN + 100`.
-// Question: Getting errors trying to get this suggestion to work: #![cfg_attr(not(feature = "std"),
-// global_allocator)]
 #![cfg_attr(not(feature = "std"), no_std, feature(alloc_error_handler, core_intrinsics))]
 
 #[cfg(not(feature = "std"))]
@@ -277,6 +270,8 @@ pub use types::*;
 
 extern crate dlmalloc;
 // Use `globalDlmalloc` as the global allocator.
+#[allow(dead_code)]
 #[cfg_attr(not(feature = "std"), global_allocator)]
 static ALLOC: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
+
 pub mod test_infrastructure;

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -18,19 +18,20 @@
 //! version 2.1+.
 //!
 //! # Global allocator
-//! When importing this library either the wee-alloc feature or the dl-malloc
-//! feature should be enabled. We recommend useing the wee-alloc feature as a
-//! standard in your project. The wee-alloc feature sets the allocator to [wee_alloc](https://docs.rs/wee_alloc/)
+//! When importing this library the wee-alloc feature can be enabled.
+//! We recommend useing the wee-alloc feature as a standard in your project.
+//! The wee-alloc feature sets the allocator to [wee_alloc](https://docs.rs/wee_alloc/)
 //! which is a memory allocator aimed at small code footprint.
 //! This allocator is designed to be used in contexts where there are a few
 //! large allocations up-front, and the memory is afterward used by the program
 //! without many further allocations. Frequent small allocations will have bad
 //! performance, and should be avoided. This allocator is unmaintained at the
-//! moment and produces a security warning. Therefore, the allocator can alternatively be set to [dlmalloc](https://docs.rs/dlmalloc/).
-//! Dlmalloc produces large module sizes.
-//!
-//! In the future it will be possible to opt-out of the global allocator via a
-//! feature.
+//! moment and produces a security warning. Therefore, you can not enable this
+//! feature or choose your own custom allocator (e.g. [dlmalloc](https://docs.rs/dlmalloc/))
+//! When building a smart contract module with no_std,
+//! enable the wee-alloc feature (or your custom allocator):
+//! ``cargo +nightly concordium build -- --no-default-features --features
+//! wee-alloc``
 //!
 //! # Panic handler
 //! When compiled without the `std` feature this crate sets the panic handler
@@ -277,19 +278,11 @@ pub use impls::*;
 pub use traits::*;
 pub use types::*;
 
-#[cfg(feature = "dl-malloc")]
-extern crate dlmalloc;
-// Use `globalDlmalloc` as the global allocator.
-#[allow(dead_code)]
-#[cfg(feature = "dl-malloc")]
-#[cfg_attr(not(feature = "std"), global_allocator)]
-static ALLOC: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
-
 #[cfg(feature = "wee-alloc")]
 extern crate wee_alloc;
 // Use `wee_alloc` as the global allocator to reduce code size.
-#[global_allocator]
 #[cfg(feature = "wee-alloc")]
+#[cfg_attr(feature = "wee-alloc", global_allocator)]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 pub mod test_infrastructure;

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -17,22 +17,6 @@
 //! Also note that `concordium-std` version 4 only works with `cargo-concordium`
 //! version 2.1+.
 //!
-//! # Global allocator
-//! When importing this library the wee-alloc feature can be enabled.
-//! We recommend useing the wee-alloc feature as a standard in your project.
-//! The wee-alloc feature sets the allocator to [wee_alloc](https://docs.rs/wee_alloc/)
-//! which is a memory allocator aimed at small code footprint.
-//! This allocator is designed to be used in contexts where there are a few
-//! large allocations up-front, and the memory is afterward used by the program
-//! without many further allocations. Frequent small allocations will have bad
-//! performance, and should be avoided. This allocator is unmaintained at the
-//! moment and produces a security warning. Therefore, you can not enable this
-//! feature or choose your own custom allocator (e.g. [dlmalloc](https://docs.rs/dlmalloc/))
-//! When building a smart contract module with no_std,
-//! enable the wee-alloc feature (or your custom allocator):
-//! ``cargo +nightly concordium build -- --no-default-features --features
-//! wee-alloc``
-//!
 //! # Panic handler
 //! When compiled without the `std` feature this crate sets the panic handler
 //! so that it terminates the process immediately, without any unwinding or
@@ -46,8 +30,9 @@
 //! This library has the following features:
 //! [`std`](#std-build-with-the-rust-standard-library),
 //! [`build-schema`](#build-schema-build-for-generating-a-module-schema),
-//! [`wasm-test`](#wasm-test-build-for-testing-in-wasm), and
-//! [`crypto-primitives`][crypto-feature].
+//! [`wasm-test`](#wasm-test-build-for-testing-in-wasm),
+//! [`crypto-primitives`][crypto-feature], and
+//! [`use-wee-alloc`](#use-a-custom-allocator)
 //!
 //! [crypto-feature]:
 //! #crypto-primitives-for-testing-crypto-with-actual-implementations
@@ -114,6 +99,36 @@
 //! **WARNING**: It is not possible to build this crate on macOS with the
 //! `crypto-primitives` feature when targeting `wasm32-unknown-unknown`.
 //! The issue arises when compiling the [`secp256k1`](https://docs.rs/secp256k1/latest/secp256k1/) crate.
+//!
+//! ## Use a custom allocator
+//!
+//! Some operations in `concordium-std` need to dynamically allocate memory.
+//! Rust programs compiled with default compiler settings have access to a
+//! [standard allocator](https://doc.rust-lang.org/std/alloc/struct.System.html)
+//! implemented in the Rust standard library. When using the
+//! `no-std` feature there is no default allocator provided by the Rust
+//! toolchain, and so one must be set explicitly.
+//!
+//! In the past `concordium-std` hard-coded the use of [wee_alloc](https://docs.rs/wee_alloc/)
+//! however since version `5.2.0` this is no longer the case.
+//! Instead no allocator is set by default, however there is a `use-wee-alloc`
+//! feature (disabled by default) that can be enabled which sets the allocator
+//! to `wee_alloc`. This can be used both with and without the `std` feature.
+//!
+//! The main reason for using `wee_alloc` instead of the default allocator, even
+//! in `std` builds, is that `wee_alloc` has a smaller code footprint, i.e, the
+//! resulting smart contracts are going to be smaller by about 6-10kB, which
+//! means they are cheaper to deploy and run. The downside is that this
+//! allocator is designed to be used in contexts where there are a few
+//! large allocations up-front, and the memory is afterward used by the program
+//! without many further allocations. Frequent small allocations will have bad
+//! performance, and should be avoided. **Do note that this allocator is
+//! at present unmaintained.** There are other allocators available, for example [dlmalloc](https://docs.rs/dlmalloc/).
+//!
+//! We only provide `wee_alloc` via a feature for backwards compatibility.
+//! Configuration of other allocators should follow their respective
+//! documentation, however note that there can only be one allocator set.
+//! See Rust [allocator](https://doc.rust-lang.org/std/alloc/index.html#the-global_allocator-attribute) documentation for more context and details.
 //!
 //! # Traits
 //! To support testing of smart contracts most of the functionality is
@@ -278,11 +293,9 @@ pub use impls::*;
 pub use traits::*;
 pub use types::*;
 
-#[cfg(feature = "wee-alloc")]
-extern crate wee_alloc;
 // Use `wee_alloc` as the global allocator to reduce code size.
-#[cfg(feature = "wee-alloc")]
-#[cfg_attr(feature = "wee-alloc", global_allocator)]
+#[cfg(feature = "use-wee-alloc")]
+#[cfg_attr(feature = "use-wee-alloc", global_allocator)]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 pub mod test_infrastructure;

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -190,6 +190,8 @@
 //! [1]: https://doc.rust-lang.org/std/primitive.unit.html
 //! Other error codes may be added in the future and custom error codes should
 //! not use the range `i32::MIN` to `i32::MIN + 100`.
+// Question: Getting errors trying to get this suggestion to work: #![cfg_attr(not(feature = "std"),
+// global_allocator)]
 #![cfg_attr(not(feature = "std"), no_std, feature(alloc_error_handler, core_intrinsics))]
 
 #[cfg(not(feature = "std"))]
@@ -273,9 +275,8 @@ pub use impls::*;
 pub use traits::*;
 pub use types::*;
 
-extern crate wee_alloc;
-// Use `wee_alloc` as the global allocator to reduce code size.
+extern crate dlmalloc;
+// Use `globalDlmalloc` as the global allocator.
 #[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
+static ALLOC: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
 pub mod test_infrastructure;

--- a/examples/auction/Cargo.toml
+++ b/examples/auction/Cargo.toml
@@ -7,9 +7,9 @@ license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/auction/Cargo.toml
+++ b/examples/auction/Cargo.toml
@@ -7,9 +7,9 @@ license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/auction/Cargo.toml
+++ b/examples/auction/Cargo.toml
@@ -7,8 +7,9 @@ license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/cis2-multi/Cargo.toml
+++ b/examples/cis2-multi/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2018"
 license = "MPL-2.0"
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std", "concordium-cis2/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/cis2-multi/Cargo.toml
+++ b/examples/cis2-multi/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 license = "MPL-2.0"
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 std = ["concordium-std/std", "concordium-cis2/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/cis2-multi/Cargo.toml
+++ b/examples/cis2-multi/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 license = "MPL-2.0"
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 std = ["concordium-std/std", "concordium-cis2/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/cis2-nft/Cargo.toml
+++ b/examples/cis2-nft/Cargo.toml
@@ -7,9 +7,8 @@ license = "MPL-2.0"
 description = "cis2-nft-project"
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std"]
 std = ["concordium-std/std", "concordium-cis2/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/cis2-nft/Cargo.toml
+++ b/examples/cis2-nft/Cargo.toml
@@ -7,8 +7,9 @@ license = "MPL-2.0"
 description = "cis2-nft-project"
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std", "concordium-cis2/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/cis2-nft/Cargo.toml
+++ b/examples/cis2-nft/Cargo.toml
@@ -9,6 +9,7 @@ description = "cis2-nft-project"
 [features]
 default = ["std"]
 std = ["concordium-std/std", "concordium-cis2/std"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/cis2-wccd/Cargo.toml
+++ b/examples/cis2-wccd/Cargo.toml
@@ -10,7 +10,6 @@ default = ["std", "crypto-primitives", "wee-alloc"]
 crypto-primitives = ["concordium-std/crypto-primitives"]
 std = ["concordium-std/std", "concordium-cis2/std"]
 wee-alloc = ["concordium-std/wee-alloc"]
-dl-malloc = ["concordium-std/dl-malloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/cis2-wccd/Cargo.toml
+++ b/examples/cis2-wccd/Cargo.toml
@@ -6,9 +6,11 @@ edition = "2018"
 license = "MPL-2.0"
 
 [features]
-default = ["std", "crypto-primitives"]
+default = ["std", "crypto-primitives", "wee-alloc"]
 crypto-primitives = ["concordium-std/crypto-primitives"]
 std = ["concordium-std/std", "concordium-cis2/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
+dl-malloc = ["concordium-std/dl-malloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/cis2-wccd/Cargo.toml
+++ b/examples/cis2-wccd/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 license = "MPL-2.0"
 
 [features]
-default = ["std", "crypto-primitives", "use-wee-alloc"]
+default = ["std", "crypto-primitives", "wee_alloc"]
 crypto-primitives = ["concordium-std/crypto-primitives"]
 std = ["concordium-std/std", "concordium-cis2/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/cis2-wccd/Cargo.toml
+++ b/examples/cis2-wccd/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 license = "MPL-2.0"
 
 [features]
-default = ["std", "crypto-primitives", "wee-alloc"]
+default = ["std", "crypto-primitives", "use-wee-alloc"]
 crypto-primitives = ["concordium-std/crypto-primitives"]
 std = ["concordium-std/std", "concordium-cis2/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/counter-notify/Cargo.toml
+++ b/examples/counter-notify/Cargo.toml
@@ -8,9 +8,9 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/counter-notify/Cargo.toml
+++ b/examples/counter-notify/Cargo.toml
@@ -8,8 +8,9 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/counter-notify/Cargo.toml
+++ b/examples/counter-notify/Cargo.toml
@@ -8,9 +8,9 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/eSealing/Cargo.toml
+++ b/examples/eSealing/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 license = "MPL-2.0"
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/eSealing/Cargo.toml
+++ b/examples/eSealing/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 license = "MPL-2.0"
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/eSealing/Cargo.toml
+++ b/examples/eSealing/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2018"
 license = "MPL-2.0"
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/fib/Cargo.toml
+++ b/examples/fib/Cargo.toml
@@ -8,9 +8,9 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/fib/Cargo.toml
+++ b/examples/fib/Cargo.toml
@@ -8,8 +8,9 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/fib/Cargo.toml
+++ b/examples/fib/Cargo.toml
@@ -8,9 +8,9 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/icecream/Cargo.toml
+++ b/examples/icecream/Cargo.toml
@@ -11,8 +11,9 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std"}
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/icecream/Cargo.toml
+++ b/examples/icecream/Cargo.toml
@@ -11,9 +11,9 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std"}
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/icecream/Cargo.toml
+++ b/examples/icecream/Cargo.toml
@@ -11,9 +11,9 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std"}
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/memo/Cargo.toml
+++ b/examples/memo/Cargo.toml
@@ -12,9 +12,9 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std"}
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/memo/Cargo.toml
+++ b/examples/memo/Cargo.toml
@@ -12,8 +12,9 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std"}
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/memo/Cargo.toml
+++ b/examples/memo/Cargo.toml
@@ -12,9 +12,9 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std"}
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/nametoken/Cargo.toml
+++ b/examples/nametoken/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2018"
 license = "MPL-2.0"
 
 [features]
-default = ["std", "crypto-primitives"]
+default = ["std", "crypto-primitives", "wee-alloc"]
 crypto-primitives = ["concordium-std/crypto-primitives"]
 std = ["concordium-std/std", "concordium-cis2/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/nametoken/Cargo.toml
+++ b/examples/nametoken/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 license = "MPL-2.0"
 
 [features]
-default = ["std", "crypto-primitives", "use-wee-alloc"]
+default = ["std", "crypto-primitives", "wee_alloc"]
 crypto-primitives = ["concordium-std/crypto-primitives"]
 std = ["concordium-std/std", "concordium-cis2/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/nametoken/Cargo.toml
+++ b/examples/nametoken/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 license = "MPL-2.0"
 
 [features]
-default = ["std", "crypto-primitives", "wee-alloc"]
+default = ["std", "crypto-primitives", "use-wee-alloc"]
 crypto-primitives = ["concordium-std/crypto-primitives"]
 std = ["concordium-std/std", "concordium-cis2/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/piggy-bank/part1/Cargo.toml
+++ b/examples/piggy-bank/part1/Cargo.toml
@@ -13,9 +13,9 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies.concordium-std]
 version = "5"

--- a/examples/piggy-bank/part1/Cargo.toml
+++ b/examples/piggy-bank/part1/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.1"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"
-description = "Two-step transfer smart contract."
+description = "Piggy bank smart contract part 1."
 homepage = "https://github.com/concordium/concordium-rust-smart-contracts"
 repository = "https://github.com/concordium/concordium-rust-smart-contracts"
 readme = "../README.md"
@@ -13,8 +13,9 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [dependencies.concordium-std]
 version = "5"

--- a/examples/piggy-bank/part1/Cargo.toml
+++ b/examples/piggy-bank/part1/Cargo.toml
@@ -18,7 +18,7 @@ std = ["concordium-std/std"]
 wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies.concordium-std]
-version = "5"
+version = "6"
 path = "../../../concordium-std"
 default-features = false
 

--- a/examples/piggy-bank/part1/Cargo.toml
+++ b/examples/piggy-bank/part1/Cargo.toml
@@ -13,9 +13,9 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [dependencies.concordium-std]
 version = "5"

--- a/examples/piggy-bank/part2/Cargo.toml
+++ b/examples/piggy-bank/part2/Cargo.toml
@@ -13,9 +13,9 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies.concordium-std]
 version = "5"

--- a/examples/piggy-bank/part2/Cargo.toml
+++ b/examples/piggy-bank/part2/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.1"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license = "MPL-2.0"
-description = "Two-step transfer smart contract."
+description = "Piggy bank smart contract part 2."
 homepage = "https://github.com/concordium/concordium-rust-smart-contracts"
 repository = "https://github.com/concordium/concordium-rust-smart-contracts"
 readme = "../README.md"
@@ -13,8 +13,9 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [dependencies.concordium-std]
 version = "5"

--- a/examples/piggy-bank/part2/Cargo.toml
+++ b/examples/piggy-bank/part2/Cargo.toml
@@ -18,7 +18,7 @@ std = ["concordium-std/std"]
 wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies.concordium-std]
-version = "5"
+version = "6"
 path = "../../../concordium-std"
 default-features = false
 

--- a/examples/piggy-bank/part2/Cargo.toml
+++ b/examples/piggy-bank/part2/Cargo.toml
@@ -13,9 +13,9 @@ readme = "../README.md"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [dependencies.concordium-std]
 version = "5"

--- a/examples/proxy/Cargo.toml
+++ b/examples/proxy/Cargo.toml
@@ -9,10 +9,10 @@ license-file = "../../../LICENSE-MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std"}

--- a/examples/proxy/Cargo.toml
+++ b/examples/proxy/Cargo.toml
@@ -9,9 +9,10 @@ license-file = "../../../LICENSE-MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std"}

--- a/examples/proxy/Cargo.toml
+++ b/examples/proxy/Cargo.toml
@@ -9,10 +9,10 @@ license-file = "../../../LICENSE-MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std"}

--- a/examples/recorder/Cargo.toml
+++ b/examples/recorder/Cargo.toml
@@ -8,9 +8,9 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/recorder/Cargo.toml
+++ b/examples/recorder/Cargo.toml
@@ -8,8 +8,9 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/recorder/Cargo.toml
+++ b/examples/recorder/Cargo.toml
@@ -8,9 +8,9 @@ license = "MPL-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std", default-features = false}

--- a/examples/signature-verifier/Cargo.toml
+++ b/examples/signature-verifier/Cargo.toml
@@ -11,10 +11,10 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std"}
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 std = ["concordium-std/std"]
 crypto-primitives = ["concordium-std/crypto-primitives"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/signature-verifier/Cargo.toml
+++ b/examples/signature-verifier/Cargo.toml
@@ -11,9 +11,10 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std"}
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std"]
 crypto-primitives = ["concordium-std/crypto-primitives"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/signature-verifier/Cargo.toml
+++ b/examples/signature-verifier/Cargo.toml
@@ -11,10 +11,10 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std"}
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 std = ["concordium-std/std"]
 crypto-primitives = ["concordium-std/crypto-primitives"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/transfer-policy-check/Cargo.toml
+++ b/examples/transfer-policy-check/Cargo.toml
@@ -11,8 +11,9 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std", default-features = false}
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/transfer-policy-check/Cargo.toml
+++ b/examples/transfer-policy-check/Cargo.toml
@@ -11,9 +11,9 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std", default-features = false}
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/transfer-policy-check/Cargo.toml
+++ b/examples/transfer-policy-check/Cargo.toml
@@ -11,9 +11,9 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std", default-features = false}
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/two-step-transfer/Cargo.toml
+++ b/examples/two-step-transfer/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/concordium/concordium-rust-smart-contracts"
 readme = "../README.md"
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies.concordium-std]
 version = "5"

--- a/examples/two-step-transfer/Cargo.toml
+++ b/examples/two-step-transfer/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/concordium/concordium-rust-smart-contracts"
 readme = "../README.md"
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [dependencies.concordium-std]
 version = "5"

--- a/examples/two-step-transfer/Cargo.toml
+++ b/examples/two-step-transfer/Cargo.toml
@@ -16,12 +16,12 @@ std = ["concordium-std/std"]
 wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies.concordium-std]
-version = "5"
+version = "6"
 path = "../../concordium-std"
 default-features = false
 
 [dev-dependencies.concordium-std]
-version = "5"
+version = "6"
 path = "../../concordium-std"
 features = ["concordium-quickcheck"]
 

--- a/examples/two-step-transfer/Cargo.toml
+++ b/examples/two-step-transfer/Cargo.toml
@@ -10,9 +10,10 @@ repository = "https://github.com/concordium/concordium-rust-smart-contracts"
 readme = "../README.md"
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [dependencies.concordium-std]
 version = "5"

--- a/examples/voting/Cargo.toml
+++ b/examples/voting/Cargo.toml
@@ -11,8 +11,9 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std", default-features = false}
 
 [features]
-default = ["std"]
+default = ["std", "wee-alloc"]
 std = ["concordium-std/std"]
+wee-alloc = ["concordium-std/wee-alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/voting/Cargo.toml
+++ b/examples/voting/Cargo.toml
@@ -11,9 +11,9 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std", default-features = false}
 
 [features]
-default = ["std", "wee-alloc"]
+default = ["std", "use-wee-alloc"]
 std = ["concordium-std/std"]
-wee-alloc = ["concordium-std/wee-alloc"]
+use-wee-alloc = ["concordium-std/use-wee-alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/voting/Cargo.toml
+++ b/examples/voting/Cargo.toml
@@ -11,9 +11,9 @@ license = "MPL-2.0"
 concordium-std = {path = "../../concordium-std", default-features = false}
 
 [features]
-default = ["std", "use-wee-alloc"]
+default = ["std", "wee_alloc"]
 std = ["concordium-std/std"]
-use-wee-alloc = ["concordium-std/use-wee-alloc"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/templates/cis2-nft/Cargo.toml
+++ b/templates/cis2-nft/Cargo.toml
@@ -9,9 +9,10 @@ description = "{{description}}"
 [features]
 default = ["std"]
 std = ["concordium-std/std", "concordium-cis2/std"]
+wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
-concordium-std = "5.1"
+concordium-std = "5.2"
 concordium-cis2 = "2.0"
 
 [lib]

--- a/templates/cis2-nft/Cargo.toml
+++ b/templates/cis2-nft/Cargo.toml
@@ -12,8 +12,8 @@ std = ["concordium-std/std", "concordium-cis2/std"]
 wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
-concordium-std = "5.2"
-concordium-cis2 = "2.0"
+concordium-std = {version = "6.0", default-features = false}
+concordium-cis2 = {version = "3.0", default-features = false}
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/templates/default/Cargo.toml
+++ b/templates/default/Cargo.toml
@@ -9,7 +9,7 @@ authors = [ "{{authors}}" ]
 description = "{{description}}"
 
 [dependencies]
-concordium-std = "5.1"
+concordium-std = "5.2"
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/templates/default/Cargo.toml
+++ b/templates/default/Cargo.toml
@@ -8,8 +8,13 @@ license = "MPL-2.0"
 authors = [ "{{authors}}" ]
 description = "{{description}}"
 
+[features]
+default = ["std"]
+std = ["concordium-std/std"]
+wee_alloc = ["concordium-std/wee_alloc"]
+
 [dependencies]
-concordium-std = "5.2"
+concordium-std = {version = "6.0", default-features = false}
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/templates/default/src/lib.rs
+++ b/templates/default/src/lib.rs
@@ -55,8 +55,8 @@ fn receive<S: HasStateApi>(
 
 /// View function that returns the content of the state.
 #[receive(contract = "{{crate_name}}", name = "view", return_value = "State")]
-fn view<'a, 'b, S: HasStateApi>(
-    _ctx: &'a impl HasReceiveContext,
+fn view<'b, S: HasStateApi>(
+    _ctx: &impl HasReceiveContext,
     host: &'b impl HasHost<State, StateApiType = S>,
 ) -> ReceiveResult<&'b State> {
     Ok(host.state())


### PR DESCRIPTION
## Purpose

closes #220 

Tests were conducted to compare the performance (module size, and execution cost) on several of our smart contract examples to compare the `wee_alloc` and the `dlmalloc` allocators. 
The `wee_alloc` had a better performance than the `dlmalloc` in terms of module size reduction. 
Because the execution cost also takes into account the module size on the Concordium chain, the `wee_alloc` also performed better in the execution cost comparison. 

The decision was made to keep the `wee_alloc` but make it a feature to give people the option to use their own custom allocator.

## Changes
The "wee-alloc" feature should be enabled by default in your smart contract project.
```
[features]
default = ["std", "crypto-primitives", "wee-alloc"]
wee-alloc = ["concordium-std/wee-alloc"]
```

then you can use wee-alloc in the no_std version as follows:
```
cargo +nightly concordium build -- --no-default-features --features wee-alloc
```

Note: The linter will fail on the `cis2-nft` example at the moment. We need to publish a new `concordium-std` library version. Then we can update the `cis2-nft` example and its associated templates to resolve the linter error.


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
