### PR TITLE
Fix linking error when using concordium_dbg!

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Fix a bug that caused a linking error when using `concordium_dbg!`.
+  - The error message states that `_debug_print` cannot be found.
+
 ## concordium-std 6.0.0 (2024-01-22)
 
 - Add a `concordium_dbg!` macro and the associated `debug` feature to enable,

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -477,4 +477,33 @@ mod host_dummy_functions {
     fn hash_keccak_256(_data: *const u8, _data_len: u32, _output: *mut u8) {
         unimplemented!("Dummy function! Not to be executed")
     }
+
+    #[no_mangle]
+    fn report_error(
+        _msg_start: *const u8,
+        _msg_length: u32,
+        _filename_start: *const u8,
+        _filename_length: u32,
+        _line: u32,
+        _column: u32,
+    ) {
+        unimplemented!("Dummy function! Not to be executed")
+    }
+
+    #[no_mangle]
+    fn debug_print(
+        _msg_start: *const u8,
+        _msg_length: u32,
+        _filename_start: *const u8,
+        _filename_length: u32,
+        _line: u32,
+        _column: u32,
+    ) {
+        unimplemented!("Dummy function! Not to be executed")
+    }
+
+    #[no_mangle]
+    fn get_random(_dest: *mut u8, _size: u32) {
+        unimplemented!("Dummy function! Not to be executed")
+    }
 }


### PR DESCRIPTION
## Purpose

Fix a linking error when using `concordium_dbg!` (see https://github.com/Concordium/concordium-rust-smart-contracts/pull/374 for more details on the debug functionality).

When running `cargo concordium test --out concordium-out/module.wasm.v1 --allow-debug` in the `icecream` example, I get the following error:

```
error: linking with `cc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/Users/kasper/.rustup/toolchains/1.72-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin
...
s/kasper/.rustup/toolchains/1.72-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib" "-o" "/Users/kasper/Developer/Concordium/rust-contracts/examples/fib/target/debug/deps/libfib.dylib" "-Wl,-dead_strip" "-dynamiclib" "-Wl,-dylib" "-nodefaultlibs"
  = note: Undefined symbols for architecture arm64:
            "_debug_print", referenced from:
                concordium_std::debug_print::h1f7e449ccf275907 in libconcordium_std-66bba2a1e91b6971.rlib(concordium_std-66bba2a1e91b6971.15091wxt0levty95.rcgu.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)

error: could not compile `fib` (lib) due to previous error
Error: Could not build and run integration tests.
```

The issue is resolved by adding the `debug_print` dummy host function.
I also added the two other methods that were missing. I assume they might cause a similar error if they were triggered.

My initial guess was that the issue only occurred if the `tests.rs` file imported the `lib.rs` file, which has the `concordium_dbg!` calls, but that is not the case; the error also occurs if the smart contract isn't imported in the tests.

Since this hasn't been caught yet, it might only be an issue on macOS.

## Changes

- Add three missing dummy host calls.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.