### PR TITLE
Handle unification of parameter and module reference types

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -12,7 +12,7 @@
   - Migrate from `parameter.0`: use `parameter.into()` instead (for both of the affected
     types).
 - For `ModuleReference`, replace `AsRef<[u8;32]>` with `AsRef<[u8]>` and make
-  inner bytes public.
+  inner `bytes` field public.
   - The change was necessary for internal reasons.
   - Migrate from `module_reference.as_ref()`: use `&module_reference.bytes` instead.
 

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -15,6 +15,12 @@
   inner `bytes` field public.
   - The change was necessary for internal reasons.
   - Migrate from `module_reference.as_ref()`: use `&module_reference.bytes` instead.
+- Replace `OwnedParameter::new` with `OwnedParameter::from_serial`, which also
+  ensures a valid length.
+  - Migrate from `new(x)`: Use `from_serial(x).unwrap()` (if known to be valid length).
+- Add an `empty` method for both `OwnedParameter` and `Parameter`.
+- Implement `Default` for `Parameter`.
+
 
 ## concordium-std 6.0.1 (2023-02-28)
 

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
 ## Unreleased changes
+- Add `Display` implementation for `OwnedParameter` and `Parameter`, which uses
+  hex encoding.
+- Replace `From<Vec<u8>>` instance for `OwnedParameter`/`Parameter` with a `TryFrom`,
+  which ensures a valid length, and the unchecked method `new_unchecked`.
+  - Migrate from `From`/`Into`: Use `new_unchecked` instead (if known to be
+    valid length).
+- Make inner field in `OwnedParameter`/`Parameter` private, but add a `From`
+  implementation for getting the raw bytes.
+  - Migrate from `parameter.0`: use `parameter.into()` instead (for both of the affected
+    types).
+- For `ModuleReference`, replace `AsRef<[u8;32]>` with `AsRef<[u8]>` and make
+  inner bytes public.
+  - The change was necessary for internal reasons.
+  - Migrate from `module_reference.as_ref()`: use `&module_reference.bytes` instead.
 
 ## concordium-std 6.0.1 (2023-02-28)
 

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -2027,7 +2027,8 @@ fn invoke_contract_construct_parameter(
     method: EntrypointName,
     amount: Amount,
 ) -> Vec<u8> {
-    let mut data = Vec::with_capacity(16 + parameter.0.len() + 2 + method.size() as usize + 2 + 8);
+    let mut data =
+        Vec::with_capacity(16 + parameter.as_ref().len() + 2 + method.size() as usize + 2 + 8);
     let mut cursor = Cursor::new(&mut data);
     to.serial(&mut cursor).unwrap_abort();
     parameter.serial(&mut cursor).unwrap_abort();

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -1943,7 +1943,7 @@ mod test {
 
         host.invoke_contract_raw(
             &other_address,
-            Parameter::new_unchecked(&[]),
+            Parameter::empty(),
             entrypoint.as_entrypoint_name(),
             Amount::from_micro_ccd(1000),
         )

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -1943,7 +1943,7 @@ mod test {
 
         host.invoke_contract_raw(
             &other_address,
-            Parameter(&[]),
+            Parameter::new_unchecked(&[]),
             entrypoint.as_entrypoint_name(),
             Amount::from_micro_ccd(1000),
         )

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -284,7 +284,7 @@ pub trait HasHost<State>: Sized {
         amount: Amount,
     ) -> CallContractResult<Self::ReturnValueType> {
         let param = to_bytes(parameter);
-        self.invoke_contract_raw(to, Parameter(&param), method, amount)
+        self.invoke_contract_raw(to, Parameter::new_unchecked(&param), method, amount)
     }
 
     /// Upgrade the module for this instance to a given module. The new module
@@ -354,7 +354,7 @@ pub trait HasHost<State>: Sized {
         amount: Amount,
     ) -> ReadOnlyCallContractResult<Self::ReturnValueType> {
         let param = to_bytes(parameter);
-        self.invoke_contract_raw_read_only(to, Parameter(&param), method, amount)
+        self.invoke_contract_raw_read_only(to, Parameter::new_unchecked(&param), method, amount)
     }
 
     /// Get the current exchange rates used by the chain. That is a Euro per

--- a/examples/fib/src/lib.rs
+++ b/examples/fib/src/lib.rs
@@ -36,7 +36,7 @@ fn contract_receive<StateApi: HasStateApi>(
         let mut n2 = host
             .invoke_contract_raw(
                 &self_address,
-                Parameter(&(n - 2).to_le_bytes()[..]),
+                Parameter::new_unchecked(&(n - 2).to_le_bytes()[..]),
                 EntrypointName::new_unchecked("receive"),
                 Amount::zero(),
             )
@@ -49,7 +49,7 @@ fn contract_receive<StateApi: HasStateApi>(
         let mut n1 = host
             .invoke_contract_raw(
                 &self_address,
-                Parameter(&(n - 1).to_le_bytes()[..]),
+                Parameter::new_unchecked(&(n - 1).to_le_bytes()[..]),
                 EntrypointName::new_unchecked("receive"),
                 Amount::zero(),
             )
@@ -114,7 +114,7 @@ mod tests {
             contract_address,
             OwnedEntrypointName::new_unchecked("receive".into()),
             MockFn::new_v1(|parameter, _amount, _balance, state: &mut State| {
-                let n: u64 = match from_bytes(parameter.0) {
+                let n: u64 = match from_bytes(parameter.into()) {
                     Ok(n) => n,
                     Err(_) => return Err(CallContractError::Trap),
                 };

--- a/examples/icecream/src/lib.rs
+++ b/examples/icecream/src/lib.rs
@@ -100,7 +100,7 @@ fn contract_buy_icecream<S: HasStateApi>(
     let weather = host
         .invoke_contract_raw(
             &weather_service,
-            Parameter::new_unchecked(&[]),
+            Parameter::empty(),
             EntrypointName::new_unchecked("get"),
             Amount::zero(),
         )?

--- a/examples/icecream/src/lib.rs
+++ b/examples/icecream/src/lib.rs
@@ -100,7 +100,7 @@ fn contract_buy_icecream<S: HasStateApi>(
     let weather = host
         .invoke_contract_raw(
             &weather_service,
-            Parameter(&[]),
+            Parameter::new_unchecked(&[]),
             EntrypointName::new_unchecked("get"),
             Amount::zero(),
         )?

--- a/examples/proxy/src/lib.rs
+++ b/examples/proxy/src/lib.rs
@@ -59,7 +59,8 @@ fn receive_fallback<S: HasStateApi>(
     let return_value = host
         .invoke_contract_raw(
             &proxied_contract,
-            Parameter(&parameter_buffer[..]),
+            // The parameter size must be valid since this receive function has been executed.
+            Parameter::new_unchecked(&parameter_buffer[..]),
             entrypoint.as_entrypoint_name(),
             amount,
         )?
@@ -110,7 +111,7 @@ mod tests {
             proxied_contract,
             proxied_entrypoint,
             MockFn::new_v1(|parameter, _, &mut _, &mut _| {
-                let mut rv = parameter.0.to_vec();
+                let mut rv = Into::<&[u8]>::into(parameter).to_vec();
                 rv.extend_from_slice(b", world!");
                 Ok((false, RawReturnValue(Some(rv))))
             }),


### PR DESCRIPTION
## Purpose

Handle unification of parameter and module reference types (https://github.com/Concordium/concordium-contracts-common/pull/73)

Depends on:
- https://github.com/Concordium/concordium-contracts-common/pull/73
- https://github.com/Concordium/concordium-contracts-common/pull/75

## Changes

- Describe changes in changelog.
- Update examples and libraries to the new API.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
