### PR TITLE
Single credential type per registry

### DIFF
--- a/examples/credential-registry/src/lib.rs
+++ b/examples/credential-registry/src/lib.rs
@@ -602,6 +602,7 @@ pub struct InitParams {
 /// `CredentialEvent::Schema` for each schema in the input.
 ///
 /// It rejects if:
+///   - Fails to parse the input parameter.
 ///   - Fails to log the events.
 ///   - Fails to register any of the initial revocation keys.
 #[init(

--- a/examples/credential-registry/src/lib.rs
+++ b/examples/credential-registry/src/lib.rs
@@ -1275,18 +1275,30 @@ fn contract_revocation_keys<S: HasStateApi>(
     Ok(host.state().view_revocation_keys())
 }
 
-/// A view entrypoint to get the issuer's metadata URL and checksum.
+#[derive(Serialize, SchemaType)]
+struct MetadataResponse {
+    metadata_url:      MetadataUrl,
+    credential_type:   CredentialType,
+    credential_schema: SchemaRef,
+}
+
+/// A view entrypoint to get the registry metadata.
 #[receive(
     contract = "credential_registry",
-    name = "issuerMetadata",
+    name = "registryMetadata",
     error = "ContractError",
-    return_value = "MetadataUrl"
+    return_value = "MetadataResponse"
 )]
-fn contract_issuer_metadata<S: HasStateApi>(
+fn contract_registry_metadata<S: HasStateApi>(
     _ctx: &impl HasReceiveContext,
     host: &impl HasHost<State<S>, StateApiType = S>,
-) -> Result<MetadataUrl, ContractError> {
-    Ok(host.state().issuer_metadata.clone())
+) -> Result<MetadataResponse, ContractError> {
+    let state = host.state();
+    Ok(MetadataResponse {
+        metadata_url:      state.issuer_metadata.clone(),
+        credential_type:   state.credential_type.clone(),
+        credential_schema: state.credential_schema.clone(),
+    })
 }
 
 /// Update issuer's metadata.

--- a/examples/credential-registry/src/lib.rs
+++ b/examples/credential-registry/src/lib.rs
@@ -7,6 +7,13 @@
 //! VC life cycle and querying VCs data and status. The intended users are
 //! issuers of VCs, holders of VCs, revocation authorities and verifiers.
 //!
+//! When initializing a contract, the issuer provides a type and a schema
+//! reference for the credentials in the registry. The schema reference points
+//! to a JSON document describing the structure of verifiable credentials in the
+//! registry (attributes and their types). If the issuer wants to issue
+//! verifiable credentials of several types, they can deploy several instances
+//! of this contract with different credential types.
+//!
 //! ## Issuer's  functionality
 //!
 //! - register a new credential;


### PR DESCRIPTION
## Purpose

Modify the credential registry example so it stores public data of verifiable credentials of one type.
This type and the corresponding schema are specified during contract initialization.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
