### PR TITLE
Move `ExchangeRates` to contracts-common

### DIFF
--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -2896,46 +2896,6 @@ impl Deserial for HashKeccak256 {
     }
 }
 
-impl Serial for ExchangeRates {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        self.euro_per_energy.serial(out)?;
-        self.micro_ccd_per_euro.serial(out)?;
-        Ok(())
-    }
-}
-
-impl Deserial for ExchangeRates {
-    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
-        let bytes: [u8; 32] = source.read_array()?;
-        let chunks = unsafe { mem::transmute::<[u8; 32], [[u8; 8]; 4]>(bytes) };
-
-        let euro_per_energy_numerator = u64::from_le_bytes(chunks[0]);
-        let euro_per_energy_denominator = u64::from_le_bytes(chunks[1]);
-        let micro_ccd_per_euro_numerator = u64::from_le_bytes(chunks[2]);
-        let micro_ccd_per_euro_denominator = u64::from_le_bytes(chunks[3]);
-
-        if euro_per_energy_numerator == 0
-            || euro_per_energy_denominator == 0
-            || micro_ccd_per_euro_numerator == 0
-            || micro_ccd_per_euro_denominator == 0
-        {
-            return Err(ParseError::default());
-        }
-
-        let euro_per_energy =
-            ExchangeRate::new_unchecked(euro_per_energy_numerator, euro_per_energy_denominator);
-        let micro_ccd_per_euro = ExchangeRate::new_unchecked(
-            micro_ccd_per_euro_numerator,
-            micro_ccd_per_euro_denominator,
-        );
-
-        Ok(Self {
-            euro_per_energy,
-            micro_ccd_per_euro,
-        })
-    }
-}
-
 impl schema::SchemaType for HashKeccak256 {
     fn get_type() -> concordium_contracts_common::schema::Type { schema::Type::ByteArray(32) }
 }

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -1,7 +1,9 @@
 use crate::{
     cell::UnsafeCell, marker::PhantomData, num::NonZeroU32, Cursor, HasStateApi, Serial, Vec,
 };
-use concordium_contracts_common::{AccountBalance, Amount, ExchangeRate};
+use concordium_contracts_common::{AccountBalance, Amount};
+// Re-export for backward compatibility.
+pub use concordium_contracts_common::ExchangeRates;
 
 #[derive(Debug)]
 /// A high-level map based on the low-level key-value store, which is the
@@ -580,37 +582,6 @@ impl ExternCallResponse {
 /// serialize values into.
 pub struct ExternReturnValue {
     pub(crate) current_position: u32,
-}
-
-/// The current exchange rates.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ExchangeRates {
-    /// Euro per NRG exchange rate.
-    pub euro_per_energy:    ExchangeRate,
-    /// Micro CCD per Euro exchange rate.
-    pub micro_ccd_per_euro: ExchangeRate,
-}
-
-impl ExchangeRates {
-    /// Convert Euro cent to CCD using the current exchange rate.
-    /// This will round down to the nearest micro CCD.
-    pub fn convert_euro_cent_to_amount(&self, euro_cent: u64) -> Amount {
-        let numerator: u128 = self.micro_ccd_per_euro.numerator().into();
-        let denominator: u128 = self.micro_ccd_per_euro.denominator().into();
-        let euro_cent: u128 = euro_cent.into();
-        let result = numerator * euro_cent / (denominator * 100);
-        Amount::from_micro_ccd(result as u64)
-    }
-
-    /// Convert CCD to Euro cent using the current exchange rate.
-    /// This will round down to the nearest Euro cent.
-    pub fn convert_amount_to_euro_cent(&self, amount: Amount) -> u64 {
-        let numerator: u128 = self.micro_ccd_per_euro.numerator().into();
-        let denominator: u128 = self.micro_ccd_per_euro.denominator().into();
-        let micro_ccd: u128 = amount.micro_ccd().into();
-        let result = micro_ccd * 100 * denominator / numerator;
-        result as u64
-    }
 }
 
 #[repr(i32)]


### PR DESCRIPTION
## Purpose

Move the `ExchangeRates` type to common as it is also needed in the contract integration testing library.

Depends on:
- https://github.com/Concordium/concordium-contracts-common/pull/78

## Changes

- Move the types and impls.
- Re-export from common for backward compatibility.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.