### PR TITLE
Update library version in docs

### DIFF
--- a/contract-testing/src/lib.rs
+++ b/contract-testing/src/lib.rs
@@ -13,7 +13,7 @@
 //! edition = "2021"
 //!
 //! [dev-dependencies]
-//! concordium-smart-contract-testing = "1.0"
+//! concordium-smart-contract-testing = "3.0"
 //! ```
 //!
 //! ## Basic usage


### PR DESCRIPTION
## Purpose

Update to latest version in module docs.

Both here and in the documentation on our web site they both reference version 1.0.

I haven’t gone through all the examples in documentation to see if any of them reference something from before 3.0. It did however work for me to use the latest (3.0) and follow the documentation.