### PR TITLE
Update CCC dependency

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,6 +10,11 @@ on:
 
 name: Clippy & fmt
 
+env:
+  RUST_FMT: nightly-2023-04-01
+  RUST_VERSION: "1.60"
+
+
 jobs:
   rustfmt:
     name: Format
@@ -49,7 +54,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-06-09
+          toolchain: ${{ env.RUST_FMT }}
           override: true
           components: rustfmt
 
@@ -135,7 +140,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
           override: true
           components: clippy
@@ -221,7 +226,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
           override: true
           components: clippy
@@ -261,7 +266,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
           override: true
           components: clippy
@@ -298,7 +303,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
           override: true
           components: clippy
@@ -338,7 +343,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
           override: true
           components: clippy
@@ -450,7 +455,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
           override: true
 
@@ -499,7 +504,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
           override: true
           components: clippy
@@ -536,7 +541,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
           override: true
 
@@ -572,7 +577,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
           override: true
 
@@ -623,7 +628,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.56
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.target }}
           override: true
 

--- a/README.md
+++ b/README.md
@@ -51,16 +51,16 @@ Changes to any of the packages must be such that
 - ```cargo clippy --all``` produces no warnings
 - ```rustfmt``` makes no changes.
 
-Everything in this repository should build with rust version 1.53 (it should work with 1.51 and up, but we do not test regularly) however the `fmt` tool must be from a nightly release since some of the configuration options are not stable. One way to run the `fmt` tool is
+Everything in this repository should build with rust version 1.60 however the `fmt` tool must be from a nightly release since some of the configuration options are not stable. One way to run the `fmt` tool is
 ```
-cargo +nightly-2022-06-09 fmt
+cargo +nightly-2023-04-01 fmt
 ```
 
 (the exact version used by the CI can be found in [.github/workflows/linter.yml](.github/workflows/linter.yml) file).
 You will need to have a recent enough nightly version installed, which can be done via
 
 ```
-rustup toolchain install nightly-2022-06-09
+rustup toolchain install nightly-2023-04-01
 ```
 
 or similar, using the [rustup](https://rustup.rs/) tool. See the documentation of the tool for more details.

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Remove the use of `alloc_error_handler` since the feature is no longer
   available in recent nightly builds of the compiler. This can increase the
   smart contract size slightly.
+- Set minimum Rust version to 1.60.
 
 ## concordium-std 6.1.1 (2023-03-16)
 

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -3,6 +3,7 @@ name = "concordium-std"
 version = "6.1.1"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2021"
+rust-version = "1.60"
 license = "MPL-2.0"
 description = "A standard library for writing smart contracts for the Concordium blockchain in Rust."
 homepage = "https://github.com/Concordium/concordium-rust-smart-contracts/"

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -2657,6 +2657,7 @@ impl<A> UnwrapAbort for Option<A> {
     type Unwrap = A;
 
     #[inline(always)]
+    #[allow(clippy::redundant_closure)]
     fn unwrap_abort(self) -> Self::Unwrap { self.unwrap_or_else(|| crate::trap()) }
 }
 

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -1288,7 +1288,7 @@ pub struct TestHost<State> {
     /// Functions that mock responses to calls.
     // This is Rc+RefCell because it needs to be cloneable. There might be another way to make the
     // MockFn cloneable, but this seemed like the easiest option.
-    mocking_fns:             Rc<RefCell<MockFnMap<State>>>,
+    mocking_fns: Rc<RefCell<MockFnMap<State>>>,
     /// Transfers the contract has made during its execution.
     transfers:               RefCell<Vec<(AccountAddress, Amount)>>,
     /// The contract balance. This is updated during execution based on contract

--- a/examples/icecream/src/lib.rs
+++ b/examples/icecream/src/lib.rs
@@ -58,12 +58,12 @@ enum ContractError {
     #[from(TransferError)]
     TransferError,
     /// Failed contract invoke.
-    ContractError,
+    ContractInvokeError,
     Unauthenticated,
 }
 
 impl<A> From<CallContractError<A>> for ContractError {
-    fn from(_: CallContractError<A>) -> Self { Self::ContractError }
+    fn from(_: CallContractError<A>) -> Self { Self::ContractInvokeError }
 }
 
 type ContractResult<A> = Result<A, ContractError>;
@@ -108,7 +108,7 @@ fn contract_buy_icecream<S: HasStateApi>(
     let weather = if let Some(mut weather) = weather {
         weather.get()?
     } else {
-        return Err(ContractError::ContractError);
+        return Err(ContractError::ContractInvokeError);
     };
 
     match weather {
@@ -319,6 +319,6 @@ mod tests {
 
         // Act + Assert (should panic)
         let result = contract_buy_icecream(&ctx, &mut host, ICECREAM_PRICE);
-        claim_eq!(result, Err(ContractError::ContractError));
+        claim_eq!(result, Err(ContractError::ContractInvokeError));
     }
 }

--- a/examples/nametoken/src/lib.rs
+++ b/examples/nametoken/src/lib.rs
@@ -101,7 +101,7 @@ struct NameInfo<S: HasStateApi> {
     // `StateBox` allows for lazy loading data; this is helpful
     // in the situations when one wants to do a partial update not touching
     // this field, which can be large.
-    data:         StateBox<Vec<u8>, S>,
+    data: StateBox<Vec<u8>, S>,
 }
 
 impl<S: HasStateApi> NameInfo<S> {


### PR DESCRIPTION
## Purpose

Update CCC dependency

## Changes

- Update CCC dependency
- Set minimum rust version to 1.60
- Update Rust and clippy versions used in CI
  - Fix some minor formatting and clippy issues
     - This includes allowing a "redundant closure", as I could not see how it could work without the closure. But there might be another solution.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.