### PR TITLE
Add example how to generate Ed25519 signature in the test case

### DIFF
--- a/examples/signature-verifier/Cargo.toml
+++ b/examples/signature-verifier/Cargo.toml
@@ -12,7 +12,7 @@ concordium-std = {path = "../../concordium-std"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }
-ed25519-dalek = { version = "2.0.0", features = ["rand_core"]  }
+ed25519-dalek = { version = "2.0", features = ["rand_core"]  }
 rand = "0.8.5"
 
 [features]

--- a/examples/signature-verifier/Cargo.toml
+++ b/examples/signature-verifier/Cargo.toml
@@ -12,6 +12,8 @@ concordium-std = {path = "../../concordium-std"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }
+ed25519-dalek = { version = "2.0.0", features = ["rand_core"]  }
+rand = "0.8.5"
 
 [features]
 default = ["std", "wee_alloc"]

--- a/examples/signature-verifier/tests/tests.rs
+++ b/examples/signature-verifier/tests/tests.rs
@@ -49,9 +49,9 @@ fn test_outside_signature_check() {
                 .expect("Parameter has valid size."),
         })
         .expect("Call signature verifier contract with an invalid signature.");
-    // Check that it returns `false`.
+    // Check that the signature does NOT verify.
     let rv: bool = update_invalid.parse_return_value().expect("Deserializing bool");
-    assert_eq!(rv, false);
+    assert!(!rv, "Signature verification should fail.");
 
     // Construct a parameter with a valid signature.
     let parameter_valid = VerificationParameter {
@@ -70,7 +70,7 @@ fn test_outside_signature_check() {
                 .expect("Parameter has valid size."),
         })
         .expect("Call signature verifier contract with a valid signature.");
-    // Check that it returns `true`.
+    // Check that the signature verifies.
     let rv: bool = update.parse_return_value().expect("Deserializing bool");
     assert!(rv, "Signature checking failed.");
 }
@@ -126,9 +126,9 @@ fn test_inside_signature_check() {
         })
         .expect("Call signature verifier contract with an invalid signature.");
 
-    // Check that it returns `false`.
+    // Check that the signature does NOT verify.
     let rv: bool = update_invalid.parse_return_value().expect("Deserializing bool");
-    assert_eq!(rv, false);
+    assert!(!rv, "Signature verification should fail.");
 
     // Construct a parameter with a valid signature.
     let parameter_valid = VerificationParameter {
@@ -148,7 +148,7 @@ fn test_inside_signature_check() {
         })
         .expect("Call signature verifier contract with a valid signature.");
 
-    // Check that it returns `true`.
+    // Check that the signature verifies.
     let rv: bool = update.parse_return_value().expect("Deserializing bool");
     assert!(rv, "Signature checking failed.");
 }


### PR DESCRIPTION
## Purpose

It would be useful if we have test cases in our example smart contracts that showcase how to generate signatures in the test case directly side by side with our current approach of using external tools to create such signatures (e.g. https://cyphr.me/ed25519_tool/ed.html). This in-code signature generation would have simplified the umbrella smart contracts tests (checking ed25519 signatures) as well as simplified some of the cis3-sponsored-transaction smart contract tests (checking account signatures).

## Changes

- Add test case to `signature-verifier` to showcase how ed25519 signatures can be generated within a test case.

