### PR TITLE
Move MetadataUrl concordium-std

### DIFF
--- a/concordium-cis2/src/lib.rs
+++ b/concordium-cis2/src/lib.rs
@@ -32,6 +32,8 @@
 //! and implements the [`IsTokenAmount`] interface.
 #![cfg_attr(not(feature = "std"), no_std)]
 use concordium_std::{collections::BTreeMap, *};
+// Re-export for backward compatibility.
+pub use concordium_std::MetadataUrl;
 #[cfg(not(feature = "std"))]
 use core::{fmt, ops};
 #[cfg(feature = "std")]

--- a/concordium-cis2/src/lib.rs
+++ b/concordium-cis2/src/lib.rs
@@ -62,30 +62,6 @@ pub const UPDATE_OPERATOR_EVENT_TAG: u8 = u8::MAX - 3;
 /// Tag for the CIS2 TokenMetadata event.
 pub const TOKEN_METADATA_EVENT_TAG: u8 = u8::MAX - 4;
 
-/// Sha256 digest
-pub type Sha256 = [u8; 32];
-
-/// The location of the metadata and an optional hash of the content.
-// Note: For the serialization to be derived according to the CIS2
-// specification, the order of the fields cannot be changed.
-#[derive(Debug, Serialize, PartialEq, Eq, Clone)]
-pub struct MetadataUrl {
-    /// The URL following the specification RFC1738.
-    #[concordium(size_length = 2)]
-    pub url:  String,
-    /// A optional hash of the content.
-    pub hash: Option<Sha256>,
-}
-
-impl schema::SchemaType for MetadataUrl {
-    fn get_type() -> schema::Type {
-        schema::Type::Struct(schema::Fields::Named(vec![
-            ("url".to_string(), schema::Type::String(schema::SizeLength::U16)),
-            ("hash".to_string(), Option::<Sha256>::get_type()),
-        ]))
-    }
-}
-
 /// Trait for marking types as CIS2 token IDs.
 /// For a type to be a valid CIS2 token ID it must implement SchemaType and
 /// Serialize, such that the first byte indicates how many bytes is used to

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased changes
 
 - Set minimum Rust version to 1.65.
+- Add `MetadataUrl` along with the schema and serialization. It is used by CIS
+  standards to represent the location of the metadata and an optional hash of
+  the content.
 
 ## concordium-std 6.2.0 (2023-05-08)
 

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -3,9 +3,8 @@
 ## Unreleased changes
 
 - Set minimum Rust version to 1.65.
-- Add `MetadataUrl` along with the schema and serialization. It is used by CIS
-  standards to represent the location of the metadata and an optional hash of
-  the content.
+- Move `MetadataUrl` from the CIS-2 library to `concordium-std` along with the schema and serialization to make it available to other CIS standards.
+- Change the `MetadataUrl` schema: use hex string representation for `hash`.
 
 ## concordium-std 6.2.0 (2023-05-08)
 

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -2969,9 +2969,10 @@ unsafe impl<T: Clone, S> StateClone<S> for T {
 
 impl schema::SchemaType for MetadataUrl {
     fn get_type() -> schema::Type {
-        schema::Type::Struct(schema::Fields::Named(vec![
-            ("url".to_string(), schema::Type::String(schema::SizeLength::U16)),
-            ("hash".to_string(), Option::<HashSha2256>::get_type()),
+        schema::Type::Struct(schema::Fields::Named(crate::vec![
+            (String::from("url"), schema::Type::String(schema::SizeLength::U16)),
+            // Use the `HashSha2256` schema to represent `hash` as a hex string.
+            (String::from("hash"), Option::<HashSha2256>::get_type()),
         ]))
     }
 }

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -2992,10 +2992,9 @@ impl Deserial for MetadataUrl {
         // Deserialize url as a string with size_length = 2
         let len: u16 = source.get()?;
         let bytes = deserial_vector_no_length(source, len as usize)?;
-        Ok(MetadataUrl { 
-            url: String::from_utf8(bytes).map_err(|_| ParseError::default())?,
+        Ok(MetadataUrl {
+            url:  String::from_utf8(bytes).map_err(|_| ParseError::default())?,
             hash: Deserial::deserial(source)?,
-         }
-        )
+        })
     }
 }

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -2966,3 +2966,36 @@ unsafe impl<T: DeserialWithState<S> + Serial, S: HasStateApi> StateClone<S> for 
 unsafe impl<T: Clone, S> StateClone<S> for T {
     unsafe fn clone_state(&self, _cloned_state_api: &S) -> Self { self.clone() }
 }
+
+impl schema::SchemaType for MetadataUrl {
+    fn get_type() -> schema::Type {
+        schema::Type::Struct(schema::Fields::Named(vec![
+            ("url".to_string(), schema::Type::String(schema::SizeLength::U16)),
+            ("hash".to_string(), Option::<HashSha2256>::get_type()),
+        ]))
+    }
+}
+
+impl Serial for MetadataUrl {
+    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
+        // Serialize url as a string with size_length = 2
+        let bytes = self.url.as_bytes();
+        let len = bytes.len() as u16;
+        len.serial(out)?;
+        serial_vector_no_length(bytes, out)?;
+        self.hash.serial(out)
+    }
+}
+
+impl Deserial for MetadataUrl {
+    fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
+        // Deserialize url as a string with size_length = 2
+        let len: u16 = source.get()?;
+        let bytes = deserial_vector_no_length(source, len as usize)?;
+        Ok(MetadataUrl { 
+            url: String::from_utf8(bytes).map_err(|_| ParseError::default())?,
+            hash: Deserial::deserial(source)?,
+         }
+        )
+    }
+}

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cell::UnsafeCell, marker::PhantomData, num::NonZeroU32, Cursor, HasStateApi, Vec, Serial
+    cell::UnsafeCell, marker::PhantomData, num::NonZeroU32, Cursor, HasStateApi, Serial, Vec,
 };
 use concordium_contracts_common::{AccountBalance, Amount, ParseError};
 use core::{fmt, str::FromStr};

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -1,10 +1,10 @@
 use crate::{
-    cell::UnsafeCell, marker::PhantomData, num::NonZeroU32, Cursor, HasStateApi, Serial, Vec,
+    cell::UnsafeCell, marker::PhantomData, num::NonZeroU32, Cursor, HasStateApi, Vec, Serial
 };
 use concordium_contracts_common::{AccountBalance, Amount, ParseError};
 use core::{fmt, str::FromStr};
 // Re-export for backward compatibility.
-pub use concordium_contracts_common::ExchangeRates;
+pub use concordium_contracts_common::*;
 
 #[derive(Debug)]
 /// A high-level map based on the low-level key-value store, which is the
@@ -1246,4 +1246,13 @@ pub enum StateError {
     IteratorAlreadyDeleted,
     /// No nodes exist with the given prefix.
     SubtreeWithPrefixNotFound,
+}
+
+/// The location of the metadata and an optional hash of the content.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct MetadataUrl {
+    /// The URL following the specification RFC1738.
+    pub url:  String,
+    /// A optional hash of the content.
+    pub hash: Option<HashSha2256>,
 }

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -4,7 +4,7 @@ use crate::{
 use concordium_contracts_common::{AccountBalance, Amount, ParseError};
 use core::{fmt, str::FromStr};
 // Re-export for backward compatibility.
-pub use concordium_contracts_common::*;
+pub use concordium_contracts_common::ExchangeRates;
 
 #[derive(Debug)]
 /// A high-level map based on the low-level key-value store, which is the
@@ -1252,7 +1252,7 @@ pub enum StateError {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct MetadataUrl {
     /// The URL following the specification RFC1738.
-    pub url:  String,
+    pub url:  crate::String,
     /// A optional hash of the content.
-    pub hash: Option<HashSha2256>,
+    pub hash: Option<[u8; 32]>,
 }

--- a/examples/cis2-wccd/src/lib.rs
+++ b/examples/cis2-wccd/src/lib.rs
@@ -90,7 +90,7 @@ struct State<S: HasStateApi> {
     /// `StateBox` allows for lazy loading data. This is helpful
     /// in the situations when one wants to do a partial update not touching
     /// this field, which can be large.
-    metadata_url: StateBox<concordium_cis2::MetadataUrl, S>,
+    metadata_url: StateBox<MetadataUrl, S>,
 }
 
 /// The parameter type for the contract function `unwrap`.
@@ -161,7 +161,7 @@ struct ReturnBasicState {
     /// Contract is paused if `paused = true` and unpaused if `paused = false`.
     paused:       bool,
     /// The metadata URL of the token.
-    metadata_url: concordium_cis2::MetadataUrl,
+    metadata_url: MetadataUrl,
 }
 
 /// The parameter type for the contract function `setMetadataUrl`.
@@ -170,7 +170,7 @@ struct SetMetadataUrlParams {
     /// The URL following the specification RFC1738.
     url:  String,
     /// The hash of the document stored at the above URL.
-    hash: Option<Sha256>,
+    hash: Option<HashSha2256>,
 }
 
 /// The parameter type for the contract function `setPaused`.
@@ -348,11 +348,7 @@ impl From<CustomContractError> for ContractError {
 
 impl<S: HasStateApi> State<S> {
     /// Creates a new state with no one owning any tokens by default.
-    fn new(
-        state_builder: &mut StateBuilder<S>,
-        admin: Address,
-        metadata_url: concordium_cis2::MetadataUrl,
-    ) -> Self {
+    fn new(state_builder: &mut StateBuilder<S>, admin: Address, metadata_url: MetadataUrl) -> Self {
         State {
             admin,
             paused: false,
@@ -1165,10 +1161,10 @@ mod tests {
         // Set up crypto primitives to hash the document.
         let crypto_primitives = TestCryptoPrimitives::new();
         // The hash of the document stored at the above URL.
-        let initial_metadata_hash: Sha256 =
-            crypto_primitives.hash_sha2_256("document".as_bytes()).0;
+        let initial_metadata_hash: HashSha2256 =
+            HashSha2256(crypto_primitives.hash_sha2_256("document".as_bytes()).0);
 
-        let metadata_url = concordium_cis2::MetadataUrl {
+        let metadata_url = MetadataUrl {
             url:  INITIAL_TOKEN_METADATA_URL.to_string(),
             hash: Some(initial_metadata_hash),
         };
@@ -1194,8 +1190,8 @@ mod tests {
         // Set up crypto primitives to hash the document.
         let crypto_primitives = TestCryptoPrimitives::new();
         // The hash of the document stored at the above URL.
-        let initial_metadata_hash: Sha256 =
-            crypto_primitives.hash_sha2_256("document".as_bytes()).0;
+        let initial_metadata_hash: HashSha2256 =
+            HashSha2256(crypto_primitives.hash_sha2_256("document".as_bytes()).0);
 
         // Set up the parameter.
         let parameter = SetMetadataUrlParams {
@@ -1264,10 +1260,10 @@ mod tests {
         // Set up crypto primitives to hash the document.
         let crypto_primitives = TestCryptoPrimitives::new();
         // The hash of the document stored at the above URL.
-        let initial_metadata_hash: Sha256 =
-            crypto_primitives.hash_sha2_256("document".as_bytes()).0;
+        let initial_metadata_hash: HashSha2256 =
+            HashSha2256(crypto_primitives.hash_sha2_256("document".as_bytes()).0);
 
-        let metadata_url = concordium_cis2::MetadataUrl {
+        let metadata_url = MetadataUrl {
             url:  INITIAL_TOKEN_METADATA_URL.to_string(),
             hash: Some(initial_metadata_hash),
         };
@@ -1281,7 +1277,7 @@ mod tests {
 
         // Create a new_url and a new_hash
         let new_url = "https://some.example/token/wccd/updated".to_string();
-        let new_hash = crypto_primitives.hash_sha2_256("document2".as_bytes()).0;
+        let new_hash = HashSha2256(crypto_primitives.hash_sha2_256("document2".as_bytes()).0);
 
         // Set up the parameter.
         let parameter = SetMetadataUrlParams {
@@ -1355,10 +1351,10 @@ mod tests {
         // Set up crypto primitives to hash the document.
         let crypto_primitives = TestCryptoPrimitives::new();
         // The hash of the document stored at the above URL.
-        let initial_metadata_hash: Sha256 =
-            crypto_primitives.hash_sha2_256("document".as_bytes()).0;
+        let initial_metadata_hash: HashSha2256 =
+            HashSha2256(crypto_primitives.hash_sha2_256("document".as_bytes()).0);
 
-        let metadata_url = concordium_cis2::MetadataUrl {
+        let metadata_url = MetadataUrl {
             url:  INITIAL_TOKEN_METADATA_URL.to_string(),
             hash: Some(initial_metadata_hash),
         };

--- a/examples/cis2-wccd/src/lib.rs
+++ b/examples/cis2-wccd/src/lib.rs
@@ -46,6 +46,9 @@ pub const NEW_ADMIN_EVENT_TAG: u8 = 0;
 const SUPPORTS_STANDARDS: [StandardIdentifier<'static>; 2] =
     [CIS0_STANDARD_IDENTIFIER, CIS2_STANDARD_IDENTIFIER];
 
+/// Sha256 digest
+pub type Sha256 = [u8; 32];
+
 // Types
 
 /// Contract token ID type.
@@ -170,7 +173,7 @@ struct SetMetadataUrlParams {
     /// The URL following the specification RFC1738.
     url:  String,
     /// The hash of the document stored at the above URL.
-    hash: Option<HashSha2256>,
+    hash: Option<Sha256>,
 }
 
 /// The parameter type for the contract function `setPaused`.
@@ -1161,8 +1164,8 @@ mod tests {
         // Set up crypto primitives to hash the document.
         let crypto_primitives = TestCryptoPrimitives::new();
         // The hash of the document stored at the above URL.
-        let initial_metadata_hash: HashSha2256 =
-            HashSha2256(crypto_primitives.hash_sha2_256("document".as_bytes()).0);
+        let initial_metadata_hash: Sha256 =
+            crypto_primitives.hash_sha2_256("document".as_bytes()).0;
 
         let metadata_url = MetadataUrl {
             url:  INITIAL_TOKEN_METADATA_URL.to_string(),
@@ -1190,8 +1193,8 @@ mod tests {
         // Set up crypto primitives to hash the document.
         let crypto_primitives = TestCryptoPrimitives::new();
         // The hash of the document stored at the above URL.
-        let initial_metadata_hash: HashSha2256 =
-            HashSha2256(crypto_primitives.hash_sha2_256("document".as_bytes()).0);
+        let initial_metadata_hash: Sha256 =
+            crypto_primitives.hash_sha2_256("document".as_bytes()).0;
 
         // Set up the parameter.
         let parameter = SetMetadataUrlParams {
@@ -1260,8 +1263,8 @@ mod tests {
         // Set up crypto primitives to hash the document.
         let crypto_primitives = TestCryptoPrimitives::new();
         // The hash of the document stored at the above URL.
-        let initial_metadata_hash: HashSha2256 =
-            HashSha2256(crypto_primitives.hash_sha2_256("document".as_bytes()).0);
+        let initial_metadata_hash: Sha256 =
+            crypto_primitives.hash_sha2_256("document".as_bytes()).0;
 
         let metadata_url = MetadataUrl {
             url:  INITIAL_TOKEN_METADATA_URL.to_string(),
@@ -1277,7 +1280,7 @@ mod tests {
 
         // Create a new_url and a new_hash
         let new_url = "https://some.example/token/wccd/updated".to_string();
-        let new_hash = HashSha2256(crypto_primitives.hash_sha2_256("document2".as_bytes()).0);
+        let new_hash = crypto_primitives.hash_sha2_256("document2".as_bytes()).0;
 
         // Set up the parameter.
         let parameter = SetMetadataUrlParams {
@@ -1351,8 +1354,8 @@ mod tests {
         // Set up crypto primitives to hash the document.
         let crypto_primitives = TestCryptoPrimitives::new();
         // The hash of the document stored at the above URL.
-        let initial_metadata_hash: HashSha2256 =
-            HashSha2256(crypto_primitives.hash_sha2_256("document".as_bytes()).0);
+        let initial_metadata_hash: Sha256 =
+            crypto_primitives.hash_sha2_256("document".as_bytes()).0;
 
         let metadata_url = MetadataUrl {
             url:  INITIAL_TOKEN_METADATA_URL.to_string(),


### PR DESCRIPTION
## Purpose

Move MetadataUrl from CIS2 to `concordium-std` to make it available for various CIS standards

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
