### PR TITLE
Block time alias

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased changes
 
 - Set minimum Rust version to 1.65.
+- Introduce `block_time` for `HasChainMetadata` which should be used for contracts written on P6 and onwards.
 
 ## concordium-std 6.2.0 (2023-05-08)
 

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1640,6 +1640,11 @@ impl HasChainMetadata for ExternChainMeta {
     fn slot_time(&self) -> SlotTime {
         Timestamp::from_timestamp_millis(unsafe { prims::get_slot_time() })
     }
+
+    #[inline(always)]
+    fn block_time(&self) -> Timestamp {
+        Timestamp::from_timestamp_millis(unsafe { prims::get_slot_time() })
+    }
 }
 
 impl AttributesCursor {

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1642,9 +1642,7 @@ impl HasChainMetadata for ExternChainMeta {
     }
 
     #[inline(always)]
-    fn block_time(&self) -> Timestamp {
-        Timestamp::from_timestamp_millis(unsafe { prims::get_slot_time() })
-    }
+    fn block_time(&self) -> Timestamp { self.slot_time() }
 }
 
 impl AttributesCursor {

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -223,6 +223,8 @@ extern "C" {
 
     // Getters for the chain meta data
     /// Slot time (in milliseconds) from chain meta data
+    /// Note that this is a Timestamp (unix timestamp with millisecond
+    /// precision).
     pub fn get_slot_time() -> u64;
 
     // Cryptographic primitives

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -448,6 +448,8 @@ fn unwrap_ctx_field<A>(opt: Option<A>, name: &str) -> A {
 // Getters for testing-context
 impl HasChainMetadata for TestChainMeta {
     fn slot_time(&self) -> SlotTime { unwrap_ctx_field(self.slot_time, "metadata.slot_time") }
+
+    fn block_time(&self) -> Timestamp { unwrap_ctx_field(self.slot_time, "metadata.slot_time") }
 }
 
 pub struct TestIterator {

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -39,6 +39,8 @@ pub trait HasCallResponse: Read {
 pub trait HasChainMetadata {
     /// Get time in milliseconds at the beginning of this block.
     fn slot_time(&self) -> SlotTime;
+    /// Get time in milliseconds at the beginning of this block.
+    fn block_time(&self) -> Timestamp;
 }
 
 /// A type which has access to a policy of a credential.


### PR DESCRIPTION
## Purpose

Introduce an alias `block_time` for the primitive `get_slot_time`.

This is relevant from P6 and onwards as slots are no longer a thing, instead blocks have an associated timestamp of when the block is being baked.


## Changes

Introduced `block_time` which just calls `get_slot_time`.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

