### PR TITLE
Add integration testing to smart_contract_upgrade

### DIFF
--- a/examples/smart-contract-upgrade/contract-version1/Cargo.toml
+++ b/examples/smart-contract-upgrade/contract-version1/Cargo.toml
@@ -22,8 +22,11 @@ concordium-smart-contract-testing = "1.0"
 [lib]
 crate-type=["cdylib", "rlib"]
 
+#`concordium-smart-contract-testing` uses the below libraries as well. We overwrite them with the ones used 
+#in this repository so we can test the newest version of the libraries with the Ci pipelines.
 [patch.crates-io]
 concordium-contracts-common = {path = "../../../concordium-contracts-common/concordium-contracts-common"}
+concordium-contracts-common-derive = {path = "../../../concordium-contracts-common/concordium-contracts-common-derive"}
 
 [profile.release]
 opt-level = "s"

--- a/examples/smart-contract-upgrade/contract-version1/Cargo.toml
+++ b/examples/smart-contract-upgrade/contract-version1/Cargo.toml
@@ -14,13 +14,16 @@ std = ["concordium-std/std"]
 wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
-concordium-std ="6.2"
+concordium-std = {path = "../../../concordium-std", default-features = false}
 
 [dev-dependencies]
 concordium-smart-contract-testing = "1.0"
 
 [lib]
 crate-type=["cdylib", "rlib"]
+
+[patch.crates-io]
+concordium-contracts-common = {path = "../../../concordium-contracts-common/concordium-contracts-common"}
 
 [profile.release]
 opt-level = "s"

--- a/examples/smart-contract-upgrade/contract-version1/Cargo.toml
+++ b/examples/smart-contract-upgrade/contract-version1/Cargo.toml
@@ -14,7 +14,10 @@ std = ["concordium-std/std"]
 wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
-concordium-std = {path = "../../../concordium-std", default-features = false}
+concordium-std ="6.2"
+
+[dev-dependencies]
+concordium-smart-contract-testing = "1.0"
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/smart-contract-upgrade/contract-version1/src/lib.rs
+++ b/examples/smart-contract-upgrade/contract-version1/src/lib.rs
@@ -38,11 +38,11 @@ pub struct State {
 /// fails. This is useful for doing migration in the same transaction triggering
 /// the upgrade.
 #[derive(Serialize, SchemaType)]
-struct UpgradeParams {
+pub struct UpgradeParams {
     /// The new module reference.
-    module:  ModuleReference,
+    pub module:  ModuleReference,
     /// Optional entrypoint to call in the new module after upgrade.
-    migrate: Option<(OwnedEntrypointName, OwnedParameter)>,
+    pub migrate: Option<(OwnedEntrypointName, OwnedParameter)>,
 }
 
 /// Smart contract errors.

--- a/examples/smart-contract-upgrade/contract-version1/tests/tests.rs
+++ b/examples/smart-contract-upgrade/contract-version1/tests/tests.rs
@@ -1,0 +1,139 @@
+use concordium_smart_contract_testing::*;
+use smart_contract_upgrade::UpgradeParams;
+
+const ACC_ADDR_OWNER: AccountAddress = AccountAddress([0u8; 32]);
+const ACC_INITIAL_BALANCE: Amount = Amount::from_ccd(1000);
+
+fn setup_chain_and_contract() -> (Chain, ContractInitSuccess) {
+    let mut chain = Chain::new();
+
+    chain.create_account(Account::new(ACC_ADDR_OWNER, ACC_INITIAL_BALANCE));
+
+    // Deploy 'contract_version1' module (built with [Cargo Concordium](https://developer.concordium.software/en/mainnet/smart-contracts/guides/setup-tools.html#cargo-concordium)).
+    let deployment = chain
+        .module_deploy_v1(
+            Signer::with_one_key(),
+            ACC_ADDR_OWNER,
+            module_load_v1("./smart_contract_upgrade.wasm.v1")
+                .expect("`Contract version1` module should be loaded"),
+        )
+        .expect("`Contract version1` deployment should always succeed");
+
+    let initialization = chain
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_ADDR_OWNER,
+            Energy::from(10000),
+            InitContractPayload {
+                amount:    Amount::zero(),
+                mod_ref:   deployment.module_reference,
+                init_name: OwnedContractName::new_unchecked(
+                    "init_smart_contract_upgrade".to_string(),
+                ),
+                param:     OwnedParameter::empty(),
+            },
+        )
+        .expect("Initialization of `Contract version1` should always succeed");
+
+    (chain, initialization)
+}
+
+#[test]
+fn test_init() {
+    let (chain, initialization) = setup_chain_and_contract();
+    assert_eq!(
+        chain.contract_balance(initialization.contract_address),
+        Some(Amount::zero()),
+        "Contract should have no funds"
+    );
+}
+
+#[test]
+fn test_upgrade_without_migration_function() {
+    let (mut chain, initialization) = setup_chain_and_contract();
+
+    // Deploy 'contract_version2' module (built with [Cargo Concordium](https://developer.concordium.software/en/mainnet/smart-contracts/guides/setup-tools.html#cargo-concordium)).
+    let deployment = chain
+        .module_deploy_v1(
+            Signer::with_one_key(),
+            ACC_ADDR_OWNER,
+            module_load_v1("../contract-version2/smart_contract_upgrade.wasm.v1")
+                .expect("`Contract version2` module should be loaded"),
+        )
+        .expect("`Contract version2` deployment should always succeed");
+
+    let input_parameter = UpgradeParams {
+        module:  deployment.module_reference,
+        migrate: None,
+    };
+
+    // Upgrade `contract_version1` to `contract_version2`.
+    let update = chain
+        .contract_update(
+            Signer::with_one_key(), // Used for specifying the number of signatures.
+            ACC_ADDR_OWNER,         // Invoker account.
+            Address::Account(ACC_ADDR_OWNER), // Sender (can also be a contract).
+            Energy::from(10000),    // Maximum energy allowed for the update.
+            UpdateContractPayload {
+                address: initialization.contract_address, // The contract to update.
+                receive_name: OwnedReceiveName::new_unchecked(
+                    "smart_contract_upgrade.upgrade".into(),
+                ), // The receive function to call.
+                message: OwnedParameter::from_serial(&input_parameter).expect("`UpgradeParams` should be a valid inut parameter"), // The parameter sent to the contract.
+                amount: Amount::from_ccd(0), // Sending the contract 0 CCD.
+            },
+        );
+
+    assert_eq!(
+        update.expect("Upgrade should succeed").state_changed,
+        false,
+        "State should not be changed because no `migration` function was called"
+    );
+}
+
+#[test]
+fn test_upgrade_with_migration_function() {
+    let (mut chain, initialization) = setup_chain_and_contract();
+
+    // Deploy 'contract_version2' module (built with [Cargo Concordium](https://developer.concordium.software/en/mainnet/smart-contracts/guides/setup-tools.html#cargo-concordium)).
+    let deployment = chain
+        .module_deploy_v1(
+            Signer::with_one_key(),
+            ACC_ADDR_OWNER,
+            module_load_v1("../contract-version2/smart_contract_upgrade.wasm.v1")
+                .expect("UpgradeParams should be a valid inut parameter"),
+        )
+        .expect("`Contract version2` deployment should always succeed");
+
+    let input_parameter = UpgradeParams {
+        module:  deployment.module_reference,
+        migrate: Some((
+            OwnedEntrypointName::new("migration".to_string())
+                .expect("`migration` should be a valid name"),
+            OwnedParameter::empty(),
+        )),
+    };
+
+    // Upgrade `contract_version1` to `contract_version2`.
+    let update = chain
+        .contract_update(
+            Signer::with_one_key(), // Used for specifying the number of signatures.
+            ACC_ADDR_OWNER,         // Invoker account.
+            Address::Account(ACC_ADDR_OWNER), // Sender (can also be a contract).
+            Energy::from(10000),    // Maximum energy allowed for the update.
+            UpdateContractPayload {
+                address: initialization.contract_address, // The contract to update.
+                receive_name: OwnedReceiveName::new_unchecked(
+                    "smart_contract_upgrade.upgrade".into(),
+                ), // The receive function to call.
+                message: OwnedParameter::from_serial(&input_parameter).expect("`UpgradeParams` should be a valid inut parameter"), // The parameter sent to the contract.
+                amount: Amount::from_ccd(0), // Sending the contract 0 CCD.
+            },
+        );
+
+    assert_eq!(
+        update.expect("Upgrade should succeed").state_changed,
+        true,
+        "State should be changed due to the `migration` function"
+    );
+}

--- a/examples/smart-contract-upgrade/contract-version1/tests/tests.rs
+++ b/examples/smart-contract-upgrade/contract-version1/tests/tests.rs
@@ -90,9 +90,8 @@ fn test_upgrade_without_migration_function() {
         },
     );
 
-    assert_eq!(
-        update.expect("Upgrade should succeed").state_changed,
-        false,
+    assert!(
+        !update.expect("Upgrade should succeed").state_changed,
         "State should not be changed because no `migration` function was called"
     );
 
@@ -162,9 +161,8 @@ fn test_upgrade_with_migration_function() {
         },
     );
 
-    assert_eq!(
+    assert!(
         update.expect("Upgrade should succeed").state_changed,
-        true,
         "State should be changed due to the `migration` function"
     );
 


### PR DESCRIPTION
## Purpose

close #264 

## Changes

Add integration testing to the `smart_contract_upgrade` example. The focus is on testing the upgrade with/without the migration function.