### PR TITLE
Re-export AccountKeys

### DIFF
--- a/.github/workflows/linter-testing-lib.yaml
+++ b/.github/workflows/linter-testing-lib.yaml
@@ -28,7 +28,7 @@ on:
 
 env:
   RUST_FMT: nightly-2023-04-01-x86_64-unknown-linux-gnu
-  RUST_CLIPPY: 1.66
+  RUST_CLIPPY: 1.67
 
 jobs:
   "lint_fmt":

--- a/contract-testing/CHANGELOG.md
+++ b/contract-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Bump minimum supported Rust version to `1.67`.
+- Re-export `AccountKeys`.
+
 ## 3.1.0
 
 - Add functionality for setting the exchange rates and block time of the chain based on queries from an external node.

--- a/contract-testing/Cargo.toml
+++ b/contract-testing/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "concordium-smart-contract-testing"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
-rust-version = "1.66"
+rust-version = "1.67"
 license = "MPL-2.0"
 readme = "README.md"
 description = "A companion crate to `concordium-std` that supports off-chain end-to-end testing of smart contracts."

--- a/contract-testing/src/lib.rs
+++ b/contract-testing/src/lib.rs
@@ -103,7 +103,7 @@ pub use concordium_base::{
         ReceiveName, SignatureThreshold, SlotTime, Timestamp,
     },
     hashes::BlockHash,
-    id::types::{CredentialPublicKeys, VerifyKey},
+    id::types::{AccountKeys, CredentialPublicKeys, VerifyKey},
     smart_contracts::{ContractEvent, ContractTraceElement, InstanceUpdatedEvent, WasmVersion},
     transactions::{AccountAccessStructure, InitContractPayload, UpdateContractPayload},
 };


### PR DESCRIPTION
## Purpose

To generate signatures in the test cases of the sponsored transaction example, we need to use the `AccountKeys` type.

## Changes

- Re-export AccountKeys type.
- Fix CI pipeline by increasing Rust version.
