### PR TITLE
Add NonceEvent

### DIFF
--- a/examples/cis3-nft-sponsored-txs/src/lib.rs
+++ b/examples/cis3-nft-sponsored-txs/src/lib.rs
@@ -84,7 +84,7 @@ pub const REGISTRATION_EVENT_TAG: u8 = 0u8;
 pub const NONCE_EVENT_TAG: u8 = u8::MAX - 5;
 
 /// Tagged events to be serialized for the event log.
-#[derive(Debug, Serial)]
+#[derive(Debug)]
 enum Event {
     /// Registration of a public key for a given account. The
     /// corresponding private key will have to sign the message that
@@ -195,6 +195,21 @@ impl schema::SchemaType for Event {
             ),
         );
         schema::Type::TaggedEnum(event_map)
+    }
+}
+
+impl Serial for Event {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        match self {
+            Event::Registration(event) => {
+                out.write_u8(REGISTRATION_EVENT_TAG)?;
+                event.serial(out)
+            }
+            Event::Nonce(event) => {
+                out.write_u8(NONCE_EVENT_TAG)?;
+                event.serial(out)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Purpose

- Add NonceEvent
- Bump nonce at the end. This allows the front-end to use the current nonce it queries from the smart contract (without having to increase it by 1) to create the permitMessage.
- Improve comments about the signing and message generation based on feedback and questions got from people.
