### PR TITLE
WIP: Procedural macros no longer require any imports from `concordium_std` to work correctly

### DIFF
--- a/concordium-std/tests/derive-deletable/success-hygienic.rs
+++ b/concordium-std/tests/derive-deletable/success-hygienic.rs
@@ -1,0 +1,19 @@
+//! Ensures that `derive(Deletable)` would compile properly without importing any symbols
+pub trait ProxyTrait {
+    type State: concordium_std::HasStateApi;
+}
+
+#[derive(concordium_std::Deletable)]
+#[concordium(state_parameter = "T::State")]
+pub struct TestDeletableOuter<T: ProxyTrait> {
+    pub test_map: concordium_std::StateMap<u32, String, T::State>,
+    pub inner: TestDeletableInner<T::State>,
+}
+
+#[derive(concordium_std::Deletable)]
+#[concordium(state_parameter = "S")]
+pub struct TestDeletableInner<S: concordium_std::HasStateApi> {
+    pub test_set: concordium_std::StateSet<u64, S>,
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-deserial-with-state/success-hygienic.rs
+++ b/concordium-std/tests/derive-deserial-with-state/success-hygienic.rs
@@ -1,0 +1,30 @@
+//! Ensures that `derive(DeserialWithState)` would compile properly without importing any symbols
+type Ok = f32;
+type Err = f64;
+type Default = str;
+
+#[derive(concordium_std::DeserialWithState)]
+#[concordium(state_parameter = "S")]
+pub struct Deserial0<S: concordium_std::HasStateApi> {
+    pub test_map: concordium_std::StateMap<u32, String, S>,
+}
+
+#[derive(concordium_std::DeserialWithState)]
+#[concordium(state_parameter = "T")]
+struct Deserial1<T, A> {
+    map:   concordium_std::StateMap<u32, String, T>,
+    other: A,
+}
+
+trait ProxyTrait {
+    type State: concordium_std::HasStateApi;
+}
+
+#[derive(concordium_std::DeserialWithState)]
+#[concordium(state_parameter = "T::State")]
+struct Deserial2<T: ProxyTrait, A> {
+    test_map: concordium_std::StateMap<u32, String, T::State>,
+    field:    A,
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-deserial/success-hygienic.rs
+++ b/concordium-std/tests/derive-deserial/success-hygienic.rs
@@ -1,0 +1,46 @@
+//! Ensures that `derive(Deserial)` would compile properly without importing any symbols
+#[derive(concordium_std::Deserial)]
+pub struct InnerStruct<A> {
+    pub num: u32,
+    pub a: A,
+}
+
+#[derive(concordium_std::Deserial)]
+#[concordium(repr(u8))]
+pub enum InnerEnum<B> {
+    One(u32),
+    #[concordium(tag = 200)]
+    TwoHundred(B),
+    #[concordium(forward = [5, 6])]
+    Three(ForwardedEnum),
+}
+
+#[derive(concordium_std::Deserial)]
+#[concordium(repr(u8))]
+pub enum ForwardedEnum {
+    #[concordium(tag = 5)]
+    Alpha {
+        balance: u32,
+    },
+    #[concordium(tag = 6)]
+    Beta(u16),
+}
+
+#[derive(concordium_std::Deserial)]
+#[concordium(bound(deserial = ""))]
+pub struct ZeroSized<A> {
+    _phantom: std::marker::PhantomData<A>,
+}
+
+#[derive(concordium_std::Deserial)]
+pub struct State<A, B> {
+    pub inner_struct: InnerStruct<A>,
+    pub inner_enum: InnerEnum<B>,
+    pub zero: ZeroSized<A>,
+    #[concordium(ensure_ordered)]
+    pub ordered_map: std::collections::BTreeMap<u32, u32>,
+    #[concordium(size_length = 2)]
+    pub numbers: Vec<u32>,
+}
+
+fn main() {}

--- a/concordium-std/tests/derive-serial/success-hygienic.rs
+++ b/concordium-std/tests/derive-serial/success-hygienic.rs
@@ -3,13 +3,13 @@ type Ok = f32;
 type Err = f64;
 type Default = str;
 
-#[derive(concordium_std::Deserial)]
+#[derive(concordium_std::Serial)]
 pub struct InnerStruct<A> {
     pub num: u32,
     pub a: A,
 }
 
-#[derive(concordium_std::Deserial)]
+#[derive(concordium_std::Serial)]
 #[concordium(repr(u8))]
 pub enum InnerEnum<B> {
     One(u32),
@@ -19,7 +19,7 @@ pub enum InnerEnum<B> {
     Three(ForwardedEnum),
 }
 
-#[derive(concordium_std::Deserial)]
+#[derive(concordium_std::Serial)]
 #[concordium(repr(u8))]
 pub enum ForwardedEnum {
     #[concordium(tag = 5)]
@@ -30,13 +30,13 @@ pub enum ForwardedEnum {
     Beta(u16),
 }
 
-#[derive(concordium_std::Deserial)]
+#[derive(concordium_std::Serial)]
 #[concordium(bound(deserial = ""))]
 pub struct ZeroSized<A> {
     _phantom: std::marker::PhantomData<A>,
 }
 
-#[derive(concordium_std::Deserial)]
+#[derive(concordium_std::Serial)]
 pub struct State<A, B> {
     pub inner_struct: InnerStruct<A>,
     pub inner_enum: InnerEnum<B>,

--- a/concordium-std/tests/proc-macros.rs
+++ b/concordium-std/tests/proc-macros.rs
@@ -2,34 +2,34 @@
 //! `concordium-std-derive` package. Test cases presented here check successful
 //! (or failed) compilation for the code which uses macros, not its functioning.
 #[test]
-fn deserial_with_state() {
+fn derive_deserial_with_state() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive-deserial-with-state/success-*.rs");
     t.compile_fail("tests/derive-deserial-with-state/fail-*.rs");
 }
 
 #[test]
-fn deletable() {
+fn derive_deletable() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive-deletable/success-*.rs");
 }
 
 #[test]
-fn serial() {
+fn derive_serial() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive-serial/success-*.rs");
     t.compile_fail("tests/derive-serial/fail-*.rs");
 }
 
 #[test]
-fn deserial() {
+fn derive_deserial() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive-deserial/success-*.rs");
     t.compile_fail("tests/derive-deserial/fail-*.rs");
 }
 
 #[test]
-fn schema_type() {
+fn derive_schema_type() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive-schema-type/success-*.rs");
     t.compile_fail("tests/derive-schema-type/fail-*.rs");


### PR DESCRIPTION
## Purpose

Make procedural macros, including derives, compile correctly without importing any symbols into scope.
Intended to remove need for wildcard imports, increase usage clarity and reduce probability of conflicts.

## Changes

* `concordium-contracts-common` macros are now self-contained
* Compilation tests to ensure everything works as expected
    * derive(Serial)
    * derive(Deserial)
    * derive(DeserialWithState)
    * derive(Deletable)
    * TODO: derive(SchemaType)
    * TODO: derive(Reject)
    * TODO: init
    * TODO: receive

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
