### PR TITLE
Fix macros like debug, fail so that they accept arguments as expected.

### DIFF
--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -429,9 +429,9 @@ macro_rules! concordium_dbg {
             $crate::debug_print("", file!(), line!(), column!());
         }
     };
-    ($($arg:tt),+) => {
+    ($($arg:tt)*) => {
         {
-            let msg = $crate::format!($($arg),+);
+            let msg = $crate::format!($($arg)*);
             $crate::debug_print(&msg, file!(), line!(), column!());
         }
     };
@@ -447,7 +447,7 @@ macro_rules! concordium_dbg {
 /// expression.
 macro_rules! concordium_dbg {
     () => {{}};
-    ($($arg:tt),+) => {{}};
+    ($($arg:tt)*) => {{}};
 }
 
 /// Emit a message in debug mode.

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -856,9 +856,9 @@ macro_rules! fail {
             panic!()
         }
     };
-    ($($arg:tt),+) => {
+    ($($arg:tt)*) => {
         {
-            let msg = format!($($arg),+);
+            let msg = format!($($arg)*);
             #[allow(deprecated)]
             $crate::test_infrastructure::report_error(&msg, file!(), line!(), column!());
             panic!("{}", msg)
@@ -880,9 +880,9 @@ macro_rules! fail {
             panic!()
         }
     };
-    ($($arg:tt),+) => {
+    ($($arg:tt)*) => {
         {
-            let msg = &$crate::alloc::format!($($arg),+);
+            let msg = &$crate::alloc::format!($($arg)*);
             #[allow(deprecated)]
             $crate::test_infrastructure::report_error(&msg, file!(), line!(), column!());
             panic!("{}", msg)
@@ -906,9 +906,9 @@ macro_rules! claim {
             $crate::fail!()
         }
     };
-    ($cond:expr, $($arg:tt),+) => {
+    ($cond:expr, $($arg:tt)*) => {
         if !$cond {
-            $crate::fail!($($arg),+)
+            $crate::fail!($($arg)*)
         }
     };
 }
@@ -930,8 +930,8 @@ macro_rules! claim_eq {
             }
         }
     };
-    ($left:expr, $right:expr, $($arg:tt),+) => {
-        $crate::claim!($left == $right, $($arg),+)
+    ($left:expr, $right:expr, $($arg:tt)*) => {
+        $crate::claim!($left == $right, $($arg)*)
     };
 }
 
@@ -952,8 +952,8 @@ macro_rules! claim_ne {
             }
         }
     };
-    ($left:expr, $right:expr, $($arg:tt),+) => {
-        $crate::claim!($left != $right, $($arg),+)
+    ($left:expr, $right:expr, $($arg:tt)*) => {
+        $crate::claim!($left != $right, $($arg)*)
     };
 }
 

--- a/concordium-std/tests/dbg.rs
+++ b/concordium-std/tests/dbg.rs
@@ -1,0 +1,6 @@
+//! Test that the debug macro generates compilable code.
+#[test]
+fn dbg() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/dbg/success.rs");
+}

--- a/concordium-std/tests/dbg/success.rs
+++ b/concordium-std/tests/dbg/success.rs
@@ -1,0 +1,12 @@
+//! Ensure `concordium_dbg` generates compilable code.
+use concordium_std::*;
+
+fn f() {
+    let one: u32 = 3;
+    let two: Option<u32> = Some(3);
+    concordium_dbg!("Hello {one:?}, {}", two.unwrap());
+    concordium_dbg!("Hello {one:?}, {}", two.unwrap(),);
+    concordium_dbg!();
+}
+
+fn main() {}


### PR DESCRIPTION
## Purpose

Fix macros defined in concordium-std so that they take arbitrary streams of tokens so that they behave as println!, assert!, etc.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
