### PR TITLE
Remove alloc_error_handler to be able to use recent nightly compilers.

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Add `write_root` helper function to write the root of the state trie. This is
   useful in migrations when upgrading smart contracts.
 - Bump Rust edition to `2021`.
+- Remove the use of `alloc_error_handler` since the feature is no longer
+  available in recent nightly builds of the compiler. This can increase the
+  smart contract size slightly.
 
 ## concordium-std 6.1.1 (2023-03-16)
 

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -210,21 +210,10 @@
 //! [1]: https://doc.rust-lang.org/std/primitive.unit.html
 //! Other error codes may be added in the future and custom error codes should
 //! not use the range `i32::MIN` to `i32::MIN + 100`.
-#![cfg_attr(not(feature = "std"), no_std, feature(alloc_error_handler, core_intrinsics))]
+#![cfg_attr(not(feature = "std"), no_std, feature(core_intrinsics))]
 
 #[cfg(not(feature = "std"))]
 pub extern crate alloc;
-
-#[cfg(not(feature = "std"))]
-#[alloc_error_handler]
-fn on_oom(_layout: alloc::alloc::Layout) -> ! {
-    #[cfg(target_arch = "wasm32")]
-    unsafe {
-        core::arch::wasm32::unreachable()
-    }
-    #[cfg(not(target_arch = "wasm32"))]
-    loop {}
-}
 
 /// Terminate execution immediately without panicking.
 /// When the `std` feature is enabled this is just [std::process::abort](https://doc.rust-lang.org/std/process/fn.abort.html).

--- a/examples/cis3-nft-sponsored-txs/Cargo.toml
+++ b/examples/cis3-nft-sponsored-txs/Cargo.toml
@@ -19,5 +19,6 @@ concordium-cis2 = {path = "../../concordium-cis2", default-features = false}
 crate-type=["cdylib", "rlib"]
 
 [profile.release]
+panic = "abort"
 opt-level = "s"
 codegen-units = 1

--- a/examples/cis3-nft-sponsored-txs/src/lib.rs
+++ b/examples/cis3-nft-sponsored-txs/src/lib.rs
@@ -709,7 +709,7 @@ fn contract_mint<S: HasStateApi>(
 
     // Check that max token_id is not reached.
     ensure!(
-        token_id != concordium_cis2::TokenIdU32(std::u32::MAX),
+        token_id != concordium_cis2::TokenIdU32(u32::MAX),
         CustomContractError::MaxTokenID.into()
     );
 


### PR DESCRIPTION
## Purpose

Remove the use of alloc_error_handler to be able to use recent nightly compilers.

This makes some contracts a bit larger (cis3 is around 800B larger). The sc-writer can still enable this if they so wish.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
