### PR TITLE
Bump allowed cargo-generate version in templates.

### DIFF
--- a/templates/cis2-nft/cargo-generate.toml
+++ b/templates/cis2-nft/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">= 0.16.0, < 0.18.0"
+cargo_generate_version = ">= 0.16.0, < 0.19.0"
 
 [placeholders]
 description = { type="string", prompt="Description for the project?" }

--- a/templates/default/cargo-generate.toml
+++ b/templates/default/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">= 0.16.0, < 0.18.0"
+cargo_generate_version = ">= 0.16.0, < 0.19.0"
 
 [placeholders]
 description = { type="string", prompt="Description for the project?" }


### PR DESCRIPTION
## Purpose

Fixes #228 

```
$ cargo generate --version     
cargo generate-generate 0.18.1
$ cargo run -- concordium init 
     Running `.../cargo-concordium concordium init`
✔ 🤷   Which template should be expanded? · default
🤷   Project Name: ff
🔧   Destination: ./ff ...
🔧   project-name: ff ...
🔧   Generating template ...
🤷   Description for the project?: fff
[1/3]   Done: Cargo.toml                                                                                                                                                                            [2/3]   Done: src/lib.rs                                                                                                                                                                            [3/3]   Done: src                                                                                                                                                                                   🔧   Moving generated files into: `/home/abizjak/Private/Documents/Concordium/concordium-smart-contract-tools/cargo-concordium/foo/./ff`...
💡   Initializing a fresh Git repository
✨   Done! New project created ./ff
Created the smart contract template.
```

When using
```
            "--branch",
            "bump-cargo-generate",
```
as extra arguments to cargo-generate.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
