### PR TITLE
More parameters to credential registry init

### DIFF
--- a/examples/credential-registry/src/lib.rs
+++ b/examples/credential-registry/src/lib.rs
@@ -557,6 +557,7 @@ pub struct InitParams {
     /// `issuer`.
     issuer:          Option<AccountAddress>,
     /// Revocation keys available right after initialization.
+    #[concordium(size_length = 1)]
     revocation_keys: Vec<PublicKeyEd25519>,
 }
 

--- a/examples/credential-registry/src/lib.rs
+++ b/examples/credential-registry/src/lib.rs
@@ -497,27 +497,27 @@ impl Serial for CredentialEvent {
         match self {
             // CIS-4 standard events are numbered from 255 counting down
             CredentialEvent::Register(data) => {
-                255u8.serial(out)?;
+                249u8.serial(out)?;
                 data.serial(out)
             }
             CredentialEvent::Revoke(data) => {
-                254u8.serial(out)?;
+                248u8.serial(out)?;
                 data.serial(out)
             }
             CredentialEvent::IssuerMetadata(data) => {
-                253u8.serial(out)?;
+                247u8.serial(out)?;
                 data.serial(out)
             }
             CredentialEvent::CredentialMetadata(data) => {
-                252u8.serial(out)?;
+                246u8.serial(out)?;
                 data.serial(out)
             }
             CredentialEvent::Schema(data) => {
-                251u8.serial(out)?;
+                245u8.serial(out)?;
                 data.serial(out)
             }
             CredentialEvent::RevocationKey(data) => {
-                250u8.serial(out)?;
+                244u8.serial(out)?;
                 data.serial(out)
             }
             // Restore event is not covered by CIS-4; it gets `0` tag.
@@ -532,12 +532,12 @@ impl Serial for CredentialEvent {
 impl Deserial for CredentialEvent {
     fn deserial<R: Read>(source: &mut R) -> ParseResult<Self> {
         match source.get()? {
-            255u8 => Ok(Self::Register(source.get()?)),
-            254u8 => Ok(Self::Revoke(source.get()?)),
-            253u8 => Ok(Self::IssuerMetadata(source.get()?)),
-            252u8 => Ok(Self::CredentialMetadata(source.get()?)),
-            251u8 => Ok(Self::Schema(source.get()?)),
-            250u8 => Ok(Self::RevocationKey(source.get()?)),
+            249u8 => Ok(Self::Register(source.get()?)),
+            248u8 => Ok(Self::Revoke(source.get()?)),
+            247u8 => Ok(Self::IssuerMetadata(source.get()?)),
+            246u8 => Ok(Self::CredentialMetadata(source.get()?)),
+            245u8 => Ok(Self::Schema(source.get()?)),
+            244u8 => Ok(Self::RevocationKey(source.get()?)),
             0u8 => Ok(Self::Restore(source.get()?)),
             _ => Err(ParseError {}),
         }

--- a/examples/credential-registry/src/lib.rs
+++ b/examples/credential-registry/src/lib.rs
@@ -586,7 +586,7 @@ fn init<S: HasStateApi>(
     logger.log(&CredentialEvent::IssuerMetadata(parameter.issuer_metadata.clone()))?;
     let mut state = State::new(
         state_builder,
-        parameter.issuer.unwrap_or(ctx.init_origin()),
+        parameter.issuer.unwrap_or_else(|| ctx.init_origin()),
         parameter.issuer_metadata,
         parameter.storage_address,
     );
@@ -1638,7 +1638,7 @@ mod tests {
         let fetched_schema =
             state.schema_registry.get(&schema.0).expect_report("Schema must be in the state");
         claim_eq!(*fetched_schema, schema.1, "Incorrect schema in the state");
-        claim_eq!(state.issuer, ISSUER_ACCOUNT.into(), "Incorrect issuer in the state");
+        claim_eq!(state.issuer, ISSUER_ACCOUNT, "Incorrect issuer in the state");
         claim_eq!(
             state.storage_address,
             STORAGE_CONTRACT,


### PR DESCRIPTION
## Purpose

Add the following data to the initialization parameters:
- optional issuer (if `None` use `init_origin()`)
- revocation keys

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.