### PR TITLE
Added schema for the view function's return value in piggybank contract

### DIFF
--- a/examples/piggy-bank/part1/src/lib.rs
+++ b/examples/piggy-bank/part1/src/lib.rs
@@ -17,13 +17,17 @@
 use concordium_std::*;
 
 /// The state of the piggy bank
-#[derive(Debug, Serialize, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, SchemaType, Serialize, PartialEq, Eq, Clone, Copy)]
 enum PiggyBankState {
     /// Alive and well, allows for CCD to be inserted.
     Intact,
     /// The piggy bank has been emptied, preventing further CCD to be inserted.
     Smashed,
 }
+
+/// The return type of the view function
+#[derive(Debug, SchemaType, Serialize, Clone, Copy)]
+struct ViewState(PiggyBankState, Amount);
 
 /// Setup a new Intact piggy bank.
 #[init(contract = "PiggyBank")]
@@ -74,12 +78,12 @@ fn piggy_smash<S: HasStateApi>(
 }
 
 /// View the state and balance of the piggy bank.
-#[receive(contract = "PiggyBank", name = "view")]
+#[receive(contract = "PiggyBank", name = "view", return_value = "ViewState")]
 fn piggy_view<S: HasStateApi>(
     _ctx: &impl HasReceiveContext,
     host: &impl HasHost<PiggyBankState, StateApiType = S>,
-) -> ReceiveResult<(PiggyBankState, Amount)> {
+) -> ReceiveResult<ViewState> {
     let current_state = *host.state();
     let current_balance = host.self_balance();
-    Ok((current_state, current_balance))
+    Ok(ViewState(current_state, current_balance))
 }

--- a/examples/piggy-bank/part1/src/lib.rs
+++ b/examples/piggy-bank/part1/src/lib.rs
@@ -25,10 +25,6 @@ enum PiggyBankState {
     Smashed,
 }
 
-/// The return type of the view function
-#[derive(Debug, SchemaType, Serialize, Clone, Copy)]
-struct ViewState(PiggyBankState, Amount);
-
 /// Setup a new Intact piggy bank.
 #[init(contract = "PiggyBank")]
 fn piggy_init<S: HasStateApi>(
@@ -78,12 +74,12 @@ fn piggy_smash<S: HasStateApi>(
 }
 
 /// View the state and balance of the piggy bank.
-#[receive(contract = "PiggyBank", name = "view", return_value = "ViewState")]
+#[receive(contract = "PiggyBank", name = "view", return_value = "(PiggyBankState, Amount)")]
 fn piggy_view<S: HasStateApi>(
     _ctx: &impl HasReceiveContext,
     host: &impl HasHost<PiggyBankState, StateApiType = S>,
-) -> ReceiveResult<ViewState> {
+) -> ReceiveResult<(PiggyBankState, Amount)> {
     let current_state = *host.state();
     let current_balance = host.self_balance();
-    Ok(ViewState(current_state, current_balance))
+    Ok((current_state, current_balance))
 }

--- a/examples/piggy-bank/part2/src/lib.rs
+++ b/examples/piggy-bank/part2/src/lib.rs
@@ -27,10 +27,6 @@ enum PiggyBankState {
     Smashed,
 }
 
-/// The return type of the view function
-#[derive(Debug, SchemaType, Serialize, PartialEq, Eq, Clone, Copy)]
-struct ViewState(PiggyBankState, Amount);
-
 /// Setup a new Intact piggy bank.
 #[init(contract = "PiggyBank")]
 fn piggy_init<S: HasStateApi>(
@@ -93,14 +89,14 @@ fn piggy_smash<S: HasStateApi>(
 }
 
 /// View the state and balance of the piggy bank.
-#[receive(contract = "PiggyBank", name = "view", return_value = "ViewState")]
+#[receive(contract = "PiggyBank", name = "view", return_value = "(PiggyBankState, Amount)")]
 fn piggy_view<S: HasStateApi>(
     _ctx: &impl HasReceiveContext,
     host: &impl HasHost<PiggyBankState, StateApiType = S>,
-) -> ReceiveResult<ViewState> {
+) -> ReceiveResult<(PiggyBankState, Amount)> {
     let current_state = *host.state();
     let current_balance = host.self_balance();
-    Ok(ViewState(current_state, current_balance))
+    Ok((current_state, current_balance))
 }
 
 // Unit tests for the smart contract "PiggyBank"
@@ -273,6 +269,6 @@ mod tests {
         let result = piggy_view(&ctx, &host);
 
         // Check the result.
-        claim_eq!(result, Ok(ViewState(PiggyBankState::Intact, self_balance)));
+        claim_eq!(result, Ok((PiggyBankState::Intact, self_balance)));
     }
 }


### PR DESCRIPTION
## Purpose & Changes

I specified a return type PiggyBank smart contract's view function so that a schema can be generated. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.