### PR TITLE
Derive forward attribute

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Support adding attribute `#[concordium(repr(u))]` for enum types, where `u` is either `u8` or `u16`. Setting this changes the integer serialization used for the variant tags in derive macros such as  `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`.
 - Support adding attribute `#[concordium(tag = n)]` for enum variants, where `n` is some unsigned integer literal. Setting this attribute on a variant overrides the tag used in derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`. Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
-
+- Support adding `#[concordium(forward = n)]`, for enum variants, where `n` is either an unsigned integer literal, `cis2_events`, `cis3_events`, `cis4_events` or an array of the same options. Setting this attribute on a variant overrides the (de)serialization to flatten with the (de)serialization of the inner field when  using derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`. Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
 
 ## concordium-std 7.0.0 (2023-06-16)
 

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - Support adding attribute `#[concordium(repr(u))]` for enum types, where `u` is either `u8` or `u16`. Setting this changes the integer serialization used for the variant tags in derive macros such as  `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`.
 - Support adding attribute `#[concordium(tag = n)]` for enum variants, where `n` is some unsigned integer literal. Setting this attribute on a variant overrides the tag used in derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`. Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
-- Support adding `#[concordium(forward = n)]`, for enum variants, where `n` is either an unsigned integer literal, `cis2_events`, `cis3_events`, `cis4_events` or an array of the same options. Setting this attribute on a variant overrides the (de)serialization to flatten with the (de)serialization of the inner field when  using derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`. Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
+- Support adding `#[concordium(forward = n)]`, for enum variants, where `n` is either an unsigned integer literal, `cis2_events`, `cis3_events`, `cis4_events` or an array of the same options.
+  Setting this attribute on a variant overrides the (de)serialization to flatten with the (de)serialization of the inner field when using derive macros such as `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`.
+  Note that setting `#[concordium(repr(u*))]` is required when using this attribute.
 
 ## concordium-std 7.0.0 (2023-06-16)
 

--- a/concordium-std/tests/derive-deserial-with-state/fail-colliding-forward.rs
+++ b/concordium-std/tests/derive-deserial-with-state/fail-colliding-forward.rs
@@ -1,0 +1,29 @@
+//! Ensure `derive(DeserialWithState)` fails when 'forward' attributes are
+//! colliding.
+use concordium_std::*;
+
+#[derive(DeserialWithState)]
+#[concordium(state_parameter = "S", repr(u8))]
+enum Count<S> {
+    One {
+        field: StateSet<u32, S>,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+
+    #[concordium(forward = 5)]
+    Three(Inner),
+}
+
+#[derive(Deserial)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-deserial-with-state/fail-colliding-forward.stderr
+++ b/concordium-std/tests/derive-deserial-with-state/fail-colliding-forward.stderr
@@ -1,0 +1,11 @@
+error: The tag of 'Three' collides with the tag of 'Two'.
+  --> tests/derive-deserial-with-state/fail-colliding-forward.rs:14:28
+   |
+14 |     #[concordium(forward = 5)]
+   |                            ^
+
+error: The tag of 'Two' collides with the tag of 'Three'.
+  --> tests/derive-deserial-with-state/fail-colliding-forward.rs:11:29
+   |
+11 |     #[concordium(forward = [5, 6])]
+   |                             ^

--- a/concordium-std/tests/derive-deserial-with-state/fail-colliding-tag-forward.rs
+++ b/concordium-std/tests/derive-deserial-with-state/fail-colliding-tag-forward.rs
@@ -1,0 +1,29 @@
+//! Ensure `derive(DeserialWithState)` fails when 'forward' and 'tag' attributes
+//! are colliding.
+use concordium_std::*;
+
+#[derive(DeserialWithState)]
+#[concordium(state_parameter = "S", repr(u8))]
+enum Count<S> {
+    One {
+        field: StateSet<u32, S>,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+
+    #[concordium(tag = 5)]
+    Three(Inner),
+}
+
+#[derive(Deserial)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-deserial-with-state/fail-colliding-tag-forward.stderr
+++ b/concordium-std/tests/derive-deserial-with-state/fail-colliding-tag-forward.stderr
@@ -1,0 +1,11 @@
+error: The tag of 'Three' collides with the tag of 'Two'.
+  --> tests/derive-deserial-with-state/fail-colliding-tag-forward.rs:14:18
+   |
+14 |     #[concordium(tag = 5)]
+   |                  ^^^
+
+error: The tag of 'Two' collides with the tag of 'Three'.
+  --> tests/derive-deserial-with-state/fail-colliding-tag-forward.rs:11:29
+   |
+11 |     #[concordium(forward = [5, 6])]
+   |                             ^

--- a/concordium-std/tests/derive-deserial-with-state/fail-forward-collide-with-inferred.rs
+++ b/concordium-std/tests/derive-deserial-with-state/fail-forward-collide-with-inferred.rs
@@ -1,0 +1,25 @@
+//! Ensure `derive(DeserialWithState)` fails when a 'forward' attribute collides
+//! with the default tag for another variant.
+use concordium_std::*;
+
+#[derive(DeserialWithState)]
+#[concordium(state_parameter = "S", repr(u8))]
+enum Count<S> {
+    One {
+        field: StateSet<u32, S>,
+    },
+    #[concordium(forward = [0, 6])]
+    Two(Inner),
+}
+
+#[derive(Deserial)]
+#[concordium(repr(u8))]
+enum Inner {
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-deserial-with-state/fail-forward-collide-with-inferred.stderr
+++ b/concordium-std/tests/derive-deserial-with-state/fail-forward-collide-with-inferred.stderr
@@ -1,0 +1,11 @@
+error: The tag of 'Two' collides with the tag of 'One'.
+  --> tests/derive-deserial-with-state/fail-forward-collide-with-inferred.rs:11:29
+   |
+11 |     #[concordium(forward = [0, 6])]
+   |                             ^
+
+error: The tag of 'One' collides with the tag of 'Two'.
+ --> tests/derive-deserial-with-state/fail-forward-collide-with-inferred.rs:8:5
+  |
+8 |     One {
+  |     ^^^

--- a/concordium-std/tests/derive-deserial-with-state/fail-forward-gt-repr.rs
+++ b/concordium-std/tests/derive-deserial-with-state/fail-forward-gt-repr.rs
@@ -1,0 +1,26 @@
+//! Ensure `derive(DeserialWithState)` fails when a 'forward' attribute is
+//! greater than what 'repr(u8)' can represent.
+use concordium_std::*;
+
+#[derive(DeserialWithState)]
+#[concordium(state_parameter = "S", repr(u8))]
+enum Count<S> {
+    One {
+        field: StateSet<u32, S>,
+    },
+    #[concordium(forward = [500, 6])]
+    Two(Inner),
+}
+
+#[derive(Deserial)]
+#[concordium(repr(u16))]
+enum Inner {
+    #[concordium(tag = 500)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-deserial-with-state/fail-forward-gt-repr.stderr
+++ b/concordium-std/tests/derive-deserial-with-state/fail-forward-gt-repr.stderr
@@ -1,0 +1,5 @@
+error: 'forward' attribute tag value of 500 cannot be represented by the type u8 set in 'repr(u8)'
+  --> tests/derive-deserial-with-state/fail-forward-gt-repr.rs:11:29
+   |
+11 |     #[concordium(forward = [500, 6])]
+   |                             ^^^

--- a/concordium-std/tests/derive-deserial-with-state/fail-forward-without-repr.rs
+++ b/concordium-std/tests/derive-deserial-with-state/fail-forward-without-repr.rs
@@ -1,0 +1,26 @@
+//! Ensure `derive(DeserialWithState)` fails when using 'forward' attribute
+//! without a 'repr' attribute.
+use concordium_std::*;
+
+#[derive(DeserialWithState)]
+#[concordium(state_parameter = "S")]
+enum Count<S> {
+    One {
+        field: StateSet<u32, S>,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+}
+
+#[derive(Deserial)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-deserial-with-state/fail-forward-without-repr.stderr
+++ b/concordium-std/tests/derive-deserial-with-state/fail-forward-without-repr.stderr
@@ -1,0 +1,7 @@
+error: 'repr(..)' attribute must be set on the type when using 'forward' attribute
+ --> tests/derive-deserial-with-state/fail-forward-without-repr.rs:5:10
+  |
+5 | #[derive(DeserialWithState)]
+  |          ^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `DeserialWithState` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/concordium-std/tests/derive-deserial/fail-colliding-forward.rs
+++ b/concordium-std/tests/derive-deserial/fail-colliding-forward.rs
@@ -1,0 +1,28 @@
+//! Ensure `derive(Deserial)` fails when 'forward' attributes are colliding.
+use concordium_std::*;
+
+#[derive(Deserial)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+
+    #[concordium(forward = 5)]
+    Three(Inner),
+}
+
+#[derive(Deserial)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-deserial/fail-colliding-forward.stderr
+++ b/concordium-std/tests/derive-deserial/fail-colliding-forward.stderr
@@ -1,0 +1,11 @@
+error: The tag of 'Three' collides with the tag of 'Two'.
+  --> tests/derive-deserial/fail-colliding-forward.rs:13:28
+   |
+13 |     #[concordium(forward = 5)]
+   |                            ^
+
+error: The tag of 'Two' collides with the tag of 'Three'.
+  --> tests/derive-deserial/fail-colliding-forward.rs:10:29
+   |
+10 |     #[concordium(forward = [5, 6])]
+   |                             ^

--- a/concordium-std/tests/derive-deserial/fail-colliding-tag-forward.rs
+++ b/concordium-std/tests/derive-deserial/fail-colliding-tag-forward.rs
@@ -1,0 +1,29 @@
+//! Ensure `derive(Deserial)` fails when 'forward' and 'tag' attributes are
+//! colliding.
+use concordium_std::*;
+
+#[derive(Deserial)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+
+    #[concordium(tag = 5)]
+    Three(Inner),
+}
+
+#[derive(Deserial)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-deserial/fail-colliding-tag-forward.stderr
+++ b/concordium-std/tests/derive-deserial/fail-colliding-tag-forward.stderr
@@ -1,0 +1,11 @@
+error: The tag of 'Three' collides with the tag of 'Two'.
+  --> tests/derive-deserial/fail-colliding-tag-forward.rs:14:18
+   |
+14 |     #[concordium(tag = 5)]
+   |                  ^^^
+
+error: The tag of 'Two' collides with the tag of 'Three'.
+  --> tests/derive-deserial/fail-colliding-tag-forward.rs:11:29
+   |
+11 |     #[concordium(forward = [5, 6])]
+   |                             ^

--- a/concordium-std/tests/derive-deserial/fail-forward-collide-with-inferred.rs
+++ b/concordium-std/tests/derive-deserial/fail-forward-collide-with-inferred.rs
@@ -1,0 +1,25 @@
+//! Ensure `derive(Deserial)` fails when a 'forward' attribute collides with the
+//! default tag for another variant.
+use concordium_std::*;
+
+#[derive(Deserial)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [0, 6])]
+    Two(Inner),
+}
+
+#[derive(Deserial)]
+#[concordium(repr(u8))]
+enum Inner {
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-deserial/fail-forward-collide-with-inferred.stderr
+++ b/concordium-std/tests/derive-deserial/fail-forward-collide-with-inferred.stderr
@@ -1,0 +1,11 @@
+error: The tag of 'Two' collides with the tag of 'One'.
+  --> tests/derive-deserial/fail-forward-collide-with-inferred.rs:11:29
+   |
+11 |     #[concordium(forward = [0, 6])]
+   |                             ^
+
+error: The tag of 'One' collides with the tag of 'Two'.
+ --> tests/derive-deserial/fail-forward-collide-with-inferred.rs:8:5
+  |
+8 |     One {
+  |     ^^^

--- a/concordium-std/tests/derive-deserial/fail-forward-gt-repr.rs
+++ b/concordium-std/tests/derive-deserial/fail-forward-gt-repr.rs
@@ -1,0 +1,26 @@
+//! Ensure `derive(Deserial)` fails when a 'forward' attribute is greater than
+//! what 'repr(u8)' can represent.
+use concordium_std::*;
+
+#[derive(Deserial)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [500, 6])]
+    Two(Inner),
+}
+
+#[derive(Deserial)]
+#[concordium(repr(u16))]
+enum Inner {
+    #[concordium(tag = 500)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-deserial/fail-forward-gt-repr.stderr
+++ b/concordium-std/tests/derive-deserial/fail-forward-gt-repr.stderr
@@ -1,0 +1,5 @@
+error: 'forward' attribute tag value of 500 cannot be represented by the type u8 set in 'repr(u8)'
+  --> tests/derive-deserial/fail-forward-gt-repr.rs:11:29
+   |
+11 |     #[concordium(forward = [500, 6])]
+   |                             ^^^

--- a/concordium-std/tests/derive-deserial/fail-forward-without-repr.rs
+++ b/concordium-std/tests/derive-deserial/fail-forward-without-repr.rs
@@ -1,0 +1,25 @@
+//! Ensure `derive(Deserial)` fails when using 'forward' attribute without a
+//! 'repr' attribute.
+use concordium_std::*;
+
+#[derive(Deserial)]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+}
+
+#[derive(Deserial)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-deserial/fail-forward-without-repr.stderr
+++ b/concordium-std/tests/derive-deserial/fail-forward-without-repr.stderr
@@ -1,0 +1,7 @@
+error: 'repr(..)' attribute must be set on the type when using 'forward' attribute
+ --> tests/derive-deserial/fail-forward-without-repr.rs:5:10
+  |
+5 | #[derive(Deserial)]
+  |          ^^^^^^^^
+  |
+  = note: this error originates in the derive macro `Deserial` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/concordium-std/tests/derive-deserial/success-forward-attribute.rs
+++ b/concordium-std/tests/derive-deserial/success-forward-attribute.rs
@@ -23,6 +23,33 @@ enum Inner {
     Beta(u16),
 }
 
+// Example using predefined forwarded tags.
+
+#[derive(Debug, Deserial, PartialEq, Eq)]
+#[concordium(repr(u8))]
+enum Event {
+    A {
+        field: u32,
+    },
+    #[concordium(forward = cis2_events)]
+    B(Cis2Event),
+}
+
+#[derive(Debug, Deserial, PartialEq, Eq)]
+#[concordium(repr(u8))]
+enum Cis2Event {
+    #[concordium(tag = 255)]
+    Transfer,
+    #[concordium(tag = 254)]
+    Mint,
+    #[concordium(tag = 253)]
+    Burn,
+    #[concordium(tag = 252)]
+    UpdateOperator,
+    #[concordium(tag = 251)]
+    TokenMetadata,
+}
+
 fn main() {
     {
         let bytes = [0, 42, 0, 0, 0];
@@ -50,5 +77,11 @@ fn main() {
         let bytes = [6, 8, 0];
         let value: Count = from_bytes(&bytes).unwrap();
         assert_eq!(Count::Two(Inner::Beta(8)), value);
+    }
+
+    {
+        let bytes = [254];
+        let value: Event = from_bytes(&bytes).unwrap();
+        assert_eq!(Event::B(Cis2Event::Mint), value);
     }
 }

--- a/concordium-std/tests/derive-deserial/success-forward-attribute.rs
+++ b/concordium-std/tests/derive-deserial/success-forward-attribute.rs
@@ -1,0 +1,54 @@
+//! Ensure `derive(Deserial)` generates code successfully for types using
+//! attributes.
+use concordium_std::*;
+
+#[derive(Debug, Deserial, PartialEq, Eq)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+}
+
+#[derive(Debug, Deserial, PartialEq, Eq)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {
+    {
+        let bytes = [0, 42, 0, 0, 0];
+        let value: Count = from_bytes(&bytes).unwrap();
+        assert_eq!(
+            Count::One {
+                field: 42,
+            },
+            value
+        );
+    }
+
+    {
+        let bytes = [5, 50, 0, 0, 0];
+        let value: Count = from_bytes(&bytes).unwrap();
+        assert_eq!(
+            Count::Two(Inner::Alpha {
+                balance: 50,
+            }),
+            value
+        );
+    }
+
+    {
+        let bytes = [6, 8, 0];
+        let value: Count = from_bytes(&bytes).unwrap();
+        assert_eq!(Count::Two(Inner::Beta(8)), value);
+    }
+}

--- a/concordium-std/tests/derive-schema-type/fail-colliding-forward.rs
+++ b/concordium-std/tests/derive-schema-type/fail-colliding-forward.rs
@@ -1,0 +1,28 @@
+//! Ensure `derive(SchemaType)` fails when 'forward' attributes are colliding.
+use concordium_std::*;
+
+#[derive(SchemaType)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+
+    #[concordium(forward = 5)]
+    Three(Inner),
+}
+
+#[derive(SchemaType)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-schema-type/fail-colliding-forward.stderr
+++ b/concordium-std/tests/derive-schema-type/fail-colliding-forward.stderr
@@ -1,0 +1,11 @@
+error: The tag of 'Three' collides with the tag of 'Two'.
+  --> tests/derive-schema-type/fail-colliding-forward.rs:13:28
+   |
+13 |     #[concordium(forward = 5)]
+   |                            ^
+
+error: The tag of 'Two' collides with the tag of 'Three'.
+  --> tests/derive-schema-type/fail-colliding-forward.rs:10:29
+   |
+10 |     #[concordium(forward = [5, 6])]
+   |                             ^

--- a/concordium-std/tests/derive-schema-type/fail-colliding-tag-forward.rs
+++ b/concordium-std/tests/derive-schema-type/fail-colliding-tag-forward.rs
@@ -1,0 +1,29 @@
+//! Ensure `derive(SchemaType)` fails when 'forward' and 'tag' attributes are
+//! colliding.
+use concordium_std::*;
+
+#[derive(SchemaType)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+
+    #[concordium(tag = 5)]
+    Three(Inner),
+}
+
+#[derive(SchemaType)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-schema-type/fail-colliding-tag-forward.stderr
+++ b/concordium-std/tests/derive-schema-type/fail-colliding-tag-forward.stderr
@@ -1,0 +1,11 @@
+error: The tag of 'Three' collides with the tag of 'Two'.
+  --> tests/derive-schema-type/fail-colliding-tag-forward.rs:14:18
+   |
+14 |     #[concordium(tag = 5)]
+   |                  ^^^
+
+error: The tag of 'Two' collides with the tag of 'Three'.
+  --> tests/derive-schema-type/fail-colliding-tag-forward.rs:11:29
+   |
+11 |     #[concordium(forward = [5, 6])]
+   |                             ^

--- a/concordium-std/tests/derive-schema-type/fail-forward-collide-with-inferred.rs
+++ b/concordium-std/tests/derive-schema-type/fail-forward-collide-with-inferred.rs
@@ -1,0 +1,25 @@
+//! Ensure `derive(SchemaType)` fails when a 'forward' attribute collides with
+//! the default tag for another variant.
+use concordium_std::*;
+
+#[derive(SchemaType)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [0, 6])]
+    Two(Inner),
+}
+
+#[derive(SchemaType)]
+#[concordium(repr(u8))]
+enum Inner {
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-schema-type/fail-forward-collide-with-inferred.stderr
+++ b/concordium-std/tests/derive-schema-type/fail-forward-collide-with-inferred.stderr
@@ -1,0 +1,11 @@
+error: The tag of 'Two' collides with the tag of 'One'.
+  --> tests/derive-schema-type/fail-forward-collide-with-inferred.rs:11:29
+   |
+11 |     #[concordium(forward = [0, 6])]
+   |                             ^
+
+error: The tag of 'One' collides with the tag of 'Two'.
+ --> tests/derive-schema-type/fail-forward-collide-with-inferred.rs:8:5
+  |
+8 |     One {
+  |     ^^^

--- a/concordium-std/tests/derive-schema-type/fail-forward-gt-repr.rs
+++ b/concordium-std/tests/derive-schema-type/fail-forward-gt-repr.rs
@@ -1,0 +1,26 @@
+//! Ensure `derive(SchemaType)` fails when a 'forward' attribute is greater than
+//! what 'repr(u8)' can represent.
+use concordium_std::*;
+
+#[derive(SchemaType)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [500, 6])]
+    Two(Inner),
+}
+
+#[derive(SchemaType)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-schema-type/fail-forward-gt-repr.stderr
+++ b/concordium-std/tests/derive-schema-type/fail-forward-gt-repr.stderr
@@ -1,0 +1,5 @@
+error: 'forward' attribute tag value of 500 cannot be represented by the type u8 set in 'repr(u8)'
+  --> tests/derive-schema-type/fail-forward-gt-repr.rs:11:29
+   |
+11 |     #[concordium(forward = [500, 6])]
+   |                             ^^^

--- a/concordium-std/tests/derive-schema-type/fail-forward-without-repr.rs
+++ b/concordium-std/tests/derive-schema-type/fail-forward-without-repr.rs
@@ -1,0 +1,25 @@
+//! Ensure `derive(SchemaType)` fails when using 'forward' attribute without a
+//! 'repr' attribute.
+use concordium_std::*;
+
+#[derive(SchemaType)]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+}
+
+#[derive(SchemaType)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-schema-type/fail-forward-without-repr.stderr
+++ b/concordium-std/tests/derive-schema-type/fail-forward-without-repr.stderr
@@ -1,0 +1,7 @@
+error: 'repr(..)' attribute must be set on the type when using 'forward' attribute
+ --> tests/derive-schema-type/fail-forward-without-repr.rs:5:10
+  |
+5 | #[derive(SchemaType)]
+  |          ^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `SchemaType` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/concordium-std/tests/derive-schema-type/success-forward-attribute.rs
+++ b/concordium-std/tests/derive-schema-type/success-forward-attribute.rs
@@ -1,0 +1,34 @@
+//! Ensure `derive(SchemaType)` generates code successfully for types using
+//! attributes.
+use concordium_std::*;
+
+#[derive(SchemaType)]
+#[concordium(repr(u8))]
+enum Count {
+    One,
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+}
+
+#[derive(SchemaType)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha,
+    #[concordium(tag = 6)]
+    Beta(u8),
+}
+
+fn main() {
+    {
+        let schema_type = <Count as schema::SchemaType>::get_type();
+        assert_eq!(
+            schema_type,
+            schema::Type::TaggedEnum(collections::BTreeMap::from([
+                (0, (String::from("One"), schema::Fields::None)),
+                (5, (String::from("Alpha"), schema::Fields::None)),
+                (6, (String::from("Beta"), schema::Fields::Unnamed(vec![schema::Type::U8])))
+            ]))
+        );
+    }
+}

--- a/concordium-std/tests/derive-schema-type/success-forward-attribute.rs
+++ b/concordium-std/tests/derive-schema-type/success-forward-attribute.rs
@@ -19,6 +19,33 @@ enum Inner {
     Beta(u8),
 }
 
+// Example using predefined forwarded tags.
+
+#[derive(SchemaType)]
+#[concordium(repr(u8))]
+enum Event {
+    A {
+        field: u32,
+    },
+    #[concordium(forward = cis2_events)]
+    B(Cis2Event),
+}
+
+#[derive(SchemaType)]
+#[concordium(repr(u8))]
+enum Cis2Event {
+    #[concordium(tag = 255)]
+    Transfer,
+    #[concordium(tag = 254)]
+    Mint,
+    #[concordium(tag = 253)]
+    Burn,
+    #[concordium(tag = 252)]
+    UpdateOperator,
+    #[concordium(tag = 251)]
+    TokenMetadata,
+}
+
 fn main() {
     {
         let schema_type = <Count as schema::SchemaType>::get_type();
@@ -28,6 +55,27 @@ fn main() {
                 (0, (String::from("One"), schema::Fields::None)),
                 (5, (String::from("Alpha"), schema::Fields::None)),
                 (6, (String::from("Beta"), schema::Fields::Unnamed(vec![schema::Type::U8])))
+            ]))
+        );
+    }
+
+    {
+        let schema_type = <Event as schema::SchemaType>::get_type();
+        assert_eq!(
+            schema_type,
+            schema::Type::TaggedEnum(collections::BTreeMap::from([
+                (
+                    0,
+                    (
+                        String::from("A"),
+                        schema::Fields::Named(vec![(String::from("field"), schema::Type::U32)])
+                    )
+                ),
+                (255, (String::from("Transfer"), schema::Fields::None)),
+                (254, (String::from("Mint"), schema::Fields::None)),
+                (253, (String::from("Burn"), schema::Fields::None)),
+                (252, (String::from("UpdateOperator"), schema::Fields::None)),
+                (251, (String::from("TokenMetadata"), schema::Fields::None))
             ]))
         );
     }

--- a/concordium-std/tests/derive-serial/fail-colliding-forward.rs
+++ b/concordium-std/tests/derive-serial/fail-colliding-forward.rs
@@ -1,0 +1,28 @@
+//! Ensure `derive(Serial)` fails when 'forward' attributes are colliding.
+use concordium_std::*;
+
+#[derive(Serial)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+
+    #[concordium(forward = 5)]
+    Three(Inner),
+}
+
+#[derive(Serial)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-serial/fail-colliding-forward.stderr
+++ b/concordium-std/tests/derive-serial/fail-colliding-forward.stderr
@@ -1,0 +1,11 @@
+error: The tag of 'Three' collides with the tag of 'Two'.
+  --> tests/derive-serial/fail-colliding-forward.rs:13:28
+   |
+13 |     #[concordium(forward = 5)]
+   |                            ^
+
+error: The tag of 'Two' collides with the tag of 'Three'.
+  --> tests/derive-serial/fail-colliding-forward.rs:10:29
+   |
+10 |     #[concordium(forward = [5, 6])]
+   |                             ^

--- a/concordium-std/tests/derive-serial/fail-colliding-tag-forward.rs
+++ b/concordium-std/tests/derive-serial/fail-colliding-tag-forward.rs
@@ -1,0 +1,28 @@
+//! Ensure `derive(Serial)` fails when 'forward' and 'tag' attributes are colliding.
+use concordium_std::*;
+
+#[derive(Serial)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+
+    #[concordium(tag = 5)]
+    Three(Inner),
+}
+
+#[derive(Serial)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-serial/fail-colliding-tag-forward.stderr
+++ b/concordium-std/tests/derive-serial/fail-colliding-tag-forward.stderr
@@ -1,0 +1,11 @@
+error: The tag of 'Three' collides with the tag of 'Two'.
+  --> tests/derive-serial/fail-colliding-tag-forward.rs:13:18
+   |
+13 |     #[concordium(tag = 5)]
+   |                  ^^^
+
+error: The tag of 'Two' collides with the tag of 'Three'.
+  --> tests/derive-serial/fail-colliding-tag-forward.rs:10:29
+   |
+10 |     #[concordium(forward = [5, 6])]
+   |                             ^

--- a/concordium-std/tests/derive-serial/fail-forward-collide-with-inferred.rs
+++ b/concordium-std/tests/derive-serial/fail-forward-collide-with-inferred.rs
@@ -1,0 +1,25 @@
+//! Ensure `derive(Serial)` fails when a 'forward' attribute collides with the
+//! default tag for another variant.
+use concordium_std::*;
+
+#[derive(Serial)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [0, 6])]
+    Two(Inner),
+}
+
+#[derive(Serial)]
+#[concordium(repr(u8))]
+enum Inner {
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-serial/fail-forward-collide-with-inferred.stderr
+++ b/concordium-std/tests/derive-serial/fail-forward-collide-with-inferred.stderr
@@ -1,0 +1,11 @@
+error: The tag of 'Two' collides with the tag of 'One'.
+  --> tests/derive-serial/fail-forward-collide-with-inferred.rs:11:29
+   |
+11 |     #[concordium(forward = [0, 6])]
+   |                             ^
+
+error: The tag of 'One' collides with the tag of 'Two'.
+ --> tests/derive-serial/fail-forward-collide-with-inferred.rs:8:5
+  |
+8 |     One {
+  |     ^^^

--- a/concordium-std/tests/derive-serial/fail-forward-gt-repr.rs
+++ b/concordium-std/tests/derive-serial/fail-forward-gt-repr.rs
@@ -1,0 +1,26 @@
+//! Ensure `derive(Serial)` fails when a 'forward' attribute is greater than
+//! what 'repr(u8)' can represent.
+use concordium_std::*;
+
+#[derive(Serial)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [500, 6])]
+    Two(Inner),
+}
+
+#[derive(Serial)]
+#[concordium(repr(u16))]
+enum Inner {
+    #[concordium(tag = 500)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-serial/fail-forward-gt-repr.stderr
+++ b/concordium-std/tests/derive-serial/fail-forward-gt-repr.stderr
@@ -1,0 +1,5 @@
+error: 'forward' attribute tag value of 500 cannot be represented by the type u8 set in 'repr(u8)'
+  --> tests/derive-serial/fail-forward-gt-repr.rs:11:29
+   |
+11 |     #[concordium(forward = [500, 6])]
+   |                             ^^^

--- a/concordium-std/tests/derive-serial/fail-forward-without-repr.rs
+++ b/concordium-std/tests/derive-serial/fail-forward-without-repr.rs
@@ -1,0 +1,25 @@
+//! Ensure `derive(Serial)` fails when using 'forward' attribute without a
+//! 'repr' attribute.
+use concordium_std::*;
+
+#[derive(Serial)]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+}
+
+#[derive(Serial)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-serial/fail-forward-without-repr.stderr
+++ b/concordium-std/tests/derive-serial/fail-forward-without-repr.stderr
@@ -1,0 +1,7 @@
+error: 'repr(..)' attribute must be set on the type when using 'forward' attribute
+ --> tests/derive-serial/fail-forward-without-repr.rs:5:10
+  |
+5 | #[derive(Serial)]
+  |          ^^^^^^
+  |
+  = note: this error originates in the derive macro `Serial` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/concordium-std/tests/derive-serial/success-forward-attribute.rs
+++ b/concordium-std/tests/derive-serial/success-forward-attribute.rs
@@ -1,0 +1,47 @@
+//! Ensure `derive(Serial)` generates code successfully for enums using
+//! forward attribute.
+use concordium_std::*;
+
+#[derive(Serial)]
+#[concordium(repr(u8))]
+enum Count {
+    One {
+        field: u32,
+    },
+    #[concordium(forward = [5, 6])]
+    Two(Inner),
+}
+
+#[derive(Serial)]
+#[concordium(repr(u8))]
+enum Inner {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+fn main() {
+    {
+        let value = Count::One {
+            field: 42,
+        };
+        let bytes = to_bytes(&value);
+        assert_eq!(bytes, vec![0, 42, 0, 0, 0]);
+    }
+    {
+        let value = Count::Two(Inner::Alpha {
+            balance: 50,
+        });
+        let bytes = to_bytes(&value);
+        assert_eq!(bytes, vec![5, 50, 0, 0, 0]);
+    }
+
+    {
+        let value = Count::Two(Inner::Beta(8));
+        let bytes = to_bytes(&value);
+        assert_eq!(bytes, vec![6, 8, 0]);
+    }
+}

--- a/concordium-std/tests/derive-serial/success-forward-attribute.rs
+++ b/concordium-std/tests/derive-serial/success-forward-attribute.rs
@@ -23,6 +23,33 @@ enum Inner {
     Beta(u16),
 }
 
+// Example using predefined forwarded tags.
+
+#[derive(Serial)]
+#[concordium(repr(u8))]
+enum Event {
+    A {
+        field: u32,
+    },
+    #[concordium(forward = cis2_events)]
+    B(Cis2Event),
+}
+
+#[derive(Serial)]
+#[concordium(repr(u8))]
+enum Cis2Event {
+    #[concordium(tag = 255)]
+    Transfer,
+    #[concordium(tag = 254)]
+    Mint,
+    #[concordium(tag = 253)]
+    Burn,
+    #[concordium(tag = 252)]
+    UpdateOperator,
+    #[concordium(tag = 251)]
+    TokenMetadata,
+}
+
 fn main() {
     {
         let value = Count::One {
@@ -43,5 +70,11 @@ fn main() {
         let value = Count::Two(Inner::Beta(8));
         let bytes = to_bytes(&value);
         assert_eq!(bytes, vec![6, 8, 0]);
+    }
+
+    {
+        let value = Event::B(Cis2Event::Transfer);
+        let bytes = to_bytes(&value);
+        assert_eq!(bytes, vec![255]);
     }
 }

--- a/examples/cis2-wccd/src/lib.rs
+++ b/examples/cis2-wccd/src/lib.rs
@@ -187,6 +187,7 @@ struct SetPausedParams {
 /// A NewAdminEvent introduced by this smart contract.
 #[derive(Serial, SchemaType)]
 #[repr(transparent)]
+#[concordium(transparent)]
 struct NewAdminEvent {
     /// New admin address.
     new_admin: Address,


### PR DESCRIPTION
## Purpose

Closes #307 
Related to https://github.com/Concordium/concordium-rust-smart-contracts/issues/307.
Should be merged after https://github.com/Concordium/concordium-contracts-common/pull/102.
Test new support of `forward` attribute in derive macros for `Serial`, `Deserial`, `DeserialWithState` and `SchemaType`.

## Changes

- Add a number of tests for new derive macro features

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
