### PR TITLE
Fix default template to also support no-std.

### DIFF
--- a/templates/default/src/lib.rs
+++ b/templates/default/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 //! # A Concordium V1 smart contract
 use concordium_std::*;
 use core::fmt::Debug;

--- a/templates/default/src/lib.rs
+++ b/templates/default/src/lib.rs
@@ -15,7 +15,7 @@ pub struct State {
 enum Error {
     /// Failed parsing the parameter.
     #[from(ParseError)]
-    ParseParamsError,
+    ParseParams,
     /// Your error
     YourError,
 }


### PR DESCRIPTION
## Purpose

The default template does not work for no-std builds, even though it has all the features to support it.

This fixes it by adding the relevant configuration.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.