### PR TITLE
Added StateBuilder::new_state_container

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -20,6 +20,8 @@
   - Migrate from `new(x)`: Use `from_serial(x).unwrap()` (if known to be valid length).
 - Add an `empty` method for both `OwnedParameter` and `Parameter`.
 - Implement `Default` for `Parameter`.
+- Add `StateBuilder::new_state_container` method which allows contract developers to use
+  their own container types atop blockchain storage
 
 
 ## concordium-std 6.0.1 (2023-02-28)

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -2108,7 +2108,7 @@ where
     /// * Object which gives access to low-level storage API. Same as the one
     ///   held by [`StateBuilder`] itself and usually the one which refers to
     ///   current contract storage.
-    /// * New unique key prefix for this container
+    /// * New unique key prefix for this container.
     #[must_use]
     pub fn new_state_container(&mut self) -> (S, [u8; 8]) {
         (self.state_api.clone(), self.get_and_update_item_prefix())

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -2084,10 +2084,32 @@ where
     }
 
     /// Provide clone of [`HasStateApi`] instance and new key prefix
-    /// for any container-like type wishing to store its data on blockchain
+    /// for any container-like type wishing to store its data on blockchain.
     ///
-    /// Contract developers can use this method to implement their own
-    /// containers
+    /// Container types [`StateBox`], [`StateSet`], [`StateMap`] provided by
+    /// Concordium SDK are created using this method internally.
+    /// Contract developers can use it to implement their own
+    /// containers.
+    ///
+    /// Any container type which provides more ergonomic APIs and behavior atop
+    /// raw storage is expected to have two items:
+    /// * Handle-like object which implements [`HasStateApi`]. It provides
+    ///   access to contract VM features, including storage management. This
+    ///   object is not serialized, instead it's provided by executon
+    ///   environment. Can be treated as handle, relatively cheap to clone.
+    /// * Prefix for keys of all entries managed by new container. Storage of
+    ///   Concordium contract behaves like flat key-value dictionary, so each
+    ///   container must have unique prefix for the keys of any entries it
+    ///   stores to avoid collisions with other containers. This prefix is
+    ///   serialized as (part of) persistent representation of container.
+    ///
+    /// # Returns
+    /// A pair of:
+    /// * Object which gives access to low-level storage API. Same as the one
+    ///   held by [`StateBuilder`] itself and usually the one which refers to
+    ///   current contract storage.
+    /// * New unique key prefix for this container
+    #[must_use]
     pub fn new_state_container(&mut self) -> (S, [u8; 8]) {
         (self.state_api.clone(), self.get_and_update_item_prefix())
     }


### PR DESCRIPTION
## Purpose

Adds `StateBuilder::new_state_container` method which allows contract developers create their own container-like types atop storage

## Changes

* Added method `StateBuilder::new_state_container` which returns clone of inner state API instance and new storage prefix for container
* Methods `new_box`, `new_set`, `new_map` now use `new_state_container` for consistency

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
