### PR TITLE
Add test cases for deriving Serial and Deserial

### DIFF
--- a/concordium-std/tests/derive-deserial/success-generics.rs
+++ b/concordium-std/tests/derive-deserial/success-generics.rs
@@ -1,0 +1,45 @@
+/// Test ensuring derivation works for types with type parameters.
+use concordium_std::*;
+
+#[derive(Deserial)]
+struct MyStruct<A> {
+    field:       A,
+    other_field: u8,
+}
+
+#[derive(Deserial)]
+struct MyOtherStruct<A, B> {
+    field:       A,
+    other_field: B,
+}
+
+#[derive(Deserial)]
+enum MyEnum<A> {
+    One(u32),
+    Two(A),
+}
+
+#[derive(Deserial)]
+enum MyOtherEnum<A, B> {
+    One(u32),
+    Two(A, B),
+}
+
+fn main() {
+    {
+        let bytes = [0u8; 9];
+        let _value: MyStruct<u64> = from_bytes(&bytes).expect("Deserialize MyStruct");
+    }
+    {
+        let bytes = [0u8; 9];
+        let _value: MyOtherStruct<u64, u8> = from_bytes(&bytes).expect("Deserialize MyOtherStruct");
+    }
+    {
+        let bytes = [1u8; 9];
+        let _value: MyEnum<u64> = from_bytes(&bytes).expect("Deserialize MyOtherStruct");
+    }
+    {
+        let bytes = [1u8; 10];
+        let _value: MyOtherEnum<u64, u8> = from_bytes(&bytes).expect("Deserialize MyOtherStruct");
+    }
+}

--- a/concordium-std/tests/derive-deserial/success-generics.rs
+++ b/concordium-std/tests/derive-deserial/success-generics.rs
@@ -25,6 +25,13 @@ enum MyOtherEnum<A, B> {
     Two(A, B),
 }
 
+#[derive(Deserial)]
+#[concordium(bound(deserial = ""))]
+struct ExplicitBound<A> {
+    field: marker::PhantomData<A>,
+}
+struct NotImplemtingDeserial;
+
 fn main() {
     {
         let bytes = [0u8; 9];
@@ -41,5 +48,10 @@ fn main() {
     {
         let bytes = [1u8; 10];
         let _value: MyOtherEnum<u64, u8> = from_bytes(&bytes).expect("Deserialize MyOtherStruct");
+    }
+    {
+        let bytes = [0u8; 0];
+        let _value: ExplicitBound<NotImplemtingDeserial> =
+            from_bytes(&bytes).expect("Deserialize ExplicitBound");
     }
 }

--- a/concordium-std/tests/derive-deserial/success-simple.rs
+++ b/concordium-std/tests/derive-deserial/success-simple.rs
@@ -1,0 +1,25 @@
+/// Test ensuring derivation works for a simple types.
+use concordium_std::*;
+
+#[derive(Deserial)]
+struct MyStruct {
+    field:       u64, // 8 bytes
+    other_field: u8,  // 1 byte
+}
+
+#[derive(Deserial)]
+enum MyEnum {
+    One(u64),
+    Two(u16),
+}
+
+fn main() {
+    {
+        let bytes = [0u8; 9];
+        let _value: MyStruct = from_bytes(&bytes).expect("Deserialize MyStruct");
+    }
+    {
+        let bytes = [0u8; 9];
+        let _value: MyEnum = from_bytes(&bytes).expect("Deserialize MyEnum");
+    }
+}

--- a/concordium-std/tests/derive-schema-type/success-generics.rs
+++ b/concordium-std/tests/derive-schema-type/success-generics.rs
@@ -1,0 +1,33 @@
+/// Test ensuring derivation works for types with type parameters.
+use concordium_std::*;
+
+#[derive(SchemaType)]
+struct MyStruct<A> {
+    field:       A,
+    other_field: u8,
+}
+
+#[derive(SchemaType)]
+struct MyOtherStruct<A, B> {
+    field:       A,
+    other_field: B,
+}
+
+#[derive(SchemaType)]
+enum MyEnum<A> {
+    One(u32),
+    Two(A),
+}
+
+#[derive(SchemaType)]
+enum MyOtherEnum<A, B> {
+    One(u32),
+    Two(A, B),
+}
+
+fn main() {
+    let _type = <MyStruct<u8> as schema::SchemaType>::get_type();
+    let _type = <MyOtherStruct<u8, u16> as schema::SchemaType>::get_type();
+    let _type = <MyEnum<u8> as schema::SchemaType>::get_type();
+    let _type = <MyOtherEnum<u8, u16> as schema::SchemaType>::get_type();
+}

--- a/concordium-std/tests/derive-schema-type/success-simple.rs
+++ b/concordium-std/tests/derive-schema-type/success-simple.rs
@@ -1,0 +1,19 @@
+/// Test ensuring derivation works for simple types.
+use concordium_std::*;
+
+#[derive(SchemaType)]
+struct MyStruct {
+    field:       u32,
+    other_field: u8,
+}
+
+#[derive(SchemaType)]
+enum MyEnum {
+    One(u32),
+    Two(u8),
+}
+
+fn main() {
+    let _type = <MyStruct as schema::SchemaType>::get_type();
+    let _type = <MyEnum as schema::SchemaType>::get_type();
+}

--- a/concordium-std/tests/derive-serial/success-generics.rs
+++ b/concordium-std/tests/derive-serial/success-generics.rs
@@ -1,0 +1,51 @@
+/// Test ensuring derivation works for types with type parameters.
+use concordium_std::*;
+
+#[derive(Serial)]
+struct MyStruct<A> {
+    field:       A,
+    other_field: u8,
+}
+
+#[derive(Serial)]
+struct MyOtherStruct<A, B> {
+    field:       A,
+    other_field: B,
+}
+
+#[derive(Serial)]
+enum MyEnum<A> {
+    One(u32),
+    Two(A),
+}
+
+#[derive(Serial)]
+enum MyOtherEnum<A, B> {
+    One(u32),
+    Two(A, B),
+}
+
+fn main() {
+    {
+        let value = MyStruct::<u32> {
+            field:       42,
+            other_field: 5,
+        };
+        let _bytes = to_bytes(&value);
+    }
+    {
+        let value = MyOtherStruct::<u64, u16> {
+            field:       42,
+            other_field: 5,
+        };
+        let _bytes = to_bytes(&value);
+    }
+    {
+        let value = MyEnum::<u64>::Two(1);
+        let _bytes = to_bytes(&value);
+    }
+    {
+        let value = MyOtherEnum::<u64, u16>::Two(1, 15);
+        let _bytes = to_bytes(&value);
+    }
+}

--- a/concordium-std/tests/derive-serial/success-simple-struct.rs
+++ b/concordium-std/tests/derive-serial/success-simple-struct.rs
@@ -1,0 +1,29 @@
+/// Test ensuring derivation works for a simple struct.
+use concordium_std::*;
+
+#[derive(Serial)]
+struct MyStruct {
+    field:       u32,
+    other_field: u8,
+}
+
+#[derive(Serial)]
+enum MyEnum {
+    One(u32),
+    Two(u8),
+}
+
+fn main() {
+    {
+        let value = MyStruct {
+            field:       42,
+            other_field: 5,
+        };
+        let _bytes = to_bytes(&value);
+    }
+
+    {
+        let value = MyEnum::Two(1);
+        let _bytes = to_bytes(&value);
+    }
+}

--- a/concordium-std/tests/derive-serial/success-state-parameter.rs
+++ b/concordium-std/tests/derive-serial/success-state-parameter.rs
@@ -1,0 +1,23 @@
+//! Ensure `derive(Serial)` generates code successfully for the
+//! simplest case when `#[concordium(state_parameter)]` is set.
+use concordium_std::*;
+
+#[derive(Serial, DeserialWithState, Deletable, StateClone)]
+#[concordium(state_parameter = "S")]
+struct State<S> {
+    map: StateMap<u8, u16, S>,
+    set: StateSet<u32, S>,
+}
+
+#[init(contract = "test")]
+fn contract_init<S: HasStateApi>(
+    _ctx: &impl HasInitContext,
+    state_builder: &mut StateBuilder<S>,
+) -> InitResult<State<S>> {
+    Ok(State {
+        map: state_builder.new_map(),
+        set: state_builder.new_set(),
+    })
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-serial/success-struct.rs
+++ b/concordium-std/tests/derive-serial/success-struct.rs
@@ -1,4 +1,4 @@
-/// Test ensuring derivation works for a simple struct.
+/// Test ensuring derivation works for simple types.
 use concordium_std::*;
 
 #[derive(Serial)]

--- a/concordium-std/tests/derives.rs
+++ b/concordium-std/tests/derives.rs
@@ -12,3 +12,15 @@ fn deletable() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive-deletable/success-*.rs");
 }
+
+#[test]
+fn serial() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/derive-serial/success-*.rs");
+}
+
+#[test]
+fn deserial() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/derive-deserial/success-*.rs");
+}

--- a/concordium-std/tests/derives.rs
+++ b/concordium-std/tests/derives.rs
@@ -24,3 +24,10 @@ fn deserial() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive-deserial/success-*.rs");
 }
+
+#[cfg(feature = "build-schema")]
+#[test]
+fn schema_type() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/derive-schema-type/success-*.rs");
+}


### PR DESCRIPTION
## Purpose

Closes https://github.com/Concordium/concordium-rust-smart-contracts/issues/283.
Should be merged after https://github.com/Concordium/concordium-contracts-common/pull/88

## Changes

- Bumps contracts-common
- Add test cases for deriving `Serial` and `Deserial`.
- Support deriving `SchemaType` for types with type parameters.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.


