### PR TITLE
Reexport quickcheck

### DIFF
--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -298,4 +298,7 @@ pub use types::*;
 #[cfg_attr(feature = "wee_alloc", global_allocator)]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
+#[cfg(feature = "concordium-quickcheck")]
+pub use quickcheck;
+
 pub mod test_infrastructure;


### PR DESCRIPTION
## Purpose

Make `quickcheck` available when writing property based tests. This is useful for defining `Arbitrary` instances for custom data types in smart contracts.