### PR TITLE
Add missing error schemas

### DIFF
--- a/examples/cis2-multi/src/lib.rs
+++ b/examples/cis2-multi/src/lib.rs
@@ -728,6 +728,7 @@ fn contract_serialization_helper(_ctx: &ReceiveContext, _host: &Host<State>) -> 
     name = "viewMessageHash",
     parameter = "PermitParam",
     return_value = "[u8;32]",
+    error = "ContractError",
     crypto_primitives,
     mutable
 )]
@@ -797,6 +798,7 @@ fn contract_view_message_hash(
     contract = "cis2_multi",
     name = "permit",
     parameter = "PermitParam",
+    error = "ContractError",
     crypto_primitives,
     mutable,
     enable_logger

--- a/examples/cis3-nft-sponsored-txs/src/lib.rs
+++ b/examples/cis3-nft-sponsored-txs/src/lib.rs
@@ -717,6 +717,7 @@ fn contract_serialization_helper(_ctx: &ReceiveContext, _host: &Host<State>) -> 
     name = "viewMessageHash",
     parameter = "PermitParam",
     return_value = "[u8;32]",
+    error = "ContractError",
     crypto_primitives,
     mutable
 )]
@@ -786,6 +787,7 @@ fn contract_view_message_hash(
     contract = "cis3_nft",
     name = "permit",
     parameter = "PermitParam",
+    error = "ContractError",
     crypto_primitives,
     mutable,
     enable_logger

--- a/examples/sponsored-tx-enabled-auction/src/lib.rs
+++ b/examples/sponsored-tx-enabled-auction/src/lib.rs
@@ -307,6 +307,7 @@ fn auction_init(ctx: &InitContext, state_builder: &mut StateBuilder) -> InitResu
     contract = "sponsored_tx_enabled_auction",
     name = "addItem",
     parameter = "AddItemParameter",
+    error = "Error",
     enable_logger,
     mutable
 )]
@@ -449,8 +450,8 @@ fn auction_bid(ctx: &ReceiveContext, host: &mut Host<State>) -> ContractResult<(
     contract = "sponsored_tx_enabled_auction",
     name = "finalize",
     parameter = "u16",
-    mutable,
-    error = "Error"
+    error = "Error",
+    mutable
 )]
 fn auction_finalize(ctx: &ReceiveContext, host: &mut Host<State>) -> ContractResult<()> {
     // Getting input parameter.
@@ -522,7 +523,8 @@ fn view(_ctx: &ReceiveContext, host: &Host<State>) -> ContractResult<ReturnParam
     contract = "sponsored_tx_enabled_auction",
     name = "viewItemState",
     return_value = "ItemState",
-    parameter = "u16"
+    parameter = "u16",
+    error = "Error"
 )]
 fn view_item_state(ctx: &ReceiveContext, host: &Host<State>) -> ContractResult<ItemState> {
     // Getting input parameter.


### PR DESCRIPTION
## Purpose

The `ccd-js-gen` tool only generates `parseErrorMessage` functions when an error schema is included. Add missing schemas on smart contract functions.

## Changes

Add missing error schemas.
