### PR TITLE
Allow debugging output in the testing library.

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+- Add a `concordium_dbg!` macro and the associated `debug` feature to enable,
+  together with `cargo concordium`, to emit debug information during contract
+  execution.
+
 ## concordium-std 8.1.0 (2023-10-18)
 
 - Set minimum Rust version to 1.66.

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -34,6 +34,7 @@ wasm-test = ["concordium-contracts-common/wasm-test"]
 build-schema = ["concordium-contracts-common/build-schema"]
 crypto-primitives = ["sha2", "sha3", "secp256k1", "ed25519-zebra"]
 concordium-quickcheck = ["getrandom", "quickcheck", "concordium-contracts-common/concordium-quickcheck", "std"]
+debug = []
 
 [lib]
 crate-type = ["rlib"]

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -152,8 +152,9 @@
 //! The `debug` feature should typically not be enabled manually. It is used
 //! implicitly by `cargo concordium` when debug output is requested. It is also
 //! **crucial** that the `debug` feature is **not** enabled when building the
-//! contract for deployment. The `concordium_dbg!` macro will ignore its
-//! arguments when the `debug` feature is not enabled.
+//! contract for deployment. If it is the contract is most likely to be rejected
+//! when it is being deployed to the chain. The `concordium_dbg!` macro will
+//! ignore its arguments when the `debug` feature is not enabled.
 //!
 //! # Essential types
 //! This crate has a number of essential types that are used when writing smart

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -400,6 +400,12 @@ pub use std::format;
 
 #[macro_export]
 #[cfg(feature = "debug")]
+/// When the `debug` feature of `concordium-std` is enabled this will use the
+/// `debug_print` host function to emit the provided information. The syntax is
+/// the same as that of `println!` macro.
+///
+/// If the `debug` feature is not enabled the macro generates an empty
+/// expression.
 macro_rules! concordium_dbg {
     () => {
         {
@@ -416,6 +422,12 @@ macro_rules! concordium_dbg {
 
 #[macro_export]
 #[cfg(not(feature = "debug"))]
+/// When the `debug` feature of `concordium-std` is enabled this will use the
+/// `debug_print` host function to emit the provided information. The syntax is
+/// the same as that of `println!` macro.
+///
+/// If the `debug` feature is not enabled the macro generates an empty
+/// expression.
 macro_rules! concordium_dbg {
     () => {{}};
     ($($arg:tt),+) => {{}};

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -39,6 +39,7 @@
 //! [`wasm-test`](#wasm-test-build-for-testing-in-wasm),
 //! [`crypto-primitives`][crypto-feature], and
 //! [`wee_alloc`](#use-a-custom-allocator)
+//! [`debug`](#emit-debug-information)
 //!
 //! [crypto-feature]:
 //! #crypto-primitives-for-testing-crypto-with-actual-implementations
@@ -138,6 +139,21 @@
 //! Configuration of other allocators should follow their respective
 //! documentation, however note that there can only be one allocator set.
 //! See Rust [allocator](https://doc.rust-lang.org/std/alloc/index.html#the-global_allocator-attribute) documentation for more context and details.
+//!
+//! Emit debug information
+//!
+//! During testing and debugging it is often useful to emit debug information to
+//! narrow down the source of the problem. `concordium-std` supports this using
+//! the [`concordium_dbg`] macro which will emit its arguments using a special
+//! host function `debug_print` which is only available when the `debug` feature
+//! is enabled. The output of this function is used by `cargo concordium run`
+//! and `cargo concordium test` to display any output that was emitted.
+//!
+//! The `debug` feature should typically not be enabled manually. It is used
+//! implicitly by `cargo concordium` when debug output is requested. It is also
+//! **crucial** that the `debug` feature is **not** enabled when building the
+//! contract for deployment. The `concordium_dbg!` macro will ignore its
+//! arguments when the `debug` feature is not enabled.
 //!
 //! # Essential types
 //! This crate has a number of essential types that are used when writing smart

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -285,7 +285,7 @@ extern "C" {
     #[cfg(feature = "debug")]
     /// Emit text together with the source location.
     /// This is used as the equivalent of the `dbg!` macro when the
-    /// `enable-debug` feature is enabled.
+    /// `debug` feature is enabled.
     ///
     /// Note that this function is not allowed on the chain, it is only there to
     /// ease local testing.

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -282,6 +282,22 @@ extern "C" {
         column: u32,
     );
 
+    #[cfg(feature = "debug")]
+    /// Emit text together with the source location.
+    /// This is used as the equivalent of the `dbg!` macro when the
+    /// `enable-debug` feature is enabled.
+    ///
+    /// Note that this function is not allowed on the chain, it is only there to
+    /// ease local testing.
+    pub fn debug_print(
+        msg_start: *const u8,
+        msg_length: u32,
+        filename_start: *const u8,
+        filename_length: u32,
+        line: u32,
+        column: u32,
+    );
+
     #[cfg(all(feature = "wasm-test", feature = "concordium-quickcheck", target_arch = "wasm32"))]
     /// Generating random numbers for randomised testing.
     /// Not available for contracts deployed on the chain.

--- a/contract-testing/CHANGELOG.md
+++ b/contract-testing/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased changes
 
+- Add support for debug output when running smart contracts. This adds a new
+  `module_deploy_v1_debug` method to the `Chain` that allows debug symbols
+  in the deployed module.
+- Add `DebugInfoExt` trait that has convenience methods for printing debug
+  information.
+- Add `debug_trace` field to `DebugTraceElement` variants. This records both any
+  information emitted by the `concordium_dbg!` macro of `concordium-std` as well
+  as the trace of all the host function calls that occurred.
+- Add `is_debug_enabled` function to detect whether tests are being run in debug
+  mode or not. This function uses the `CARGO_CONCORDIUM_TEST_ALLOW_DEBUG`
+  environment variable that is set by `cargo-concordium` when running in debug
+  mode.
+
 ## 3.2.0
 
 - Bump minimum supported Rust version to `1.67`.

--- a/contract-testing/Cargo.toml
+++ b/contract-testing/Cargo.toml
@@ -26,3 +26,7 @@ num-integer = "0.1"
 
 [dev-dependencies]
 rand = "0.7"
+clap = { version = "4", features = ["derive", "env"] }
+tokio = {version = "1", features = ["rt-multi-thread", "macros"]}
+futures = "0.3"
+

--- a/contract-testing/Cargo.toml
+++ b/contract-testing/Cargo.toml
@@ -26,6 +26,3 @@ num-integer = "0.1"
 
 [dev-dependencies]
 rand = "0.7"
-# clap = { version = "4", features = ["derive", "env"] }
-# futures = "0.3"
-

--- a/contract-testing/Cargo.toml
+++ b/contract-testing/Cargo.toml
@@ -26,7 +26,6 @@ num-integer = "0.1"
 
 [dev-dependencies]
 rand = "0.7"
-clap = { version = "4", features = ["derive", "env"] }
-tokio = {version = "1", features = ["rt-multi-thread", "macros"]}
-futures = "0.3"
+# clap = { version = "4", features = ["derive", "env"] }
+# futures = "0.3"
 

--- a/contract-testing/src/impls.rs
+++ b/contract-testing/src/impls.rs
@@ -21,8 +21,8 @@ use concordium_base::{
 use concordium_rust_sdk::{self as sdk, v2::Endpoint};
 use concordium_smart_contract_engine::{
     v0,
-    v1::{self, InvokeResponse},
-    InterpreterEnergy,
+    v1::{self, DebugTracker, InvalidReturnCodeError, InvokeResponse},
+    DebugInfo, InterpreterEnergy,
 };
 use concordium_wasm::validate::ValidationConfig;
 use num_bigint::BigUint;
@@ -383,6 +383,17 @@ impl Default for ChainBuilder {
     fn default() -> Self { Self::new() }
 }
 
+// Exit early with an out of energy error.
+macro_rules! exit_ooe {
+    ($charge:expr, $trace:expr) => {
+        if let Err(InsufficientEnergy) = $charge {
+            return Err(ContractInitErrorKind::OutOfEnergy {
+                debug_trace: $trace,
+            });
+        }
+    };
+}
+
 impl Chain {
     /// Get a [`ChainBuilder`] for constructing a new [`Chain`] with a builder
     /// pattern.
@@ -485,6 +496,27 @@ impl Chain {
         sender: AccountAddress,
         wasm_module: WasmModule,
     ) -> Result<ModuleDeploySuccess, ModuleDeployError> {
+        self.module_deploy_v1_worker(signer, sender, wasm_module, false)
+    }
+
+    /// Like [`module_deploy_v1`](Self::module_deploy_v1)
+    /// except that the use of debug tools is allowed.
+    pub fn module_deploy_v1_debug(
+        &mut self,
+        signer: Signer,
+        sender: AccountAddress,
+        wasm_module: WasmModule,
+    ) -> Result<ModuleDeploySuccess, ModuleDeployError> {
+        self.module_deploy_v1_worker(signer, sender, wasm_module, true)
+    }
+
+    fn module_deploy_v1_worker(
+        &mut self,
+        signer: Signer,
+        sender: AccountAddress,
+        wasm_module: WasmModule,
+        enable_debug: bool,
+    ) -> Result<ModuleDeploySuccess, ModuleDeployError> {
         // For maintainers:
         //
         // This function does not correspond exactly to what happens in the node.
@@ -559,6 +591,7 @@ impl Chain {
                 ValidationConfig::V1,
                 &v1::ConcordiumAllowedImports {
                     support_upgrade: true,
+                    enable_debug,
                 },
                 wasm_module.source.as_ref(),
             ) {
@@ -688,7 +721,7 @@ impl Chain {
         };
 
         // Charge the header cost.
-        remaining_energy.tick_energy(check_header_cost)?;
+        exit_ooe!(remaining_energy.tick_energy(check_header_cost), DebugTracker::empty_trace());
 
         // Ensure that the parameter has a valid size.
         if payload.param.as_ref().len() > contracts_common::constants::MAX_PARAMETER_LEN {
@@ -696,7 +729,10 @@ impl Chain {
         }
 
         // Charge the base cost for initializing a contract.
-        remaining_energy.tick_energy(constants::INITIALIZE_CONTRACT_INSTANCE_BASE_COST)?;
+        exit_ooe!(
+            remaining_energy.tick_energy(constants::INITIALIZE_CONTRACT_INSTANCE_BASE_COST),
+            DebugTracker::empty_trace()
+        );
 
         // Check that the account also has enough funds to pay for the amount (in
         // addition to the reserved energy).
@@ -709,7 +745,7 @@ impl Chain {
         let lookup_cost = lookup_module_cost(&module);
 
         // Charge the cost for looking up the module.
-        remaining_energy.tick_energy(lookup_cost)?;
+        exit_ooe!(remaining_energy.tick_energy(lookup_cost), DebugTracker::empty_trace());
 
         // Ensure the module contains the provided init name.
         let init_name = payload.init_name.as_contract_name().get_chain_name();
@@ -743,8 +779,9 @@ impl Chain {
         // presently, so the loader is not used.
         let mut loader = v1::trie::Loader::new(&[][..]);
 
-        let energy_given_to_interpreter = to_interpreter_energy(*remaining_energy);
-        let res = v1::invoke_init(
+        let energy_given_to_interpreter =
+            InterpreterEnergy::new(to_interpreter_energy(*remaining_energy));
+        let res = v1::invoke_init::<_, _, DebugTracker>(
             module.artifact,
             init_ctx,
             v1::InitInvocation {
@@ -764,6 +801,7 @@ impl Chain {
                                   * it for inits, currently. */
                 remaining_energy: remaining_interpreter_energy,
                 mut state,
+                trace,
             }) => {
                 let contract_address = self.create_contract_address();
                 let mut collector = v1::trie::SizeCollector::default();
@@ -774,17 +812,20 @@ impl Chain {
                 // and *then* convert to `Energy`. This is how it is done in the node, and if we
                 // swap the operations, it can result in a small discrepancy due to rounding.
                 let energy_used_in_interpreter = from_interpreter_energy(
-                    energy_given_to_interpreter.saturating_sub(remaining_interpreter_energy),
+                    &energy_given_to_interpreter.saturating_sub(&remaining_interpreter_energy),
                 );
-                remaining_energy.tick_energy(energy_used_in_interpreter)?;
+                exit_ooe!(remaining_energy.tick_energy(energy_used_in_interpreter), trace);
 
                 // Charge one energy per stored state byte.
                 let energy_for_state_storage = Energy::from(collector.collect());
-                remaining_energy.tick_energy(energy_for_state_storage)?;
+                exit_ooe!(remaining_energy.tick_energy(energy_for_state_storage), trace);
 
                 // Charge the constant cost for initializing a contract.
-                remaining_energy
-                    .tick_energy(constants::INITIALIZE_CONTRACT_INSTANCE_CREATE_COST)?;
+                exit_ooe!(
+                    remaining_energy
+                        .tick_energy(constants::INITIALIZE_CONTRACT_INSTANCE_CREATE_COST),
+                    trace
+                );
 
                 let contract = Contract {
                     module_reference: payload.mod_ref,
@@ -810,48 +851,60 @@ impl Chain {
                     events: contract_events_from_logs(logs),
                     energy_used,
                     transaction_fee,
+                    debug_trace: trace,
                 })
             }
             Ok(v1::InitResult::Reject {
                 reason,
                 return_value,
                 remaining_energy: remaining_interpreter_energy,
+                trace,
             }) => {
                 let energy_used_in_interpreter = from_interpreter_energy(
-                    energy_given_to_interpreter.saturating_sub(remaining_interpreter_energy),
+                    &energy_given_to_interpreter.saturating_sub(&remaining_interpreter_energy),
                 );
-                remaining_energy.tick_energy(energy_used_in_interpreter)?;
+                exit_ooe!(remaining_energy.tick_energy(energy_used_in_interpreter), trace);
                 Err(ContractInitErrorKind::ExecutionError {
-                    error: InitExecutionError::Reject {
+                    error:       InitExecutionError::Reject {
                         reason,
                         return_value,
                     },
+                    debug_trace: trace,
                 })
             }
             Ok(v1::InitResult::Trap {
                 error,
                 remaining_energy: remaining_interpreter_energy,
+                trace,
             }) => {
                 let energy_used_in_interpreter = from_interpreter_energy(
-                    energy_given_to_interpreter.saturating_sub(remaining_interpreter_energy),
+                    &energy_given_to_interpreter.saturating_sub(&remaining_interpreter_energy),
                 );
-                remaining_energy.tick_energy(energy_used_in_interpreter)?;
+                exit_ooe!(remaining_energy.tick_energy(energy_used_in_interpreter), trace);
                 Err(ContractInitErrorKind::ExecutionError {
-                    error: InitExecutionError::Trap {
+                    error:       InitExecutionError::Trap {
                         error: error.into(),
                     },
+                    debug_trace: trace,
                 })
             }
-            Ok(v1::InitResult::OutOfEnergy) => {
+            Ok(v1::InitResult::OutOfEnergy {
+                trace,
+            }) => {
                 *remaining_energy = Energy::from(0);
                 Err(ContractInitErrorKind::ExecutionError {
-                    error: InitExecutionError::OutOfEnergy,
+                    error:       InitExecutionError::OutOfEnergy,
+                    debug_trace: trace,
                 })
             }
-            Err(error) => Err(ContractInitErrorKind::ExecutionError {
+            Err(InvalidReturnCodeError {
+                value,
+                debug_trace,
+            }) => Err(ContractInitErrorKind::ExecutionError {
                 error: InitExecutionError::Trap {
-                    error: error.into(),
+                    error: anyhow::anyhow!("Invalid return value received: {value:?}").into(),
                 },
+                debug_trace,
             }),
         }
     }
@@ -923,7 +976,8 @@ impl Chain {
             next_contract_modification_index: 1,
         };
 
-        match contract_invocation.invoke_entrypoint(invoker, sender, payload) {
+        let res = contract_invocation.invoke_entrypoint(invoker, sender, payload);
+        match res {
             Ok((result, trace_elements)) => {
                 Ok((result, contract_invocation.changeset, trace_elements))
             }
@@ -1036,7 +1090,9 @@ impl Chain {
                 energy_used:     Energy::from(0),
                 transaction_fee: Amount::zero(),
                 trace_elements:  Vec::new(),
-                kind:            ContractInvokeErrorKind::OutOfEnergy,
+                kind:            ContractInvokeErrorKind::OutOfEnergy {
+                    debug_trace: DebugTracker::empty_trace(), // we haven't done anything yet.
+                },
             })?;
 
         let invoker_amount_reserved_for_nrg =
@@ -1073,7 +1129,17 @@ impl Chain {
                         &mut self.accounts,
                         &mut self.contracts,
                     );
-                    res.map_err(|_| self.invocation_out_of_energy_error(energy_reserved))?
+                    if let Ok(res) = res {
+                        res
+                    } else {
+                        // the error happens when storing the state, so there are no trace elements
+                        // associated with it. The trace is already in the
+                        // "debug trace" vector.
+                        return Err(self.invocation_out_of_energy_error(
+                            energy_reserved,
+                            DebugTracker::empty_trace(),
+                        ));
+                    }
                 } else {
                     // An error occurred, so state hasn't changed.
                     false
@@ -1171,9 +1237,19 @@ impl Chain {
                 // Charge energy for contract storage. Or return an error if out
                 // of energy.
                 let state_changed = if matches!(result, v1::InvokeResponse::Success { .. }) {
-                    changeset
-                        .collect_energy_for_state(&mut remaining_energy, contract_address)
-                        .map_err(|_| self.invocation_out_of_energy_error(energy_reserved))?
+                    if let Ok(state_changed) =
+                        changeset.collect_energy_for_state(&mut remaining_energy, contract_address)
+                    {
+                        state_changed
+                    } else {
+                        // the error happens when storing the state, so there are no trace elements
+                        // associated with it. The trace is already in the
+                        // "debug trace" vector.
+                        return Err(self.invocation_out_of_energy_error(
+                            energy_reserved,
+                            DebugTracker::empty_trace(),
+                        ));
+                    }
                 } else {
                     // An error occurred, so state hasn't changed.
                     false
@@ -1481,7 +1557,7 @@ impl Chain {
         energy_reserved: Energy,
         remaining_energy: Energy,
     ) -> ContractInvokeError {
-        let remaining_energy = if matches!(kind, ContractInvokeErrorKind::OutOfEnergy) {
+        let remaining_energy = if matches!(kind, ContractInvokeErrorKind::OutOfEnergy { .. }) {
             0.into()
         } else {
             remaining_energy
@@ -1499,9 +1575,15 @@ impl Chain {
     /// Construct a [`ContractInvokeErrorKind`] of the `OutOfEnergy` kind with
     /// the energy and transaction fee fields based on the `energy_reserved`
     /// parameter.
-    fn invocation_out_of_energy_error(&self, energy_reserved: Energy) -> ContractInvokeError {
+    fn invocation_out_of_energy_error(
+        &self,
+        energy_reserved: Energy,
+        debug_trace: DebugTracker,
+    ) -> ContractInvokeError {
         self.convert_to_invoke_error(
-            ContractInvokeErrorKind::OutOfEnergy,
+            ContractInvokeErrorKind::OutOfEnergy {
+                debug_trace,
+            },
             Vec::new(),
             energy_reserved,
             Energy::from(0),
@@ -1998,27 +2080,24 @@ impl ContractInvokeError {
     }
 }
 
-impl From<InsufficientEnergy> for ContractInitErrorKind {
-    #[inline(always)]
-    fn from(_: InsufficientEnergy) -> Self { Self::OutOfEnergy }
-}
-
 impl From<TestConfigurationError> for ContractInvokeErrorKind {
     fn from(err: TestConfigurationError) -> Self {
         match err {
-            TestConfigurationError::OutOfEnergy => Self::OutOfEnergy,
+            TestConfigurationError::OutOfEnergy {
+                debug_trace,
+            } => Self::OutOfEnergy {
+                debug_trace,
+            },
             TestConfigurationError::BalanceOverflow => Self::BalanceOverflow,
         }
     }
 }
 
 /// Convert [`Energy`] to [`InterpreterEnergy`] by multiplying by `1000`.
-pub(crate) fn to_interpreter_energy(energy: Energy) -> InterpreterEnergy {
-    InterpreterEnergy::from(energy.energy * 1000)
-}
+pub(crate) fn to_interpreter_energy(energy: Energy) -> u64 { energy.energy * 1000 }
 
 /// Convert [`InterpreterEnergy`] to [`Energy`] by dividing by `1000`.
-pub(crate) fn from_interpreter_energy(interpreter_energy: InterpreterEnergy) -> Energy {
+pub(crate) fn from_interpreter_energy(interpreter_energy: &InterpreterEnergy) -> Energy {
     Energy::from(interpreter_energy.energy / 1000)
 }
 

--- a/contract-testing/src/invocation/impls.rs
+++ b/contract-testing/src/invocation/impls.rs
@@ -1391,8 +1391,7 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                 // more energy than what is available.
                 let used_energy = from_interpreter_energy(
                     &InterpreterEnergy::new(available_interpreter_energy)
-                        .saturating_sub(&remaining_energy), /* TODO: This is stupid. Revise
-                                                             * abstractions. */
+                        .saturating_sub(&remaining_energy),
                 );
                 self.remaining_energy.tick_energy(used_energy)?;
                 remaining_energy.energy = to_interpreter_energy(*self.remaining_energy);

--- a/contract-testing/src/invocation/types.rs
+++ b/contract-testing/src/invocation/types.rs
@@ -9,7 +9,7 @@ use concordium_base::{
     transactions::UpdateContractPayload,
 };
 use concordium_smart_contract_engine::v1::{
-    trie::MutableState, InvokeResponse, ReceiveContext, ReceiveInterruptedState,
+    trie::MutableState, DebugTracker, InvokeResponse, ReceiveContext, ReceiveInterruptedState,
 };
 use concordium_wasm::artifact::CompiledFunction;
 use std::collections::BTreeMap;
@@ -169,7 +169,9 @@ pub(super) enum AmountDelta {
 #[derive(Debug)]
 pub(crate) enum TestConfigurationError {
     /// The method ran out of energy.
-    OutOfEnergy,
+    OutOfEnergy {
+        debug_trace: DebugTracker,
+    },
     /// The balance of an account or contract oveflowed while adding a new
     /// [`Amount`]. On the chain there is roughly 10 billion CCD, which
     /// means that overflows of amounts cannot occur.

--- a/contract-testing/src/lib.rs
+++ b/contract-testing/src/lib.rs
@@ -89,7 +89,7 @@ mod constants;
 mod impls;
 mod invocation;
 mod types;
-pub use impls::{module_load_v1, module_load_v1_raw};
+pub use impls::{is_debug_enabled, module_load_v1, module_load_v1_raw};
 pub use types::*;
 
 // Re-export types.

--- a/contract-testing/src/types.rs
+++ b/contract-testing/src/types.rs
@@ -591,7 +591,7 @@ impl ContractInvokeSuccess {
                                 Some(error),
                             )));
                             if !trace_elements.is_empty() {
-                                self.stack.push(Next::Remaining(&trace_elements));
+                                self.stack.push(Next::Remaining(trace_elements));
                             }
                         }
                     }

--- a/contract-testing/src/types.rs
+++ b/contract-testing/src/types.rs
@@ -17,7 +17,7 @@ use concordium_base::{
 };
 use concordium_rust_sdk as sdk;
 use concordium_smart_contract_engine::{
-    v1::{self, trie, DebugTracker, EmittedDebugStatement, HostFunctionV1, ReturnValue},
+    v1::{self, trie, DebugTracker, HostFunctionV1, ReturnValue},
     InterpreterEnergy,
 };
 use concordium_wasm::artifact;

--- a/contract-testing/src/types.rs
+++ b/contract-testing/src/types.rs
@@ -17,7 +17,7 @@ use concordium_base::{
 };
 use concordium_rust_sdk as sdk;
 use concordium_smart_contract_engine::{
-    v1::{self, trie, DebugTracker, EmittedDebugStatement, HostFunctionV1, ReturnValue},
+    v1::{self, trie, DebugTracker, EmittedDebugStatement, HostCall, HostFunctionV1, ReturnValue},
     InterpreterEnergy,
 };
 use concordium_wasm::artifact;
@@ -745,15 +745,23 @@ pub trait DebugInfoExt: Sized {
     /// remaining trace and in the rolled back part.
     fn host_calls(&self) -> Box<dyn Iterator<Item = HostCallInfo<'_>> + '_> {
         Box::new(self.debug_events().flat_map(|de| {
-            de.debug_trace.host_call_trace.iter().map(move |(_, host_function, energy_used)| {
-                HostCallInfo {
-                    address:       de.address,
-                    entrypoint:    de.entrypoint,
-                    host_function: *host_function,
-                    energy_used:   *energy_used,
-                    rolled_back:   de.rolled_back,
-                }
-            })
+            de.debug_trace.host_call_trace.iter().map(
+                move |(
+                    _,
+                    HostCall {
+                        host_function,
+                        energy_used,
+                    },
+                )| {
+                    HostCallInfo {
+                        address:       de.address,
+                        entrypoint:    de.entrypoint,
+                        host_function: *host_function,
+                        energy_used:   *energy_used,
+                        rolled_back:   de.rolled_back,
+                    }
+                },
+            )
         }))
     }
 

--- a/examples/icecream/src/lib.rs
+++ b/examples/icecream/src/lib.rs
@@ -42,7 +42,7 @@ struct State {
     weather_service: ContractAddress,
 }
 
-#[derive(Serialize, SchemaType, Clone, Copy)]
+#[derive(Serialize, SchemaType, Clone, Copy, Debug)]
 pub enum Weather {
     Rainy,
     Sunny,
@@ -93,6 +93,7 @@ fn contract_buy_icecream(
 ) -> ContractResult<()> {
     let weather_service = host.state().weather_service;
     let icecream_vendor: AccountAddress = ctx.parameter_cursor().get()?;
+    concordium_dbg!("vendor = {icecream_vendor:?}");
 
     let weather = host
         .invoke_contract_raw(
@@ -107,6 +108,7 @@ fn contract_buy_icecream(
     } else {
         return Err(ContractError::ContractInvokeError);
     };
+    concordium_dbg!("Got weather = {weather:?}");
 
     match weather {
         Weather::Rainy => {
@@ -140,7 +142,7 @@ fn contract_replace_weather_service(
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/// Initialse the weather service with the weather.
+/// Initialise the weather service with the weather.
 #[init(contract = "weather", parameter = "Weather")]
 fn weather_init(ctx: &InitContext, _state_builder: &mut StateBuilder) -> InitResult<Weather> {
     let weather = ctx.parameter_cursor().get()?;

--- a/examples/icecream/tests/tests.rs
+++ b/examples/icecream/tests/tests.rs
@@ -38,6 +38,7 @@ fn test_sunny_day() {
                     .expect("Serialize account address."),
             },
         )
+        .print_emitted_events()
         .expect("Call icecream contract");
 
     // Check that the icecream vendor received the correct amount of money.
@@ -77,6 +78,7 @@ fn test_rainy_days() {
                 message:      OwnedParameter::from_serial(&ACC_1).expect("Serialize address"),
             },
         )
+        .print_debug(DebugOutputKind::HostCalls)
         .expect("Call icecream contract");
 
     // Check that the icecream vendor still has the original balance.
@@ -115,6 +117,7 @@ fn test_missing_weather() {
                 message:      OwnedParameter::from_serial(&ACC_1).expect("Serialize address"),
             },
         )
+        .print_debug(DebugOutputKind::Full)
         .expect_err("Call icecream contract");
 
     // Deserialize the return value from `update` and check that it is the expected
@@ -153,6 +156,7 @@ fn test_missing_icecream_vendor() {
                     .expect("Serialize address"),
             },
         )
+        .print_debug(DebugOutputKind::HostCallsSummary)
         .expect_err("Call icecream contract");
 
     // Deserialize the return value from `update` and check that it is the expected
@@ -209,7 +213,8 @@ fn initialize_chain() -> (Chain, ModuleReference) {
 
     // Load and deploy the module.
     let module = module_load_v1("concordium-out/module.wasm.v1").expect("Module exists");
-    let deployment = chain.module_deploy_v1(SIGNER, ACC_0, module).expect("Deploy valid module");
+    let deployment =
+        chain.module_deploy_v1_debug(SIGNER, ACC_0, module, is_debug_enabled()).expect("Deploy valid module");
 
     (chain, deployment.module_reference)
 }

--- a/examples/icecream/tests/tests.rs
+++ b/examples/icecream/tests/tests.rs
@@ -38,7 +38,7 @@ fn test_sunny_day() {
                     .expect("Serialize account address."),
             },
         )
-        .print_emitted_events()
+        .print_emitted_events() // log all `concordium_dbg` emitted events.
         .expect("Call icecream contract");
 
     // Check that the icecream vendor received the correct amount of money.
@@ -78,7 +78,7 @@ fn test_rainy_days() {
                 message:      OwnedParameter::from_serial(&ACC_1).expect("Serialize address"),
             },
         )
-        .print_debug(DebugOutputKind::HostCalls)
+        .print_debug(DebugOutputKind::HostCalls) // print all host calls that occurred during execution.
         .expect("Call icecream contract");
 
     // Check that the icecream vendor still has the original balance.

--- a/examples/icecream/tests/tests.rs
+++ b/examples/icecream/tests/tests.rs
@@ -213,8 +213,9 @@ fn initialize_chain() -> (Chain, ModuleReference) {
 
     // Load and deploy the module.
     let module = module_load_v1("concordium-out/module.wasm.v1").expect("Module exists");
-    let deployment =
-        chain.module_deploy_v1_debug(SIGNER, ACC_0, module, is_debug_enabled()).expect("Deploy valid module");
+    let deployment = chain
+        .module_deploy_v1_debug(SIGNER, ACC_0, module, is_debug_enabled())
+        .expect("Deploy valid module");
 
     (chain, deployment.module_reference)
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2021"
 combine_control_expr = false
 wrap_comments = true
 brace_style = "PreferSameLine"


### PR DESCRIPTION
## Purpose

Enable debugging support in the contract testing library.

## Changes

The main change from the user's perspective is the addition of `debug_trace` in Invoke and Init results and errors, together with the `DebugInfoExt` trait which has utility functions for extracting and printing the debug information.

The testing library always runs the execution engine with debug output collection enabled to avoid additional generics.

I deem this performance impact acceptable due to the way the testing library is intended to be used.

Depends on
- [x] https://github.com/Concordium/concordium-base/pull/488
- [x] https://github.com/Concordium/concordium-rust-sdk/pull/147

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
