### PR TITLE
Fix comment for event tags

### DIFF
--- a/examples/credential-registry/src/lib.rs
+++ b/examples/credential-registry/src/lib.rs
@@ -527,7 +527,7 @@ impl schema::SchemaType for CredentialEvent {
 impl Serial for CredentialEvent {
     fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
         match self {
-            // CIS-4 standard events are numbered from 255 counting down
+            // CIS-4 standard events are numbered from 249 counting down
             CredentialEvent::Register(data) => {
                 249u8.serial(out)?;
                 data.serial(out)


### PR DESCRIPTION
## Purpose

The comment was referring to an incorrect initial tag number for CIS-4 event tags. This PR fixes it.
