### PR TITLE
Manual implementaion for event schema in registry contract

### DIFF
--- a/examples/credential-registry/src/lib.rs
+++ b/examples/credential-registry/src/lib.rs
@@ -499,49 +499,73 @@ impl schema::SchemaType for CredentialEvent {
                 249,
                 (
                     "Register".to_string(),
-                    schema::Fields::Unnamed(Vec::from([CredentialEventData::get_type()])),
+                    schema::Fields::Named(Vec::from([
+                        ("holder_id".to_string(), PublicKeyEd25519::get_type()),
+                        ("schema_ref".to_string(), SchemaRef::get_type()),
+                        ("credential_type".to_string(), CredentialType::get_type()),
+                        ("metadata_url".to_string(), MetadataUrl::get_type()),
+                    ])),
                 ),
             ),
             (
                 248,
                 (
                     "Revoke".to_string(),
-                    schema::Fields::Unnamed(Vec::from([RevokeCredentialEvent::get_type()])),
+                    schema::Fields::Named(Vec::from([
+                        ("holder_id".to_string(), CredentialHolderId::get_type()),
+                        ("revoker".to_string(), Revoker::get_type()),
+                        ("reason".to_string(), Option::<Reason>::get_type()),
+                    ])),
                 ),
             ),
             (
                 247,
                 (
                     "IssuerMetadata".to_string(),
-                    schema::Fields::Unnamed(Vec::from([MetadataUrl::get_type()])),
+                    schema::Fields::Named(Vec::from([
+                        ("url".to_string(), schema::Type::String(schema::SizeLength::U16)),
+                        ("hash".to_string(), Option::<HashSha2256>::get_type()),
+                    ])),
                 ),
             ),
             (
                 246,
                 (
                     "CredentialMetadata".to_string(),
-                    schema::Fields::Unnamed(Vec::from([CredentialMetadataEvent::get_type()])),
+                    schema::Fields::Named(Vec::from([
+                        ("credential_id".to_string(), CredentialHolderId::get_type()),
+                        ("metadata_url".to_string(), MetadataUrl::get_type()),
+                    ])),
                 ),
             ),
             (
                 245,
                 (
                     "Schema".to_string(),
-                    schema::Fields::Unnamed(Vec::from([CredentialSchemaRefEvent::get_type()])),
+                    schema::Fields::Named(Vec::from([
+                        ("credential_type".to_string(), CredentialType::get_type()),
+                        ("schema_ref".to_string(), SchemaRef::get_type()),
+                    ])),
                 ),
             ),
             (
                 244,
                 (
                     "RevocationKey".to_string(),
-                    schema::Fields::Unnamed(Vec::from([RevocationKeyEvent::get_type()])),
+                    schema::Fields::Named(Vec::from([
+                        ("key".to_string(), PublicKeyEd25519::get_type()),
+                        ("action".to_string(), RevocationKeyAction::get_type()),
+                    ])),
                 ),
             ),
             (
                 0, // Restore event is not covered by CIS-4; it gets `0` tag.
                 (
                     "Restore".to_string(),
-                    schema::Fields::Unnamed(Vec::from([RestoreCredentialEvent::get_type()])),
+                    schema::Fields::Named(Vec::from([
+                        ("holder_id".to_string(), CredentialHolderId::get_type()),
+                        ("reason".to_string(), Option::<Reason>::get_type()),
+                    ])),
                 ),
             ),
         ]))

--- a/examples/credential-registry/src/lib.rs
+++ b/examples/credential-registry/src/lib.rs
@@ -473,7 +473,6 @@ struct RevocationKeyEvent {
 
 /// Tagged credential registry event.
 /// This version should be used for logging the events.
-#[derive(SchemaType)]
 enum CredentialEvent {
     /// Credential registration event. Logged when an entry in the registry is
     /// created for the first time.
@@ -490,6 +489,63 @@ enum CredentialEvent {
     Schema(CredentialSchemaRefEvent),
     /// Revocation key changes
     RevocationKey(RevocationKeyEvent),
+}
+
+// Implementing a custom schemaType use tags required by CIS-4.
+impl schema::SchemaType for CredentialEvent {
+    fn get_type() -> schema::Type {
+        schema::Type::TaggedEnum(collections::BTreeMap::from([
+            (
+                249,
+                (
+                    "Register".to_string(),
+                    schema::Fields::Unnamed(Vec::from([CredentialEventData::get_type()])),
+                ),
+            ),
+            (
+                248,
+                (
+                    "Revoke".to_string(),
+                    schema::Fields::Unnamed(Vec::from([RevokeCredentialEvent::get_type()])),
+                ),
+            ),
+            (
+                247,
+                (
+                    "IssuerMetadata".to_string(),
+                    schema::Fields::Unnamed(Vec::from([MetadataUrl::get_type()])),
+                ),
+            ),
+            (
+                246,
+                (
+                    "CredentialMetadata".to_string(),
+                    schema::Fields::Unnamed(Vec::from([CredentialMetadataEvent::get_type()])),
+                ),
+            ),
+            (
+                245,
+                (
+                    "Schema".to_string(),
+                    schema::Fields::Unnamed(Vec::from([CredentialSchemaRefEvent::get_type()])),
+                ),
+            ),
+            (
+                244,
+                (
+                    "RevocationKey".to_string(),
+                    schema::Fields::Unnamed(Vec::from([RevocationKeyEvent::get_type()])),
+                ),
+            ),
+            (
+                0, // Restore event is not covered by CIS-4; it gets `0` tag.
+                (
+                    "Restore".to_string(),
+                    schema::Fields::Unnamed(Vec::from([RestoreCredentialEvent::get_type()])),
+                ),
+            ),
+        ]))
+    }
 }
 
 impl Serial for CredentialEvent {


### PR DESCRIPTION
## Purpose

Fix schema type for events in credential registry example.

The SchemaType implementation is derived for CredentialEvent which is using values 0 to 7 for tagging the variants, which does not match the serialization for the type which is using 0 and 244 to 249.

## Changes

- Manually implement the schema type instead of deriving it for `CredentialEvent` in `credential-registry`.
