### PR TITLE
Deprecate `test_infrastructure` and supporting traits

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Set minimum Rust version to 1.66.
 - Fix bug in `StateMap::get_mut`, which allowed multiple mutable references to the state to coexist.
   - The signature has changed using `&self` to using `&mut self`.
+- Deprecate the `test_infrastructure` module in favour of [concordium-smart-contract-testing](https://docs.rs/concordium-smart-contract-testing).
+  - Several traits are also deprecated as they are only needed when using the `test_infrastructure` for testing.
+  - Among the traits are `HasHost`, `HasStateApi`, `HasInitContext`, `HasReceiveContext`.
+    - They are replaced by concrete types, e.g. `Host`, `StateApi`, etc. in the documentation and nearly all example contracts.
+  - Add a section in the library documentation about how to migrate your contracts and tests.
 
 ## concordium-std 8.0.0 (2023-08-21)
 

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -290,7 +290,7 @@
 //!    ) -> ReceiveResult<MyReturnValue> { todo!() }
 //!    ```
 //!
-//!    If you use logging, crypto-primitives, or similar, you must also also
+//!    If you use logging, crypto-primitives, or similar, you must also
 //! replace those uses of traits with concrete types. E.g. replacing `&mut impl
 //! HasLogger` with `&mut Logger`.
 //!
@@ -299,11 +299,10 @@
 //!    For an introduction to the library, see our [guide](https://developer.concordium.software/en/mainnet/smart-contracts/guides/integration-test-contract.html).
 //!
 //!    If you follow our [recommended structure](https://developer.concordium.software/en/mainnet/smart-contracts/best-practices/development.html#recommended-structure) in your contract,
-//!    then you can easily keep unit tests that only call methods directly on
-//!    your state struct.
-//!    Unit tests that call init or receive methods must, on the other hand, be
-//! migrated.
-//!
+//!    then you have a mix of unit and integrations tests:
+//!    - Unit tests that call methods directly on your state struct (without any
+//!      init/receive calls)
+//!    - Integration tests that call the init and receive methods
 //!
 //! [1]: https://doc.rust-lang.org/std/primitive.unit.html
 //! [test_infrastructure]: ./test_infrastructure/index.html

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -373,7 +373,9 @@ pub mod constants;
 mod impls;
 pub mod prims;
 mod traits;
-mod types;
+// TODO: For reviewers: I made this pub to avoid a never used warning for
+// `ChainMetadata`. I am not sure why `pub use types::*;` isn't sufficient.
+pub mod types;
 pub use concordium_contracts_common::*;
 pub use impls::*;
 pub use traits::*;
@@ -384,4 +386,8 @@ pub use types::*;
 #[cfg_attr(feature = "wee_alloc", global_allocator)]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
+#[deprecated(
+    since = "9.0.0",
+    note = "Deprecated in favour of [concordium-smart-contract-testing](https://docs.rs/concordium-smart-contract-testing)."
+)]
 pub mod test_infrastructure;

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -17,7 +17,7 @@
 //! Also note that `concordium-std` version 4 only works with `cargo-concordium`
 //! version 2.1+.
 //!
-//! Version 9 deprecates the module [test_infrastructure] in favour of the
+//! Version 8.1 deprecates the module [`test_infrastructure`] in favor of the
 //! library [concordium_smart_contract_testing], which should be used instead.
 //! For more details including how to migrate your contract, see the
 //! [Deprecating the
@@ -144,7 +144,7 @@
 //! contracts. The structure of these are, at present, a bit odd without the
 //! historic context, which is explained below.
 //!
-//! Prior to version 9, a number of traits and generics were used when writing
+//! Prior to version 8.1, a number of traits and generics were used when writing
 //! smart contracts, e.g. [`HasHost`], to support the usage of
 //! [`crate::test_infrastructure`] for testing, where two primary
 //! implementations of each trait existed. The first one is supported by
@@ -229,7 +229,7 @@
 //! not use the range `i32::MIN` to `i32::MIN + 100`.
 //!
 //! # Deprecating the `test_infrastructure`
-//! Version 9 deprecates the [test_infrastructure] in favour of the library
+//! Version 8.1 deprecates the [test_infrastructure] in favor of the library
 //! [concordium_smart_contract_testing]. A number of traits are also
 //! deprecated at the same time since they only exist to support the
 //! [test_infrastructure] and are not needed in the new testing library.
@@ -376,9 +376,7 @@ pub mod constants;
 mod impls;
 pub mod prims;
 mod traits;
-// TODO: For reviewers: I made this pub to avoid a never used warning for
-// `ChainMetadata`. I am not sure why `pub use types::*;` isn't sufficient.
-pub mod types;
+mod types;
 pub use concordium_contracts_common::*;
 pub use impls::*;
 pub use traits::*;
@@ -390,7 +388,7 @@ pub use types::*;
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 #[deprecated(
-    since = "9.0.0",
-    note = "Deprecated in favour of [concordium-smart-contract-testing](https://docs.rs/concordium-smart-contract-testing)."
+    since = "8.1.0",
+    note = "Deprecated in favor of [concordium-smart-contract-testing](https://docs.rs/concordium-smart-contract-testing)."
 )]
 pub mod test_infrastructure;

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -304,6 +304,10 @@
 //!      init/receive calls)
 //!    - Integration tests that call the init and receive methods
 //!
+//! If you do not want to migrate your contract and tests yet, then you can add
+//! the `#[allow(deprecated)]` attribute to your test modules to avoid the
+//! deprecation warnings.
+//!
 //! [1]: https://doc.rust-lang.org/std/primitive.unit.html
 //! [test_infrastructure]: ./test_infrastructure/index.html
 //! [concordium_smart_contract_testing]: https://docs.rs/concordium-smart-contract-testing

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -21,6 +21,16 @@ use concordium_contracts_common::*;
 ///
 /// The reuse of `Read` methods is the reason for the slightly strange choice of
 /// methods of this trait.
+///
+/// # Deprecation notice
+/// **This trait is deprecated along with
+/// [`crate::test_infrastructure`].**
+///
+/// Use [`ExternParameter`] instead unless you intend to use
+/// the deprecated test infrastructure.
+///
+/// See the [crate](../concordium_std/#deprecating-the-test_infrastructure)
+/// documentation for more details.
 pub trait HasParameter: Read + Seek + HasSize {}
 
 /// Objects which can access call responses from contract invocations.
@@ -31,12 +41,32 @@ pub trait HasParameter: Read + Seek + HasSize {}
 ///
 /// The reuse of `Read` methods is the reason for the slightly strange choice of
 /// methods of this trait.
+///
+/// # Deprecation notice
+/// **This trait is deprecated along with
+/// [`crate::test_infrastructure`].**
+///
+/// Use [`CallResponse`] instead unless you intend to use
+/// the deprecated test infrastructure.
+///
+/// See the [crate](../concordium_std/#deprecating-the-test_infrastructure)
+/// documentation for more details.
 pub trait HasCallResponse: Read {
     /// Get the size of the call response to the contract invocation.
     fn size(&self) -> u32;
 }
 
 /// Objects which can access chain metadata.
+///
+/// # Deprecation notice
+/// **This trait is deprecated along with
+/// [`crate::test_infrastructure`].**
+///
+/// Use [`ChainMetadata`] instead unless you intend to use
+/// the deprecated test infrastructure.
+///
+/// See the [crate](../concordium_std/#deprecating-the-test_infrastructure)
+/// documentation for more details.
 pub trait HasChainMetadata {
     /// Get time in milliseconds at the beginning of this block.
     fn slot_time(&self) -> SlotTime;
@@ -49,6 +79,16 @@ pub trait HasChainMetadata {
 /// Since policies can be large this is deliberately written in a relatively
 /// low-level style to enable efficient traversal of all the attributes without
 /// any allocations.
+///
+/// # Deprecation notice
+/// **This trait is deprecated along with
+/// [`crate::test_infrastructure`].**
+///
+/// Use [`Policy<AttributeCursor>`] instead unless you intend to use the
+/// deprecated test infrastructure.
+///
+/// See the [crate](../concordium_std/#deprecating-the-test_infrastructure)
+/// documentation for more details.
 pub trait HasPolicy: Sized {
     type Iterator: Iterator<Item = (AttributeTag, AttributeValue)>;
     /// Identity provider who signed the identity object the credential is
@@ -76,6 +116,16 @@ pub trait HasPolicy: Sized {
 }
 
 /// Common data accessible to both init and receive methods.
+///
+/// # Deprecation notice
+/// **This trait is deprecated along with
+/// [`crate::test_infrastructure`].**
+///
+/// Use [`InitContext`] or [`ReceiveContext`] instead unless you intend to use
+/// the deprecated test infrastructure.
+///
+/// See the [crate](../concordium_std/#deprecating-the-test_infrastructure)
+/// documentation for more details.
 pub trait HasCommonData {
     type PolicyType: HasPolicy;
     type MetadataType: HasChainMetadata;
@@ -96,6 +146,16 @@ pub trait HasCommonData {
 }
 
 /// Types which can act as init contexts.
+///
+/// # Deprecation notice
+/// **This trait is deprecated along with
+/// [`crate::test_infrastructure`].**
+///
+/// Use [`InitContext`] instead unless you intend to use
+/// the deprecated test infrastructure.
+///
+/// See the [crate](../concordium_std/#deprecating-the-test_infrastructure)
+/// documentation for more details.
 pub trait HasInitContext<Error: Default = ()>: HasCommonData {
     /// Data needed to open the context.
     type InitData;
@@ -106,6 +166,16 @@ pub trait HasInitContext<Error: Default = ()>: HasCommonData {
 }
 
 /// Types which can act as receive contexts.
+///
+/// # Deprecation notice
+/// **This trait is deprecated along with
+/// [`crate::test_infrastructure`].**
+///
+/// Use [`ReceiveContext`] instead unless you intend to use
+/// the deprecated test infrastructure.
+///
+/// See the [crate](../concordium_std/#deprecating-the-test_infrastructure)
+/// documentation for more details.
 pub trait HasReceiveContext<Error: Default = ()>: HasCommonData {
     type ReceiveData;
 
@@ -128,6 +198,16 @@ pub trait HasReceiveContext<Error: Default = ()>: HasCommonData {
 }
 
 /// A type that can serve as the contract state entry type.
+///
+/// # Deprecation notice
+/// **This trait is deprecated along with
+/// [`crate::test_infrastructure`].**
+///
+/// Use [`StateEntry`] instead unless you intend to use
+/// the deprecated test infrastructure.
+///
+/// See the [crate](../concordium_std/#deprecating-the-test_infrastructure)
+/// documentation for more details.
 pub trait HasStateEntry
 where
     Self: Read,
@@ -172,6 +252,16 @@ where
 }
 
 /// Types which can serve as the contract state.
+///
+/// # Deprecation notice
+/// **This trait is deprecated along with
+/// [`crate::test_infrastructure`].**
+///
+/// Use [`StateApi`] instead unless you intend to use
+/// the deprecated test infrastructure.
+///
+/// See the [crate](../concordium_std/#deprecating-the-test_infrastructure)
+/// documentation for more details.
 pub trait HasStateApi: Clone {
     type EntryType: HasStateEntry;
     type IterType: Iterator<Item = Self::EntryType>;
@@ -250,6 +340,16 @@ pub trait HasStateApi: Clone {
 ///
 /// The trait is parameterized by the `State` type. This is the type of the
 /// contract state that the particular contract operates on.
+///
+/// # Deprecation notice
+/// **This trait is deprecated along with
+/// [`crate::test_infrastructure`].**
+///
+/// Use [`Host`] instead unless you intend to use
+/// the deprecated test infrastructure.
+///
+/// See the [crate](../concordium_std/#deprecating-the-test_infrastructure)
+/// documentation for more details.
 pub trait HasHost<State>: Sized {
     /// The type of low-level state that is associated with the host.
     /// This provides access to low-level state operations.
@@ -477,6 +577,16 @@ pub trait Deletable {
 /// [`invoke_contract`](HasHost::invoke_contract) or
 /// [`invoke_transfer`](HasHost::invoke_transfer) calls. In each section at most
 /// `64` items may be logged.
+///
+/// # Deprecation notice
+/// **This trait is deprecated along with
+/// [`crate::test_infrastructure`].**
+///
+/// Use [`Logger`] instead unless you intend to use
+/// the deprecated test infrastructure.
+///
+/// See the [crate](../concordium_std/#deprecating-the-test_infrastructure)
+/// documentation for more details.
 pub trait HasLogger {
     /// Initialize a logger.
     fn init() -> Self;
@@ -498,6 +608,16 @@ pub trait HasLogger {
 }
 
 /// Objects which provide cryptographic primitives.
+///
+/// # Deprecation notice
+/// **This trait is deprecated along with
+/// [`crate::test_infrastructure`].**
+///
+/// Use [`CryptoPrimitives`] instead unless you intend to use
+/// the deprecated test infrastructure.
+///
+/// See the [crate](../concordium_std/#deprecating-the-test_infrastructure)
+/// documentation for more details.
 pub trait HasCryptoPrimitives {
     /// Verify an ed25519 signature.
     fn verify_ed25519_signature(

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -406,6 +406,8 @@ impl<'a, V: Serial, S: HasStateApi> StateRefMut<'a, V, S> {
 #[repr(transparent)]
 /// An iterator over a part of the state. Its implementation is supported by
 /// host calls.
+///
+/// **Typically referred to via the alias [`StateIter`].**
 pub struct ExternStateIter {
     pub(crate) iterator_id: StateIteratorId,
 }
@@ -544,6 +546,8 @@ pub struct ExternParameter {
 ///
 /// This type is designed to be used via its [Read](crate::Read) and
 /// [HasCallResponse](crate::HasCallResponse) traits.
+///
+/// **Typically referred to via the alias [`CallResponse`].**
 #[derive(Debug)]
 pub struct ExternCallResponse {
     /// The index of the call response.
@@ -567,6 +571,8 @@ impl ExternCallResponse {
 /// The intention is that this type is manipulated using methods of the
 /// [Write](crate::Write) trait. In particular it can be used as a sink to
 /// serialize values into.
+///
+/// **Typically referred to via the alias [`ReturnValue`].**
 pub struct ExternReturnValue {
     pub(crate) current_position: u32,
 }
@@ -1075,6 +1081,8 @@ pub type ReturnValue = ExternReturnValue;
 pub type CallResponse = ExternCallResponse;
 
 /// Operations backed by host functions for the high-level interface.
+///
+/// **Typically referred to via the alias [`Host`].**
 pub struct ExternHost<State> {
     pub state:         State,
     pub state_builder: StateBuilder<ExternStateApi>,
@@ -1105,6 +1113,8 @@ impl<S> StateBuilder<S> {
 
 /// A struct for which HasCryptoPrimitives is implemented via the crypto host
 /// functions.
+///
+/// **Typically referred to via the alias [`CryptoPrimitives`].**
 pub struct ExternCryptoPrimitives;
 
 /// Sha2 digest with 256 bits (32 bytes).
@@ -1149,6 +1159,7 @@ pub struct HashSha3256(pub [u8; 32]);
 pub struct HashKeccak256(pub [u8; 32]);
 
 #[derive(Debug, Clone, Default)]
+/// Typicall referred to via the alias [`StateApi`].
 pub struct ExternStateApi;
 
 impl ExternStateApi {
@@ -1158,6 +1169,8 @@ impl ExternStateApi {
 }
 
 /// Operations backed by host functions for the low-level interface.
+///
+/// **Typically referred to via the alias [`LowLevelHost`].**
 #[derive(Default)]
 pub struct ExternLowLevelHost {
     pub(crate) state_api:     ExternStateApi,
@@ -1165,11 +1178,14 @@ pub struct ExternLowLevelHost {
 }
 
 /// Context backed by host functions.
+///
+/// Usuaully referred to via aliases [`InitContext`] or [`ReceiveContext`].
 #[derive(Default)]
 pub struct ExternContext<T: sealed::ContextType> {
     marker: crate::marker::PhantomData<T>,
 }
 
+/// **Typically referred to via the alias [`ChainMetadata`].**
 pub struct ExternChainMeta {}
 
 #[derive(Default)]

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -846,6 +846,7 @@ macro_rules! ensure_ne {
 macro_rules! fail {
     () => {
         {
+            #[allow(deprecated)]
             $crate::test_infrastructure::report_error("", file!(), line!(), column!());
             panic!()
         }
@@ -853,6 +854,7 @@ macro_rules! fail {
     ($($arg:tt),+) => {
         {
             let msg = format!($($arg),+);
+            #[allow(deprecated)]
             $crate::test_infrastructure::report_error(&msg, file!(), line!(), column!());
             panic!("{}", msg)
         }
@@ -867,6 +869,7 @@ macro_rules! fail {
 macro_rules! fail {
     () => {
         {
+            #[allow(deprecated)]
             $crate::test_infrastructure::report_error("", file!(), line!(), column!());
             panic!()
         }
@@ -874,6 +877,7 @@ macro_rules! fail {
     ($($arg:tt),+) => {
         {
             let msg = &$crate::alloc::format!($($arg),+);
+            #[allow(deprecated)]
             $crate::test_infrastructure::report_error(&msg, file!(), line!(), column!());
             panic!("{}", msg)
         }

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -64,38 +64,36 @@ pub use concordium_contracts_common::ExchangeRates;
 /// The type parameter `S` is extra compared to usual Rust collections. As
 /// mentioned above it specifies the [low-level state
 /// implementation](crate::HasStateApi). This library provides two such
-/// implementations. The "external" one, which is the implementation supported
-/// by external host functions provided by the chain, and a
-/// [test](crate::test_infrastructure::TestStateApi) one. The latter one is
-/// useful for testing since it provides an implementation that is easier to
-/// construct, execute, and inspect during unit testing.
+/// implementations. The "external" one ([`StateApi`]), which is the
+/// implementation supported by external host functions provided by the chain,
+/// and a [test](crate::test_infrastructure::TestStateApi) one. The latter one
+/// is only useful for testing with the deprecated
+/// [`concordium_std::test_infrastructure`] module.
 ///
 /// In user code this type parameter should generally be treated as boilerplate,
 /// and contract entrypoints should always be stated in terms of a generic type
-/// `S` that implements [HasStateApi](crate::HasStateApi)
+/// `S` that implements [HasStateApi](crate::HasStateApi) and defaults to
+/// `StateApi`, unless you intend to use the deprecated testing library.
 ///
 /// #### Example
 /// ```rust
 /// # use concordium_std::*;
 /// #[derive(Serial, DeserialWithState)]
 /// #[concordium(state_parameter = "S")]
-/// struct MyState<S: HasStateApi> {
+/// struct MyState<S: HasStateApi = StateApi> {
 ///     inner: StateMap<u64, u64, S>,
 /// }
 /// #[init(contract = "mycontract")]
-/// fn contract_init<S: HasStateApi>(
-///     _ctx: &impl HasInitContext,
-///     state_builder: &mut StateBuilder<S>,
-/// ) -> InitResult<MyState<S>> {
+/// fn contract_init(_ctx: &InitContext, state_builder: &mut StateBuilder) -> InitResult<MyState> {
 ///     Ok(MyState {
 ///         inner: state_builder.new_map(),
 ///     })
 /// }
 ///
 /// #[receive(contract = "mycontract", name = "receive", return_value = "Option<u64>")]
-/// fn contract_receive<S: HasStateApi>(
-///     _ctx: &impl HasReceiveContext,
-///     host: &impl HasHost<MyState<S>, StateApiType = S>, // the same low-level state must be propagated throughout
+/// fn contract_receive(
+///     _ctx: &ReceiveContext,
+///     host: &Host<MyState>, // the same low-level state must be propagated throughout
 /// ) -> ReceiveResult<Option<u64>> {
 ///     let state = host.state();
 ///     Ok(state.inner.get(&0).map(|v| *v))
@@ -109,13 +107,10 @@ pub use concordium_contracts_common::ExchangeRates;
 ///
 /// ```no_run
 /// # use concordium_std::*;
-/// struct MyState<S: HasStateApi> {
+/// struct MyState<S: HasStateApi = StateApi> {
 ///     inner: StateMap<u64, u64, S>,
 /// }
-/// fn incorrect_replace<S: HasStateApi>(
-///     state_builder: &mut StateBuilder<S>,
-///     state: &mut MyState<S>,
-/// ) {
+/// fn incorrect_replace(state_builder: &mut StateBuilder, state: &mut MyState) {
 ///     // The following is incorrect. The old value of `inner` is not properly deleted.
 ///     // from the state.
 ///     state.inner = state_builder.new_map(); // ⚠️
@@ -126,26 +121,20 @@ pub use concordium_contracts_common::ExchangeRates;
 ///
 /// ```no_run
 /// # use concordium_std::*;
-/// # struct MyState<S: HasStateApi> {
+/// # struct MyState<S: HasStateApi = StateApi> {
 /// #    inner: StateMap<u64, u64, S>
 /// # }
-/// fn correct_replace<S: HasStateApi>(
-///     state_builder: &mut StateBuilder<S>,
-///     state: &mut MyState<S>,
-/// ) {
+/// fn correct_replace(state_builder: &mut StateBuilder, state: &mut MyState) {
 ///     state.inner.clear_flat();
 /// }
 /// ```
 /// Or alternatively
 /// ```no_run
 /// # use concordium_std::*;
-/// # struct MyState<S: HasStateApi> {
+/// # struct MyState<S: HasStateApi = StateApi> {
 /// #    inner: StateMap<u64, u64, S>
 /// # }
-/// fn correct_replace<S: HasStateApi>(
-///     state_builder: &mut StateBuilder<S>,
-///     state: &mut MyState<S>,
-/// ) {
+/// fn correct_replace(state_builder: &mut StateBuilder, state: &mut MyState) {
 ///     let old_map = mem::replace(&mut state.inner, state_builder.new_map());
 ///     old_map.delete()
 /// }
@@ -203,6 +192,20 @@ pub struct StateMapIterMut<'a, K, V, S: HasStateApi> {
 /// New sets can be constructed using the
 /// [`new_set`][StateBuilder::new_set] method on the [`StateBuilder`].
 ///
+/// ```
+/// # use concordium_std::*;
+/// # use concordium_std::test_infrastructure::*;
+/// # let mut state_builder = TestStateBuilder::new();
+/// /// In an init method:
+/// let mut set1 = state_builder.new_set();
+/// # set1.insert(0u8); // Specifies type of set.
+///
+/// # let mut host = TestHost::new((), state_builder);
+/// /// In a receive method:
+/// let mut set2 = host.state_builder().new_set();
+/// # set2.insert(0u16);
+/// ```
+///
 /// ## Type parameters
 ///
 /// The set `StateSet<T, S>` is parametrized by the type of _values_ `T`, and
@@ -222,39 +225,34 @@ pub struct StateMapIterMut<'a, K, V, S: HasStateApi> {
 /// The type parameter `S` is extra compared to usual Rust collections. As
 /// mentioned above it specifies the [low-level state
 /// implementation](crate::HasStateApi). This library provides two such
-/// implementations. The "external" one, which is the implementation supported
-/// by external host functions provided by the chain, and a
-/// [test](crate::test_infrastructure::TestStateApi) one. The latter one is
-/// useful for testing since it provides an implementation that is easier to
-/// construct, execute, and inspect during unit testing.
+/// implementations. The "external" one ([`StateApi`]), which is the
+/// implementation supported by external host functions provided by the chain,
+/// and a [test](crate::test_infrastructure::TestStateApi) one. The latter one
+/// is only useful for testing with the deprecated
+/// [`concordium_std::test_infrastructure`] module.
 ///
 /// In user code this type parameter should generally be treated as boilerplate,
 /// and contract entrypoints should always be stated in terms of a generic type
-/// `S` that implements [HasStateApi](crate::HasStateApi)
+/// `S` that implements [HasStateApi](crate::HasStateApi) and defaults to
+/// `StateApi`, unless you intend to use the deprecated testing library.
 ///
 /// #### Example
 /// ```rust
 /// # use concordium_std::*;
 /// #[derive(Serial, DeserialWithState)]
 /// #[concordium(state_parameter = "S")]
-/// struct MyState<S: HasStateApi> {
+/// struct MyState<S: HasStateApi = StateApi> {
 ///     inner: StateSet<u64, S>,
 /// }
 /// #[init(contract = "mycontract")]
-/// fn contract_init<S: HasStateApi>(
-///     _ctx: &impl HasInitContext,
-///     state_builder: &mut StateBuilder<S>,
-/// ) -> InitResult<MyState<S>> {
+/// fn contract_init(_ctx: &InitContext, state_builder: &mut StateBuilder) -> InitResult<MyState> {
 ///     Ok(MyState {
 ///         inner: state_builder.new_set(),
 ///     })
 /// }
 ///
 /// #[receive(contract = "mycontract", name = "receive", return_value = "bool")]
-/// fn contract_receive<S: HasStateApi>(
-///     _ctx: &impl HasReceiveContext,
-///     host: &impl HasHost<MyState<S>, StateApiType = S>, // the same low-level state must be propagated throughout
-/// ) -> ReceiveResult<bool> {
+/// fn contract_receive(_ctx: &ReceiveContext, host: &Host<MyState>) -> ReceiveResult<bool> {
 ///     let state = host.state();
 ///     Ok(state.inner.contains(&0))
 /// }
@@ -267,13 +265,10 @@ pub struct StateMapIterMut<'a, K, V, S: HasStateApi> {
 ///
 /// ```no_run
 /// # use concordium_std::*;
-/// struct MyState<S: HasStateApi> {
+/// struct MyState<S: HasStateApi = StateApi> {
 ///     inner: StateSet<u64, S>,
 /// }
-/// fn incorrect_replace<S: HasStateApi>(
-///     state_builder: &mut StateBuilder<S>,
-///     state: &mut MyState<S>,
-/// ) {
+/// fn incorrect_replace(state_builder: &mut StateBuilder, state: &mut MyState) {
 ///     // The following is incorrect. The old value of `inner` is not properly deleted.
 ///     // from the state.
 ///     state.inner = state_builder.new_set(); // ⚠️
@@ -284,26 +279,20 @@ pub struct StateMapIterMut<'a, K, V, S: HasStateApi> {
 ///
 /// ```no_run
 /// # use concordium_std::*;
-/// # struct MyState<S: HasStateApi> {
+/// # struct MyState<S: HasStateApi = StateApi> {
 /// #    inner: StateSet<u64, S>
 /// # }
-/// fn correct_replace<S: HasStateApi>(
-///     state_builder: &mut StateBuilder<S>,
-///     state: &mut MyState<S>,
-/// ) {
+/// fn correct_replace(state_builder: &mut StateBuilder, state: &mut MyState) {
 ///     state.inner.clear();
 /// }
 /// ```
 /// Or alternatively
 /// ```no_run
 /// # use concordium_std::*;
-/// # struct MyState<S: HasStateApi> {
+/// # struct MyState<S: HasStateApi = StateApi> {
 /// #    inner: StateSet<u64, S>
 /// # }
-/// fn correct_replace<S: HasStateApi>(
-///     state_builder: &mut StateBuilder<S>,
-///     state: &mut MyState<S>,
-/// ) {
+/// fn correct_replace(state_builder: &mut StateBuilder, state: &mut MyState) {
 ///     let old_set = mem::replace(&mut state.inner, state_builder.new_set());
 ///     old_set.delete()
 /// }
@@ -417,7 +406,6 @@ impl<'a, V: Serial, S: HasStateApi> StateRefMut<'a, V, S> {
 #[repr(transparent)]
 /// An iterator over a part of the state. Its implementation is supported by
 /// host calls.
-#[doc(hidden)]
 pub struct ExternStateIter {
     pub(crate) iterator_id: StateIteratorId,
 }
@@ -541,7 +529,6 @@ pub(crate) struct ExternParameterDataPlaceholder {}
 
 /// A type representing the parameter to init and receive methods.
 /// Its trait implementations are backed by host functions.
-#[doc(hidden)]
 pub struct ExternParameter {
     pub(crate) cursor: Cursor<ExternParameterDataPlaceholder>,
 }
@@ -558,7 +545,6 @@ pub struct ExternParameter {
 /// This type is designed to be used via its [Read](crate::Read) and
 /// [HasCallResponse](crate::HasCallResponse) traits.
 #[derive(Debug)]
-#[doc(hidden)]
 pub struct ExternCallResponse {
     /// The index of the call response.
     pub(crate) i:                NonZeroU32,
@@ -850,11 +836,11 @@ macro_rules! ensure_ne {
     };
 }
 
-// Macros for failing a test
+// Macros for failing a test (in `concordium_std::test_infrastructure`).
 
 /// The `fail` macro is used for testing as a substitute for the panic macro.
 /// It reports back error information to the host.
-/// Used only in testing.
+/// Used only in testing with [`concordium_std::test_infrastructure`]
 #[cfg(feature = "std")]
 #[macro_export]
 macro_rules! fail {
@@ -875,7 +861,7 @@ macro_rules! fail {
 
 /// The `fail` macro is used for testing as a substitute for the panic macro.
 /// It reports back error information to the host.
-/// Used only in testing.
+/// Used only in testing with [`concordium_std::test_infrastructure`]
 #[cfg(not(feature = "std"))]
 #[macro_export]
 macro_rules! fail {
@@ -896,7 +882,7 @@ macro_rules! fail {
 
 /// The `claim` macro is used for testing as a substitute for the assert macro.
 /// It checks the condition and if false it reports back an error.
-/// Used only in testing.
+/// Used only in testing with [`concordium_std::test_infrastructure`].
 #[macro_export]
 macro_rules! claim {
     ($cond:expr) => {
@@ -917,7 +903,8 @@ macro_rules! claim {
 }
 
 /// Ensure the first two arguments are equal, just like `assert_eq!`, otherwise
-/// reports an error. Used only in testing.
+/// reports an error.
+/// Used only in testing with [`concordium_std::test_infrastructure`]
 #[macro_export]
 macro_rules! claim_eq {
     ($left:expr, $right:expr $(,)?) => {
@@ -938,7 +925,7 @@ macro_rules! claim_eq {
 
 /// Ensure the first two arguments are *not* equal, just like `assert_ne!`,
 /// otherwise reports an error.
-/// Used only in testing.
+/// Used only in testing with [`concordium_std::test_infrastructure`]
 #[macro_export]
 macro_rules! claim_ne {
     ($left:expr, $right:expr $(,)?) => {
@@ -960,8 +947,7 @@ macro_rules! claim_ne {
 /// The expected return type of the receive method of a smart contract.
 ///
 /// Optionally, to define a custom type for error instead of using
-/// Reject, allowing to track the reason for rejection, *but only in unit
-/// tests*.
+/// Reject, allowing to track the reason for rejection.
 ///
 /// See also the documentation for [bail!](macro.bail.html) for how to use
 /// custom error types.
@@ -976,10 +962,7 @@ macro_rules! claim_ne {
 /// }
 ///
 /// #[receive(contract = "mycontract", name = "receive")]
-/// fn contract_receive<S: HasStateApi>(
-///     _ctx: &impl HasReceiveContext,
-///     _host: &impl HasHost<(), StateApiType = S>,
-/// ) -> Result<(), MyCustomError> {
+/// fn contract_receive(_ctx: &ReceiveContext, _host: &Host<()>) -> Result<(), MyCustomError> {
 ///     Err(MyCustomError::SomeError)
 /// }
 /// ```
@@ -989,7 +972,7 @@ pub type ReceiveResult<A> = Result<A, Reject>;
 /// parametrized by the state type of the smart contract.
 ///
 /// Optionally, to define a custom type for error instead of using Reject,
-/// allowing the track the reason for rejection, *but only in unit tests*.
+/// allowing the track the reason for rejection.
 ///
 /// See also the documentation for [bail!](macro.bail.html) for how to use
 /// custom error types.
@@ -1004,39 +987,106 @@ pub type ReceiveResult<A> = Result<A, Reject>;
 /// }
 ///
 /// #[init(contract = "mycontract")]
-/// fn contract_init<S: HasStateApi>(
-///     _ctx: &impl HasInitContext,
-///     _state_builder: &mut StateBuilder<S>,
+/// fn contract_init(
+///     _ctx: &InitContext,
+///     _state_builder: &mut StateBuilder,
 /// ) -> Result<(), MyCustomError> {
 ///     Err(MyCustomError::SomeError)
 /// }
 /// ```
 pub type InitResult<S> = Result<S, Reject>;
 
-// TODO: Document these.
+/// Type alias for the context of init methods.
+///
+/// See [`ExternContext`] for more details.
 pub type InitContext = ExternContext<ExternInitContext>;
+
+/// Type alias for the context of receive methods.
+///
+/// See [`ExternContext`] for more details.
 pub type ReceiveContext = ExternContext<ExternReceiveContext>;
+
+/// The host, which supports interactions with the chain, such as querying
+/// balance of the contract, accessing its state, and invoking operations on
+/// other contracts and accounts.
+///
+/// The type is parameterized by the `State` type. This is the type of the
+/// contract state that the particular contract operates on.
+///
+/// See [`ExternHost`] for more details.
 pub type Host<State> = ExternHost<State>;
+
+/// The contract state, which uses Wasm host functions to interact with the node
+/// and use the state.
+///
+/// See [`ExternStateApi`] for more details.
 pub type StateApi = ExternStateApi;
+
+/// Host-backed cryptographic primitives.
+///
+/// See [`ExternCryptoPrimitives`] for the methods implemented via
+/// [`HasCryptoPrimitives`].
 pub type CryptoPrimitives = ExternCryptoPrimitives;
+
+/// A low-level host, used by receive methods with the attribute `low_level`.
+///
+/// See [`ExternLowLevelHost`] for the methods implemented via `HasHost`.
 pub type LowLevelHost = ExternLowLevelHost;
-pub type ChainMeta = ExternChainMeta;
+
+/// Host-backed access to chain metadata.
+///
+/// See [`ExternChainMeta`] for the methods implemented via the
+/// `HasChainMetadata` trait.
+pub type ChainMetadata = ExternChainMeta;
+
+/// A host-backed iterator over part of the state.
+///
+/// See [`ExternStateIter`] for the methods implemented via primarily
+/// [`Iterator`].
 pub type StateIter = ExternStateIter;
+
+/// A type representing the return value of contract init or receive method.
+///
+/// The intention is that this type is manipulated using methods of the
+/// [Write](crate::Write) trait. In particular it can be used as a sink to
+/// serialize values into.
+///
+/// See [`ExternReturnValue`] for more details.
 pub type ReturnValue = ExternReturnValue;
 
+/// A type representing the return value of contract invocation.
+///
+/// A contract invocation **may** return a value. It is returned in the
+/// following cases
+/// - an entrypoint of a V1 contract was invoked and the invocation succeeded
+/// - an entrypoint of a V1 contract was invoked and the invocation failed due
+///   to a [CallContractError::LogicReject]
+///
+/// In all other cases there is no response.
+///
+/// This type is designed to be used via its [Read](crate::Read) and
+/// [HasCallResponse](crate::HasCallResponse) traits.
+///
+/// See [`ExternCallResponse`] for more details.
+pub type CallResponse = ExternCallResponse;
+
 /// Operations backed by host functions for the high-level interface.
-#[doc(hidden)]
 pub struct ExternHost<State> {
     pub state:         State,
     pub state_builder: StateBuilder<ExternStateApi>,
 }
 
 #[derive(Default)]
-/// An state builder that allows the creation of [`StateMap`], [`StateSet`], and
-/// [`StateBox`]. It is parametrized by a parameter `S` that is assumed to
-/// implement [`HasStateApi`].
+/// A state builder that allows the creation of [`StateMap`], [`StateSet`], and
+/// [`StateBox`].
 ///
-/// The state_builder is designed to provide an abstraction over the contract
+/// It is parametrized by a parameter `S` that is assumed to
+/// implement [`HasStateApi`] to support testing with the deprecated
+/// [`concordium_std::test_infrastructure`]. The `S` defaults to `StateApi`,
+/// which is sufficient to test with the [concordium-smart-contract-testing](https://docs.rs/concordium-smart-contract-testing)
+/// library.
+///
+/// The StateBuilder is designed to provide an abstraction over the contract
 /// state, abstracting over the exact **keys** (keys in the sense of key-value
 /// store, which is the low-level semantics of contract state) that are used
 /// when storing specific values.
@@ -1051,7 +1101,6 @@ impl<S> StateBuilder<S> {
 
 /// A struct for which HasCryptoPrimitives is implemented via the crypto host
 /// functions.
-#[doc(hidden)]
 pub struct ExternCryptoPrimitives;
 
 /// Sha2 digest with 256 bits (32 bytes).
@@ -1096,7 +1145,6 @@ pub struct HashSha3256(pub [u8; 32]);
 pub struct HashKeccak256(pub [u8; 32]);
 
 #[derive(Debug, Clone, Default)]
-#[doc(hidden)]
 pub struct ExternStateApi;
 
 impl ExternStateApi {
@@ -1106,7 +1154,6 @@ impl ExternStateApi {
 }
 
 /// Operations backed by host functions for the low-level interface.
-#[doc(hidden)]
 #[derive(Default)]
 pub struct ExternLowLevelHost {
     pub(crate) state_api:     ExternStateApi,
@@ -1115,19 +1162,15 @@ pub struct ExternLowLevelHost {
 
 /// Context backed by host functions.
 #[derive(Default)]
-#[doc(hidden)]
 pub struct ExternContext<T: sealed::ContextType> {
     marker: crate::marker::PhantomData<T>,
 }
 
-#[doc(hidden)]
 pub struct ExternChainMeta {}
 
 #[derive(Default)]
-#[doc(hidden)]
 pub struct ExternInitContext;
 #[derive(Default)]
-#[doc(hidden)]
 pub struct ExternReceiveContext;
 
 pub(crate) mod sealed {

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -1047,7 +1047,7 @@ pub type LowLevelHost = ExternLowLevelHost;
 ///
 /// See [`ExternChainMeta`] for the methods implemented via the
 /// `HasChainMetadata` trait.
-pub type ChainMetadata = ExternChainMeta;
+pub type ChainMeta = ExternChainMeta;
 
 /// A host-backed iterator over part of the state.
 ///
@@ -1070,12 +1070,12 @@ pub type ReturnValue = ExternReturnValue;
 /// following cases
 /// - an entrypoint of a V1 contract was invoked and the invocation succeeded
 /// - an entrypoint of a V1 contract was invoked and the invocation failed due
-///   to a [CallContractError::LogicReject]
+///   to a [`CallContractError::LogicReject`]
 ///
 /// In all other cases there is no response.
 ///
 /// This type is designed to be used via its [Read](crate::Read) and
-/// [HasCallResponse](crate::HasCallResponse) traits.
+/// [`HasCallResponse`](crate::HasCallResponse) traits.
 ///
 /// See [`ExternCallResponse`] for more details.
 pub type CallResponse = ExternCallResponse;

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -1017,7 +1017,7 @@ pub type InitContext = ExternContext<ExternInitContext>;
 pub type ReceiveContext = ExternContext<ExternReceiveContext>;
 
 /// The host, which supports interactions with the chain, such as querying
-/// balance of the contract, accessing its state, and invoking operations on
+/// the balance of the contract, accessing its state, and invoking operations on
 /// other contracts and accounts.
 ///
 /// The type is parameterized by the `State` type. This is the type of the

--- a/examples/credential-registry/src/lib.rs
+++ b/examples/credential-registry/src/lib.rs
@@ -1636,6 +1636,7 @@ fn contract_upgrade<S: HasStateApi>(
 }
 
 #[concordium_cfg_test]
+#[allow(deprecated)]
 mod tests {
 
     use super::*;

--- a/examples/offchain-transfers/src/lib.rs
+++ b/examples/offchain-transfers/src/lib.rs
@@ -582,6 +582,7 @@ pub fn contract_get_settlement<S: HasStateApi>(
 // Tests //
 
 #[concordium_cfg_test]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use concordium_std::test_infrastructure::*;

--- a/examples/two-step-transfer/src/lib.rs
+++ b/examples/two-step-transfer/src/lib.rs
@@ -306,6 +306,7 @@ fn contract_receive_message<S: HasStateApi>(
 // Tests
 
 #[concordium_cfg_test]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use concordium_std::test_infrastructure::*;


### PR DESCRIPTION
## Purpose

Deprecate the `test_infrastructure` and supporting traits.
Closes https://github.com/Concordium/concordium-rust-smart-contracts/issues/339.
Closes https://github.com/Concordium/concordium-rust-smart-contracts/issues/340.

Depends on:
 - https://github.com/Concordium/concordium-base/pull/457
 - https://github.com/Concordium/concordium-rust-sdk/pull/130

## Changes

- Deprecate the `test_infrastructure` using the `deprecated` attribute.
- Deprecate a number of traits, including `HasHost` via the doc comments.
   - While using the `deprecated` attribute would be ideal, it would require a substantial amount of other changes to avoid deprecation warnings in user code. Since we are removing the `test_infrastructure` and traits completely in a version or two, the extra work was not worth the effort. 
- Document how to migrate your contracts to use the concrete types directly in the library docs.
- Added type aliases that remove the `Extern` prefixes for the concrete types.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.