### PR TITLE
Fix the order of data passed to the host.

### DIFF
--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -2141,9 +2141,9 @@ fn check_account_signature_worker(
     data: &[u8],
 ) -> CheckAccountSignatureResult {
     let mut buffer = address.0.to_vec();
-    signatures.serial(&mut buffer).unwrap_abort();
     (data.len() as u32).serial(&mut buffer).unwrap_abort();
     buffer.extend_from_slice(data);
+    signatures.serial(&mut buffer).unwrap_abort();
 
     let response = unsafe {
         prims::invoke(
@@ -2152,6 +2152,8 @@ fn check_account_signature_worker(
             buffer.len() as u32,
         )
     };
+    // Be explicit that the buffer must survive up to here.
+    drop(buffer);
     parse_check_account_signature_response_code(response)
 }
 


### PR DESCRIPTION
The node expects data before the signature.

https://github.com/Concordium/concordium-node/blob/main/concordium-consensus/src/Concordium/Scheduler.hs#L1454

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.