### PR TITLE
Add viewMessageHash function

### DIFF
--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -1036,13 +1036,10 @@ impl FromStr for PublicKeyEd25519 {
             return Err(ParseError {});
         }
 
-        let public_key: [u8; 32] = (0..s.len())
-            .step_by(2)
-            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
-            .collect::<Vec<u8>>()
-            .as_slice()
-            .try_into()
-            .unwrap();
+        let mut public_key: [u8; 32] = [0u8; 32];
+        for (i, place) in public_key.iter_mut().enumerate() {
+            *place = u8::from_str_radix(&s[2 * i..2 * i + 2], 16).map_err(|_| ParseError {})?;
+        }
 
         Ok(PublicKeyEd25519(public_key))
     }
@@ -1070,13 +1067,10 @@ impl FromStr for PublicKeyEcdsaSecp256k1 {
             return Err(ParseError {});
         }
 
-        let public_key: [u8; 33] = (0..s.len())
-            .step_by(2)
-            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
-            .collect::<Vec<u8>>()
-            .as_slice()
-            .try_into()
-            .unwrap();
+        let mut public_key: [u8; 33] = [0u8; 33];
+        for (i, place) in public_key.iter_mut().enumerate() {
+            *place = u8::from_str_radix(&s[2 * i..2 * i + 2], 16).map_err(|_| ParseError {})?;
+        }
 
         Ok(PublicKeyEcdsaSecp256k1(public_key))
     }
@@ -1104,13 +1098,10 @@ impl FromStr for SignatureEd25519 {
             return Err(ParseError {});
         }
 
-        let signature: [u8; 64] = (0..s.len())
-            .step_by(2)
-            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
-            .collect::<Vec<u8>>()
-            .as_slice()
-            .try_into()
-            .unwrap();
+        let mut signature: [u8; 64] = [0u8; 64];
+        for (i, place) in signature.iter_mut().enumerate() {
+            *place = u8::from_str_radix(&s[2 * i..2 * i + 2], 16).map_err(|_| ParseError {})?;
+        }
 
         Ok(SignatureEd25519(signature))
     }
@@ -1139,13 +1130,10 @@ impl FromStr for SignatureEcdsaSecp256k1 {
             return Err(ParseError {});
         }
 
-        let signature: [u8; 64] = (0..s.len())
-            .step_by(2)
-            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
-            .collect::<Vec<u8>>()
-            .as_slice()
-            .try_into()
-            .unwrap();
+        let mut signature: [u8; 64] = [0u8; 64];
+        for (i, place) in signature.iter_mut().enumerate() {
+            *place = u8::from_str_radix(&s[2 * i..2 * i + 2], 16).map_err(|_| ParseError {})?;
+        }
 
         Ok(SignatureEcdsaSecp256k1(signature))
     }
@@ -1173,13 +1161,10 @@ impl FromStr for HashSha2256 {
             return Err(ParseError {});
         }
 
-        let hash: [u8; 32] = (0..s.len())
-            .step_by(2)
-            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
-            .collect::<Vec<u8>>()
-            .as_slice()
-            .try_into()
-            .unwrap();
+        let mut hash: [u8; 32] = [0u8; 32];
+        for (i, place) in hash.iter_mut().enumerate() {
+            *place = u8::from_str_radix(&s[2 * i..2 * i + 2], 16).map_err(|_| ParseError {})?;
+        }
 
         Ok(HashSha2256(hash))
     }

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -1,7 +1,8 @@
 use crate::{
     cell::UnsafeCell, marker::PhantomData, num::NonZeroU32, Cursor, HasStateApi, Serial, Vec,
 };
-use concordium_contracts_common::{AccountBalance, Amount};
+use concordium_contracts_common::{AccountBalance, Amount, ParseError};
+use core::{fmt, str::FromStr};
 // Re-export for backward compatibility.
 pub use concordium_contracts_common::ExchangeRates;
 
@@ -1018,15 +1019,102 @@ pub struct ExternCryptoPrimitives;
 #[repr(transparent)]
 pub struct PublicKeyEd25519(pub [u8; 32]);
 
+impl std::fmt::Display for PublicKeyEd25519 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0 {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for PublicKeyEd25519 {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() != 64 {
+            return Err(ParseError {});
+        }
+
+        let public_key: [u8; 32] = (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+            .collect::<Vec<u8>>()
+            .as_slice()
+            .try_into()
+            .unwrap();
+
+        Ok(PublicKeyEd25519(public_key))
+    }
+}
+
 /// Public key for ECDSA over Secp256k1. Must be 33 bytes long.
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 #[repr(transparent)]
 pub struct PublicKeyEcdsaSecp256k1(pub [u8; 33]);
 
+impl std::fmt::Display for PublicKeyEcdsaSecp256k1 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0 {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for PublicKeyEcdsaSecp256k1 {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() != 66 {
+            return Err(ParseError {});
+        }
+
+        let public_key: [u8; 33] = (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+            .collect::<Vec<u8>>()
+            .as_slice()
+            .try_into()
+            .unwrap();
+
+        Ok(PublicKeyEcdsaSecp256k1(public_key))
+    }
+}
+
 /// Signature for a Ed25519 message. Must be 64 bytes long.
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 #[repr(transparent)]
 pub struct SignatureEd25519(pub [u8; 64]);
+
+impl std::fmt::Display for SignatureEd25519 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0 {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for SignatureEd25519 {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() != 128 {
+            return Err(ParseError {});
+        }
+
+        let signature: [u8; 64] = (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+            .collect::<Vec<u8>>()
+            .as_slice()
+            .try_into()
+            .unwrap();
+
+        Ok(SignatureEd25519(signature))
+    }
+}
 
 /// Signature for a ECDSA (over Secp256k1) message. Must be 64 bytes longs
 /// (serialized in compressed format).
@@ -1034,10 +1122,68 @@ pub struct SignatureEd25519(pub [u8; 64]);
 #[repr(transparent)]
 pub struct SignatureEcdsaSecp256k1(pub [u8; 64]);
 
+impl std::fmt::Display for SignatureEcdsaSecp256k1 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0 {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for SignatureEcdsaSecp256k1 {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() != 128 {
+            return Err(ParseError {});
+        }
+
+        let signature: [u8; 64] = (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+            .collect::<Vec<u8>>()
+            .as_slice()
+            .try_into()
+            .unwrap();
+
+        Ok(SignatureEcdsaSecp256k1(signature))
+    }
+}
+
 /// Sha2 digest with 256 bits (32 bytes).
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 #[repr(transparent)]
 pub struct HashSha2256(pub [u8; 32]);
+
+impl std::fmt::Display for HashSha2256 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in self.0 {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for HashSha2256 {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.len() != 64 {
+            return Err(ParseError {});
+        }
+
+        let hash: [u8; 32] = (0..s.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+            .collect::<Vec<u8>>()
+            .as_slice()
+            .try_into()
+            .unwrap();
+
+        Ok(HashSha2256(hash))
+    }
+}
 
 /// Sha3 digest with 256 bits (32 bytes).
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -1019,7 +1019,7 @@ pub struct ExternCryptoPrimitives;
 #[repr(transparent)]
 pub struct PublicKeyEd25519(pub [u8; 32]);
 
-impl std::fmt::Display for PublicKeyEd25519 {
+impl fmt::Display for PublicKeyEd25519 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for b in self.0 {
             write!(f, "{:02x}", b)?;
@@ -1053,7 +1053,7 @@ impl FromStr for PublicKeyEd25519 {
 #[repr(transparent)]
 pub struct PublicKeyEcdsaSecp256k1(pub [u8; 33]);
 
-impl std::fmt::Display for PublicKeyEcdsaSecp256k1 {
+impl fmt::Display for PublicKeyEcdsaSecp256k1 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for b in self.0 {
             write!(f, "{:02x}", b)?;
@@ -1087,7 +1087,7 @@ impl FromStr for PublicKeyEcdsaSecp256k1 {
 #[repr(transparent)]
 pub struct SignatureEd25519(pub [u8; 64]);
 
-impl std::fmt::Display for SignatureEd25519 {
+impl fmt::Display for SignatureEd25519 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for b in self.0 {
             write!(f, "{:02x}", b)?;
@@ -1122,7 +1122,7 @@ impl FromStr for SignatureEd25519 {
 #[repr(transparent)]
 pub struct SignatureEcdsaSecp256k1(pub [u8; 64]);
 
-impl std::fmt::Display for SignatureEcdsaSecp256k1 {
+impl fmt::Display for SignatureEcdsaSecp256k1 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for b in self.0 {
             write!(f, "{:02x}", b)?;
@@ -1156,7 +1156,7 @@ impl FromStr for SignatureEcdsaSecp256k1 {
 #[repr(transparent)]
 pub struct HashSha2256(pub [u8; 32]);
 
-impl std::fmt::Display for HashSha2256 {
+impl fmt::Display for HashSha2256 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for b in self.0 {
             write!(f, "{:02x}", b)?;

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,3 +32,5 @@ The list of contracts is as follows
 - [voting](./voting) An example of how to conduct an election using a smart contract.
 - [transfer-policy-check](./transfer-policy-check) A contract that showcases how to use policies.
 - [eSealing](./eSealing) A contract implementing an eSealing service.
+- [sponsoredTransactions](./cis3-nft-sponsored-txs) A contract implementing the sponsored transaction mechanism (CIS3 standard).
+

--- a/examples/cis3-nft-sponsored-txs/src/lib.rs
+++ b/examples/cis3-nft-sponsored-txs/src/lib.rs
@@ -846,12 +846,12 @@ fn contract_view_message_hash<S: HasStateApi>(
     // Parse the parameter.
     let mut cursor = ctx.parameter_cursor();
     // The input parameter is `PermitParam` but we only read the initial part of it
-    // with `PermitParamPartial`. I.e. we only read the `signature`, the
-    // `signer` but WITHOUT the `message` here.
+    // with `PermitParamPartial`. I.e. we read the `signature` and the
+    // `signer`, but not the `message` here.
     let param: PermitParamPartial = cursor.get()?;
 
-    // The input parameter is `PermitParam` but we only read the initial part of it
-    // with `PermitParamPartial` so far. We read in the `message` now.
+    // The input parameter is `PermitParam` but we have only read the initial part
+    // of it with `PermitParamPartial` so far. We read in the `message` now.
     // `(cursor.size() - cursor.cursor_position()` is the length of the message in
     // bytes.
     let mut message_bytes = vec![0; (cursor.size() - cursor.cursor_position()) as usize];

--- a/examples/cis3-nft-sponsored-txs/src/lib.rs
+++ b/examples/cis3-nft-sponsored-txs/src/lib.rs
@@ -859,7 +859,12 @@ fn contract_view_message_hash<S: HasStateApi>(
     cursor.read_exact(&mut message_bytes)?;
 
     // The message signed in the Concordium browser wallet is prepended with the
-    // `account` address and 8 zero bytes.
+    // `account` address and 8 zero bytes. Accounts in the Concordium browser wallet
+    // can either sign a regular transaction (in that case the prepend is
+    // `account` address and the nonce of the account which is by design >= 1)
+    // or sign a message (in that case the prepend is `account` address and 8 zero
+    // bytes). Hence, the 8 zero bytes ensure that the user does not accidentally
+    // sign a transaction. The account nonce is of type u64 (8 bytes).
     let mut msg_prepend = vec![0; 32 + 8];
     // Prepend the `account` address of the signer.
     msg_prepend[0..32].copy_from_slice(param.signer.as_ref());

--- a/examples/proxy/Cargo.toml
+++ b/examples/proxy/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2021"
 license = "MPL-2.0"
-license-file = "../../../LICENSE-MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/two-step-transfer/Cargo.toml
+++ b/examples/two-step-transfer/Cargo.toml
@@ -19,11 +19,11 @@ wee_alloc = ["concordium-std/wee_alloc"]
 version = "6"
 path = "../../concordium-std"
 default-features = false
+features = ["concordium-quickcheck"]
 
 [dev-dependencies.concordium-std]
 version = "6"
 path = "../../concordium-std"
-features = ["concordium-quickcheck"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
## Purpose

Improvements and fixes.


## Changes

- Add `viewMessageHash` helper function.
- Add Display + FromStr Trait to PublicKeyEd25519/PublicKeyEcdsaSecp256k1/SignatureEd25519/SignatureEcdsaSecp256k1/HashSha2256 types.

- Fix `cargo clippy warning`: calling `set_len()` immediately after reserving a buffer creates uninitialized values
https://rust-lang.github.io/rust-clippy/master/index.html#uninit_vec.
- Fix warning of duplicated licence field in `proxy` example.
- Fix `two-step-transfer` example dependency: `concordium-quickcheck` needs to be a `dependency` (not `dev_dependency`) otherwise `cargo concordium test` will not run.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
