### PR TITLE
Derive PartialEq and Eq for cis2 MetadataUrl

### DIFF
--- a/concordium-cis2/CHANGELOG.md
+++ b/concordium-cis2/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Derive `PartialEq` and `Eq` for the `MetadataUrl` from the CIS2 library.
+
 ## concordium-cis2 3.0.0 (2023-02-08)
 
 - Update `concordium-std` to version 6.

--- a/concordium-cis2/src/lib.rs
+++ b/concordium-cis2/src/lib.rs
@@ -68,7 +68,7 @@ pub type Sha256 = [u8; 32];
 /// The location of the metadata and an optional hash of the content.
 // Note: For the serialization to be derived according to the CIS2
 // specification, the order of the fields cannot be changed.
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, PartialEq, Eq, Clone)]
 pub struct MetadataUrl {
     /// The URL following the specification RFC1738.
     #[concordium(size_length = 2)]


### PR DESCRIPTION
## Purpose

Derive missing `PartialEq` and `Eq`  for the `MetadataUrl` from the CIS2 library.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
