### PR TITLE
Use the current nonce value for validation

### DIFF
--- a/examples/credential-registry/src/lib.rs
+++ b/examples/credential-registry/src/lib.rs
@@ -1110,10 +1110,11 @@ fn contract_revoke_credential_other<S: HasStateApi>(
     let mut entry =
         state.revocation_keys.entry(public_key).occupied_or(ContractError::KeyDoesNotExist)?;
 
-    // Update the nonce.
-    *entry += 1;
-
+    // Get the current nonce value
     let nonce = *entry;
+
+    // Update the nonce in the state.
+    *entry += 1;
 
     // Set the revoker to be the revocation authority.
     let revoker = Revoker::Other(public_key);


### PR DESCRIPTION
## Purpose

This PR changes how the nonce is used in the signature validation. Now, it uses the value given by the user and compares it to the nonce stored in the state (either per credential, if the holder revokes, or per revocation key, if a revocation authority revokes) and then increments the nonce.
Previously, the increment was done *before* comparing the nonces and required to send the *incremented* nonce in the input.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
