### PR TITLE
Allow operators to sign a permit transfer action

### DIFF
--- a/examples/cis2-multi/src/lib.rs
+++ b/examples/cis2-multi/src/lib.rs
@@ -846,13 +846,15 @@ fn contract_permit(
 
         let TransferParams(transfers): TransferParameter = from_bytes(&message.payload)?;
 
-        for transfer_struct in transfers {
+        for transfer_entry in transfers {
+            // Authenticate the signer for this transfer
             ensure!(
-                transfer_struct.from.matches_account(&param.signer),
+                transfer_entry.from.matches_account(&param.signer)
+                    || host.state().is_operator(&Address::from(param.signer), &transfer_entry.from),
                 ContractError::Unauthorized
             );
 
-            transfer(transfer_struct, host, logger)?
+            transfer(transfer_entry, host, logger)?
         }
     } else if message.entry_point.as_entrypoint_name()
         == EntrypointName::new_unchecked("updateOperator")

--- a/examples/cis3-nft-sponsored-txs/src/lib.rs
+++ b/examples/cis3-nft-sponsored-txs/src/lib.rs
@@ -835,13 +835,15 @@ fn contract_permit(
 
         let TransferParams(transfers): TransferParameter = from_bytes(&message.payload)?;
 
-        for transfer_struct in transfers {
+        for transfer_entry in transfers {
+            // Authenticate the signer for this transfer
             ensure!(
-                transfer_struct.from.matches_account(&param.signer),
+                transfer_entry.from.matches_account(&param.signer)
+                    || host.state().is_operator(&Address::from(param.signer), &transfer_entry.from),
                 ContractError::Unauthorized
             );
 
-            transfer(transfer_struct, host, logger)?
+            transfer(transfer_entry, host, logger)?
         }
     } else if message.entry_point.as_entrypoint_name()
         == EntrypointName::new_unchecked("updateOperator")


### PR DESCRIPTION
## Purpose

To adhere to the CIS3 standard, we discussed and decided to allow `operators` to sign and execute a `transfer` permit operation as well. The logic/authentication is now equivalent to the normal `transfer` function.

## Changes

Allow operators to sign/authorize a transfer permit operation. 