### PR TITLE
Move concordium-std-derive to concordium-contracts-common-derive

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
 
 This repository consists of the core standard library for writing smart
 contracts for the Concordium blockchain in the Rust programming languages, as
-well as some sample smart contracts. The core libraries are
-[concordium-std](./concordium-std) and its helper crate of procedural macros
-[concordium-std-derive](./concordium-std-derive).
+well as some sample smart contracts. The core library is
+[concordium-std](./concordium-std).
 
-The procedural macros reduce the amount of boilerplate the user needs to write,
+The core library provide procedural macros to reduce the amount of boilerplate the user needs to write,
 while the `concordium-std` library exposes a high-level API that smart contract
 writers can use when writing contracts, alleviating them from the need to deal
 with low-level details of how the interaction with the chain works.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ contracts for the Concordium blockchain in the Rust programming languages, as
 well as some sample smart contracts. The core library is
 [concordium-std](./concordium-std).
 
-The core library provide procedural macros to reduce the amount of boilerplate the user needs to write,
+The core library provides procedural macros to reduce the amount of boilerplate the user needs to write,
 while the `concordium-std` library exposes a high-level API that smart contract
 writers can use when writing contracts, alleviating them from the need to deal
 with low-level details of how the interaction with the chain works.

--- a/concordium-std-derive/README.md
+++ b/concordium-std-derive/README.md
@@ -1,3 +1,6 @@
+
+**Deprecated: The content of this crate have been moved to the crate concordium-contracts-common-derive**
+
 A library of procedural macros to be used in combination with
 [concordium-std](https://crates.io/crates/concordium-std).
 

--- a/concordium-std-derive/README.md
+++ b/concordium-std-derive/README.md
@@ -1,5 +1,5 @@
 
-**Deprecated: The content of this crate have been moved to the crate concordium-contracts-common-derive**
+**Deprecated: The content of this crate has been moved to the crate [concordium-contracts-common-derive](https://github.com/Concordium/concordium-contracts-common)**
 
 A library of procedural macros to be used in combination with
 [concordium-std](https://crates.io/crates/concordium-std).

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -21,22 +21,19 @@ ed25519-zebra = { version = "2.2", optional = true }
 quickcheck = {version = "1", optional = true }
 getrandom = { version = "0.2", features = ["custom"], optional = true }
 
-[dependencies.concordium-std-derive]
-path = "../concordium-std-derive"
-version = "5.2"
-
 [dependencies.concordium-contracts-common]
 path = "../concordium-contracts-common/concordium-contracts-common"
 version = "6.0"
 default-features = false
+features = ["smart-contract"]
 
 [features]
 default = ["std"]
 std = ["concordium-contracts-common/std"]
-wasm-test = ["concordium-std-derive/wasm-test"]
-build-schema = ["concordium-std-derive/build-schema"]
+wasm-test = ["concordium-contracts-common/wasm-test"]
+build-schema = ["concordium-contracts-common/build-schema"]
 crypto-primitives = ["sha2", "sha3", "secp256k1", "ed25519-zebra"]
-concordium-quickcheck = ["concordium-std-derive/concordium-quickcheck", "getrandom", "quickcheck", "concordium-contracts-common/concordium-quickcheck", "std"]
+concordium-quickcheck = ["getrandom", "quickcheck", "concordium-contracts-common/concordium-quickcheck", "std"]
 
 [lib]
 crate-type = ["rlib"]

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -277,7 +277,6 @@ pub mod prims;
 mod traits;
 mod types;
 pub use concordium_contracts_common::*;
-pub use concordium_std_derive::*;
 pub use impls::*;
 pub use traits::*;
 pub use types::*;


### PR DESCRIPTION
## Purpose

Remove duplication code by merging `concordium-std-derive` into `concordium-contracts-common-derive`.
Closes https://github.com/Concordium/concordium-rust-smart-contracts/issues/290.
Should be merged after https://github.com/Concordium/concordium-contracts-common/pull/90.

The public API of `concordium-std` should not change because of this.

## Changes

- Remove dependency `concordium-std-derive` from `concordium-std`.
- Enabled `smart-contract` feature on `concordium-contracts-common`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

