### PR TITLE
Query contract module

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -35,6 +35,7 @@ jobs:
           - examples/cis3-nft-sponsored-txs/Cargo.toml
           - examples/cis2-wccd/Cargo.toml
           - examples/credential-registry/Cargo.toml
+          - examples/factory/Cargo.toml
           - examples/fib/Cargo.toml
           - examples/icecream/Cargo.toml
           - examples/memo/Cargo.toml
@@ -458,6 +459,7 @@ jobs:
           -
           - build-schema
           - concordium-quickcheck
+          - p7
 
     steps:
       - name: Checkout sources
@@ -533,6 +535,7 @@ jobs:
           - wasm-test
           - wasm-test,build-schema
           - wasm-test,concordium-quickcheck
+          - wasm-test,p7
 
     steps:
       - name: Checkout sources
@@ -687,6 +690,7 @@ jobs:
           - examples/cis3-nft-sponsored-txs/Cargo.toml
           - examples/cis2-wccd/Cargo.toml
           - examples/credential-registry/Cargo.toml
+          - examples/factory/Cargo.toml
           - examples/fib/Cargo.toml
           - examples/icecream/Cargo.toml
           - examples/memo/Cargo.toml
@@ -818,6 +822,7 @@ jobs:
           - examples/cis3-nft-sponsored-txs
           - examples/cis2-wccd
           - examples/credential-registry
+          - examples/factory
           - examples/fib
           - examples/icecream
           - examples/memo

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -611,6 +611,7 @@ jobs:
           - examples/nametoken/Cargo.toml
           - examples/account-signature-checks/Cargo.toml
           - examples/bump-alloc-tests/Cargo.toml
+          - examples/factory/Cargo.toml
 
         features:
           -

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+- Add support for querying the module reference and contract name of an instance,
+  via the `HasHost::contract_module_reference` and `HasHost::contract_name` functions.
+  These are only available from protocol version 7, and as such are guarded by the
+  `p7` feature flag.
+
 ## concordium-std 9.0.2 (2024-02-07)
 
 - Make the `concordium_dbg!` and related macros also usable with the full syntax

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -35,6 +35,8 @@ build-schema = ["concordium-contracts-common/build-schema"]
 crypto-primitives = ["sha2", "sha3", "secp256k1", "ed25519-zebra"]
 concordium-quickcheck = ["getrandom", "quickcheck", "concordium-contracts-common/concordium-quickcheck", "std"]
 debug = []
+# p7 enables support for functionality introduced in protocol version 7.
+p7 = []
 
 [lib]
 crate-type = ["rlib"]

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -2236,7 +2236,7 @@ fn query_contract_module_reference_worker(
 fn query_contract_name_worker(address: &ContractAddress) -> QueryContractNameResult {
     let data = [address.index.to_le_bytes(), address.subindex.to_le_bytes()];
     let response = unsafe {
-        prims::invoke(INVOKE_QUERY_CONTRACT_MODULE_REFERENCE_TAG, data.as_ptr() as *const u8, 16)
+        prims::invoke(INVOKE_QUERY_CONTRACT_NAME_TAG, data.as_ptr() as *const u8, 16)
     };
     parse_query_contract_name_response_code(response)
 }

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "p7")]
+use crate::vec;
 use crate::{
     cell::UnsafeCell,
     convert::{self, TryInto},

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1819,6 +1819,10 @@ const INVOKE_QUERY_EXCHANGE_RATES_TAG: u32 = 4;
 const INVOKE_CHECK_ACCOUNT_SIGNATURE_TAG: u32 = 5;
 /// Tag of the query account's public keys [prims::invoke].
 const INVOKE_QUERY_ACCOUNT_PUBLIC_KEYS_TAG: u32 = 6;
+/// Tag of the query contract module reference operation. See [prims::invoke].
+const INVOKE_QUERY_CONTRACT_MODULE_REFERENCE_TAG: u32 = 7;
+/// Tag of the query contract name operation. See [prims::invoke].
+const INVOKE_QUERY_CONTRACT_NAME_TAG: u32 = 8;
 
 /// Check whether the response code from calling `invoke` is encoding a failure
 /// and map out the byte used for the error code.
@@ -1839,7 +1843,7 @@ fn get_invoke_failure_code(code: u64) -> Option<u8> {
 /// - Success if the last 5 bytes are all zero:
 ///   - the first 3 bytes encodes the return value index, except the first bit,
 ///     which is used to indicate whether the contract state was modified.
-/// - In case of failure the 4th byte is used, and encodes the enviroment
+/// - In case of failure the 4th byte is used, and encodes the environment
 ///   failure, where:
 ///   - 0x01 encodes amount too large.
 ///   - 0x02 encodes missing account.
@@ -1861,7 +1865,7 @@ fn parse_transfer_response_code(code: u64) -> TransferResult {
 /// - Success if the last 5 bytes are all zero:
 ///   - the first 3 bytes encodes the return value index, except the first bit,
 ///     which is used to indicate whether the contract state was modified.
-/// - In case of failure the 4th byte is used, and encodes the enviroment
+/// - In case of failure the 4th byte is used, and encodes the environment
 ///   failure, where:
 ///   - 0x07 encodes missing module.
 ///   - 0x08 encodes missing contract.
@@ -1889,7 +1893,8 @@ fn parse_upgrade_response_code(code: u64) -> UpgradeResult {
 /// - In case of failure:
 ///   - if the 4th byte is 0 then the remaining 4 bytes encode the rejection
 ///     reason from the contract
-///   - otherwise only the 4th byte is used, and encodes the enviroment failure.
+///   - otherwise only the 4th byte is used, and encodes the environment
+///     failure.
 ///     - 0x01 encodes amount too large.
 ///     - 0x02 encodes missing account.
 ///     - 0x03 encodes missing contract.
@@ -1945,7 +1950,7 @@ fn parse_call_response_code(code: u64) -> CallContractResult<ExternCallResponse>
 ///
 /// - Success if the last 5 bytes are all zero:
 ///   - the first 3 bytes encodes the return value index.
-/// - In case of failure the 4th byte is used, and encodes the enviroment
+/// - In case of failure the 4th byte is used, and encodes the environment
 ///   failure where:
 ///    - '0x02' encodes missing account.
 fn parse_query_account_balance_response_code(
@@ -1968,7 +1973,7 @@ fn parse_query_account_balance_response_code(
 ///
 /// - Success if the last 5 bytes are all zero:
 ///   - the first 3 bytes encodes the return value index.
-/// - In case of failure the 4th byte is used, and encodes the enviroment
+/// - In case of failure the 4th byte is used, and encodes the environment
 ///   failure where:
 ///    - '0x03' encodes missing contract.
 fn parse_query_contract_balance_response_code(
@@ -1991,7 +1996,7 @@ fn parse_query_contract_balance_response_code(
 ///
 /// - Success if the last 5 bytes are all zero:
 ///   - the first 3 bytes encodes the return value index.
-/// - In case of failure the 4th byte is used, and encodes the enviroment
+/// - In case of failure the 4th byte is used, and encodes the environment
 ///   failure where:
 ///    - '0x02' encodes missing account.
 fn parse_query_account_public_keys_response_code(
@@ -2013,7 +2018,7 @@ fn parse_query_account_public_keys_response_code(
 /// Decode the response from checking account signatures.
 ///
 /// - Success if the last 5 bytes are all zero:
-/// - In case of failure the 4th byte is used, and encodes the enviroment
+/// - In case of failure the 4th byte is used, and encodes the environment
 ///   failure where:
 ///    - '0x02' encodes missing account.
 ///    - '0x0a' encodes malformed data, i.e., the call was made with incorrect
@@ -2051,6 +2056,61 @@ fn parse_query_exchange_rates_response_code(code: u64) -> ExternCallResponse {
         // Map out the 3 bytes encoding the return value index.
         let return_value_index = NonZeroU32::new((code >> 40) as u32).unwrap_abort();
         ExternCallResponse::new(return_value_index)
+    }
+}
+
+/// Decode the contract module reference response code.
+///
+/// - Success if the last 5 bytes are all zero:
+///   - the first 3 bytes encodes the return value index.
+/// - In case of failure the 4th byte is used, and encodes the environment
+///   failure where:
+///    - '0x03' encodes missing contract.
+fn parse_query_contract_module_reference_response_code(
+    code: u64,
+) -> Result<ExternCallResponse, QueryContractModuleReferenceError> {
+    if let Some(error_code) = get_invoke_failure_code(code) {
+        if error_code == 0x03 {
+            Err(QueryContractModuleReferenceError)
+        } else {
+            unsafe { crate::hint::unreachable_unchecked() }
+        }
+    } else {
+        // Map out the 3 bytes encoding the return value index.
+        let return_value_index = NonZeroU32::new((code >> 40) as u32).unwrap_abort();
+        Ok(ExternCallResponse::new(return_value_index))
+    }
+}
+
+/// Decode the contract name response code.
+///
+/// - Success if the last 5 bytes are all zero:
+///   - the first 3 bytes encodes the return value index.
+/// - In case of failure the 4th byte is used, and encodes the environment
+///   failure where:
+///    - '0x03' encodes missing contract.
+fn parse_query_contract_name_response_code(
+    code: u64,
+) -> Result<OwnedContractName, QueryContractNameError> {
+    if let Some(error_code) = get_invoke_failure_code(code) {
+        if error_code == 0x03 {
+            Err(QueryContractNameError)
+        } else {
+            unsafe { crate::hint::unreachable_unchecked() }
+        }
+    } else {
+        // Map out the 3 bytes encoding the return value index.
+        let return_value_index = (code >> 40) as u32;
+        let name = unsafe {
+            let name_size = prims::get_parameter_size(return_value_index);
+            if name_size < 0 {
+                crate::hint::unreachable_unchecked()
+            }
+            let mut buf = vec![0; name_size as usize];
+            prims::get_parameter_section(return_value_index, buf.as_mut_ptr(), name_size as u32, 0);
+            String::from_utf8_unchecked(buf)
+        };
+        Ok(OwnedContractName::new_unchecked(name))
     }
 }
 
@@ -2156,6 +2216,29 @@ fn check_account_signature_worker(
     // Be explicit that the buffer must survive up to here.
     drop(buffer);
     parse_check_account_signature_response_code(response)
+}
+
+/// Helper factoring out the common behaviour of contract_module_reference for
+/// the two extern hosts below.
+fn query_contract_module_reference_worker(
+    address: &ContractAddress,
+) -> QueryContractModuleReferenceResult {
+    let data = [address.index.to_le_bytes(), address.subindex.to_le_bytes()];
+    let response = unsafe {
+        prims::invoke(INVOKE_QUERY_CONTRACT_MODULE_REFERENCE_TAG, data.as_ptr() as *const u8, 16)
+    };
+    let mut return_value = parse_query_contract_module_reference_response_code(response)?;
+    Ok(ModuleReference::deserial(&mut return_value).unwrap_abort())
+}
+
+/// Helper factoring out the common behaviour of contract_name for
+/// the two extern hosts below.
+fn query_contract_name_worker(address: &ContractAddress) -> QueryContractNameResult {
+    let data = [address.index.to_le_bytes(), address.subindex.to_le_bytes()];
+    let response = unsafe {
+        prims::invoke(INVOKE_QUERY_CONTRACT_MODULE_REFERENCE_TAG, data.as_ptr() as *const u8, 16)
+    };
+    parse_query_contract_name_response_code(response)
 }
 
 impl<S> StateBuilder<S>
@@ -2418,6 +2501,19 @@ where
         check_account_signature_worker(address, signatures, data)
     }
 
+    #[inline(always)]
+    fn contract_module_reference(
+        &self,
+        address: ContractAddress,
+    ) -> QueryContractModuleReferenceResult {
+        query_contract_module_reference_worker(&address)
+    }
+
+    #[inline(always)]
+    fn contract_name(&self, address: ContractAddress) -> QueryContractNameResult {
+        query_contract_name_worker(&address)
+    }
+
     fn state(&self) -> &S { &self.state }
 
     fn state_mut(&mut self) -> &mut S { &mut self.state }
@@ -2494,6 +2590,19 @@ impl HasHost<ExternStateApi> for ExternLowLevelHost {
         data: &[u8],
     ) -> CheckAccountSignatureResult {
         check_account_signature_worker(address, signatures, data)
+    }
+
+    #[inline(always)]
+    fn contract_module_reference(
+        &self,
+        address: ContractAddress,
+    ) -> QueryContractModuleReferenceResult {
+        query_contract_module_reference_worker(&address)
+    }
+
+    #[inline(always)]
+    fn contract_name(&self, address: ContractAddress) -> QueryContractNameResult {
+        query_contract_name_worker(&address)
     }
 
     #[inline(always)]

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1820,8 +1820,10 @@ const INVOKE_CHECK_ACCOUNT_SIGNATURE_TAG: u32 = 5;
 /// Tag of the query account's public keys [prims::invoke].
 const INVOKE_QUERY_ACCOUNT_PUBLIC_KEYS_TAG: u32 = 6;
 /// Tag of the query contract module reference operation. See [prims::invoke].
+#[cfg(feature = "p7")]
 const INVOKE_QUERY_CONTRACT_MODULE_REFERENCE_TAG: u32 = 7;
 /// Tag of the query contract name operation. See [prims::invoke].
+#[cfg(feature = "p7")]
 const INVOKE_QUERY_CONTRACT_NAME_TAG: u32 = 8;
 
 /// Check whether the response code from calling `invoke` is encoding a failure
@@ -2066,6 +2068,7 @@ fn parse_query_exchange_rates_response_code(code: u64) -> ExternCallResponse {
 /// - In case of failure the 4th byte is used, and encodes the environment
 ///   failure where:
 ///    - '0x03' encodes missing contract.
+#[cfg(feature = "p7")]
 fn parse_query_contract_module_reference_response_code(
     code: u64,
 ) -> Result<ExternCallResponse, QueryContractModuleReferenceError> {
@@ -2089,6 +2092,7 @@ fn parse_query_contract_module_reference_response_code(
 /// - In case of failure the 4th byte is used, and encodes the environment
 ///   failure where:
 ///    - '0x03' encodes missing contract.
+#[cfg(feature = "p7")]
 fn parse_query_contract_name_response_code(
     code: u64,
 ) -> Result<OwnedContractName, QueryContractNameError> {
@@ -2220,6 +2224,7 @@ fn check_account_signature_worker(
 
 /// Helper factoring out the common behaviour of contract_module_reference for
 /// the two extern hosts below.
+#[cfg(feature = "p7")]
 fn query_contract_module_reference_worker(
     address: &ContractAddress,
 ) -> QueryContractModuleReferenceResult {
@@ -2233,11 +2238,11 @@ fn query_contract_module_reference_worker(
 
 /// Helper factoring out the common behaviour of contract_name for
 /// the two extern hosts below.
+#[cfg(feature = "p7")]
 fn query_contract_name_worker(address: &ContractAddress) -> QueryContractNameResult {
     let data = [address.index.to_le_bytes(), address.subindex.to_le_bytes()];
-    let response = unsafe {
-        prims::invoke(INVOKE_QUERY_CONTRACT_NAME_TAG, data.as_ptr() as *const u8, 16)
-    };
+    let response =
+        unsafe { prims::invoke(INVOKE_QUERY_CONTRACT_NAME_TAG, data.as_ptr() as *const u8, 16) };
     parse_query_contract_name_response_code(response)
 }
 
@@ -2501,6 +2506,7 @@ where
         check_account_signature_worker(address, signatures, data)
     }
 
+    #[cfg(feature = "p7")]
     #[inline(always)]
     fn contract_module_reference(
         &self,
@@ -2509,6 +2515,7 @@ where
         query_contract_module_reference_worker(&address)
     }
 
+    #[cfg(feature = "p7")]
     #[inline(always)]
     fn contract_name(&self, address: ContractAddress) -> QueryContractNameResult {
         query_contract_name_worker(&address)
@@ -2592,6 +2599,7 @@ impl HasHost<ExternStateApi> for ExternLowLevelHost {
         check_account_signature_worker(address, signatures, data)
     }
 
+    #[cfg(feature = "p7")]
     #[inline(always)]
     fn contract_module_reference(
         &self,
@@ -2600,6 +2608,7 @@ impl HasHost<ExternStateApi> for ExternLowLevelHost {
         query_contract_module_reference_worker(&address)
     }
 
+    #[cfg(feature = "p7")]
     #[inline(always)]
     fn contract_name(&self, address: ContractAddress) -> QueryContractNameResult {
         query_contract_name_worker(&address)

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -21,9 +21,13 @@ extern "C" {
     /// - `tag`, which instruction to invoke
     ///   - 0 for transfer to account
     ///   - 1 for call to a contract
-    ///   - 2 for query an account balance.
-    ///   - 3 for query a contract balance.
-    ///   - 4 for query the exchange rates.
+    ///   - 2 for query an account balance (protocol 5 onwards).
+    ///   - 3 for query a contract balance (protocol 5 onwards).
+    ///   - 4 for query the exchange rates (protocol 5 onwards).
+    ///   - 5 for checking an account signature (protocol 6 onwards).
+    ///   - 6 for getting the public keys of an account (protocol 6 onwards).
+    ///   - 7 for getting the module reference of a contract instance (protocol 7 onwards).
+    ///   - 8 for getting the contract name of a contract instance (protocol 7 onwards).
     /// - `start`, pointer to the start of the invoke payload
     /// - `length`, length of the payload
     /// - if the last 5 bytes are 0 then the call succeeded. In this case the

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -26,8 +26,10 @@ extern "C" {
     ///   - 4 for query the exchange rates (protocol 5 onwards).
     ///   - 5 for checking an account signature (protocol 6 onwards).
     ///   - 6 for getting the public keys of an account (protocol 6 onwards).
-    ///   - 7 for getting the module reference of a contract instance (protocol 7 onwards).
-    ///   - 8 for getting the contract name of a contract instance (protocol 7 onwards).
+    ///   - 7 for getting the module reference of a contract instance (protocol
+    ///     7 onwards).
+    ///   - 8 for getting the contract name of a contract instance (protocol 7
+    ///     onwards).
     /// - `start`, pointer to the start of the invoke payload
     /// - `length`, length of the payload
     /// - if the last 5 bytes are 0 then the call succeeded. In this case the

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -1577,6 +1577,23 @@ impl<State: Serial + DeserialWithState<TestStateApi>> HasHost<State> for TestHos
              functionality."
         )
     }
+
+    fn contract_module_reference(
+        &self,
+        _address: ContractAddress,
+    ) -> QueryContractModuleReferenceResult {
+        unimplemented!(
+            "The test infrastructure will be deprecated and so does not implement new \
+             functionality."
+        )
+    }
+
+    fn contract_name(&self, _address: ContractAddress) -> QueryContractNameResult {
+        unimplemented!(
+            "The test infrastructure will be deprecated and so does not implement new \
+             functionality."
+        )
+    }
 }
 
 impl<State: Serial + DeserialWithState<TestStateApi>> TestHost<State> {

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -1578,6 +1578,7 @@ impl<State: Serial + DeserialWithState<TestStateApi>> HasHost<State> for TestHos
         )
     }
 
+    #[cfg(feature = "p7")]
     fn contract_module_reference(
         &self,
         _address: ContractAddress,
@@ -1588,6 +1589,7 @@ impl<State: Serial + DeserialWithState<TestStateApi>> HasHost<State> for TestHos
         )
     }
 
+    #[cfg(feature = "p7")]
     fn contract_name(&self, _address: ContractAddress) -> QueryContractNameResult {
         unimplemented!(
             "The test infrastructure will be deprecated and so does not implement new \

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -531,13 +531,16 @@ pub trait HasHost<State>: Sized {
     ) -> CheckAccountSignatureResult;
 
     /// Get the module reference of a contract instance.
+    ///
+    /// Note: after a successful [`upgrade`], this will return the new module
+    /// reference.
     #[cfg(feature = "p7")]
     fn contract_module_reference(
         &self,
         address: ContractAddress,
     ) -> QueryContractModuleReferenceResult;
 
-    /// Get the name of the initializer of a contract instance.
+    /// Get the contract name of a contract instance.
     #[cfg(feature = "p7")]
     fn contract_name(&self, address: ContractAddress) -> QueryContractNameResult;
 

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -532,8 +532,8 @@ pub trait HasHost<State>: Sized {
 
     /// Get the module reference of a contract instance.
     ///
-    /// Note: after a successful [`upgrade`], this will return the new module
-    /// reference.
+    /// Note: after a successful [`Self::upgrade`], this will return the new
+    /// module reference.
     #[cfg(feature = "p7")]
     fn contract_module_reference(
         &self,

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -9,8 +9,9 @@ use crate::{
     AccountSignatures, CallContractResult, CheckAccountSignatureResult, EntryRaw, ExchangeRates,
     HashKeccak256, HashSha2256, HashSha3256, Key, OccupiedEntryRaw, PublicKeyEcdsaSecp256k1,
     PublicKeyEd25519, QueryAccountBalanceResult, QueryAccountPublicKeysResult,
-    QueryContractBalanceResult, ReadOnlyCallContractResult, SignatureEcdsaSecp256k1,
-    SignatureEd25519, StateBuilder, TransferResult, UpgradeResult, VacantEntryRaw,
+    QueryContractBalanceResult, QueryContractModuleReferenceResult, QueryContractNameResult,
+    ReadOnlyCallContractResult, SignatureEcdsaSecp256k1, SignatureEd25519, StateBuilder,
+    TransferResult, UpgradeResult, VacantEntryRaw,
 };
 use concordium_contracts_common::*;
 
@@ -527,6 +528,15 @@ pub trait HasHost<State>: Sized {
         signatures: &AccountSignatures,
         data: &[u8],
     ) -> CheckAccountSignatureResult;
+
+    /// Get the module reference of a contract instance.
+    fn contract_module_reference(
+        &self,
+        address: ContractAddress,
+    ) -> QueryContractModuleReferenceResult;
+
+    /// Get the name of the initializer of a contract instance.
+    fn contract_name(&self, address: ContractAddress) -> QueryContractNameResult;
 
     /// Get an immutable reference to the contract state.
     fn state(&self) -> &State;

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -9,10 +9,11 @@ use crate::{
     AccountSignatures, CallContractResult, CheckAccountSignatureResult, EntryRaw, ExchangeRates,
     HashKeccak256, HashSha2256, HashSha3256, Key, OccupiedEntryRaw, PublicKeyEcdsaSecp256k1,
     PublicKeyEd25519, QueryAccountBalanceResult, QueryAccountPublicKeysResult,
-    QueryContractBalanceResult, QueryContractModuleReferenceResult, QueryContractNameResult,
-    ReadOnlyCallContractResult, SignatureEcdsaSecp256k1, SignatureEd25519, StateBuilder,
-    TransferResult, UpgradeResult, VacantEntryRaw,
+    QueryContractBalanceResult, ReadOnlyCallContractResult, SignatureEcdsaSecp256k1,
+    SignatureEd25519, StateBuilder, TransferResult, UpgradeResult, VacantEntryRaw,
 };
+#[cfg(feature = "p7")]
+use crate::{QueryContractModuleReferenceResult, QueryContractNameResult};
 use concordium_contracts_common::*;
 
 /// Objects which can access parameters to contracts.
@@ -530,12 +531,14 @@ pub trait HasHost<State>: Sized {
     ) -> CheckAccountSignatureResult;
 
     /// Get the module reference of a contract instance.
+    #[cfg(feature = "p7")]
     fn contract_module_reference(
         &self,
         address: ContractAddress,
     ) -> QueryContractModuleReferenceResult;
 
     /// Get the name of the initializer of a contract instance.
+    #[cfg(feature = "p7")]
     fn contract_name(&self, address: ContractAddress) -> QueryContractNameResult;
 
     /// Get an immutable reference to the contract state.

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -1,7 +1,9 @@
 use crate::{
     cell::UnsafeCell, marker::PhantomData, num::NonZeroU32, Cursor, HasStateApi, Serial, Vec,
 };
-use concordium_contracts_common::{AccountBalance, Amount, ParseError};
+use concordium_contracts_common::{
+    AccountBalance, Amount, ModuleReference, OwnedContractName, ParseError,
+};
 use core::{fmt, str::FromStr};
 
 #[derive(Debug)]
@@ -652,6 +654,16 @@ pub enum CheckAccountSignatureError {
     MalformedData,
 }
 
+/// Error for querying the module reference of a smart contract instance.
+/// No instance found for the provided contract address.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct QueryContractModuleReferenceError;
+
+/// Error for querying the contract name of a smart contract instance.
+/// No instance found for the provided contract address.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct QueryContractNameError;
+
 /// A wrapper around [`Result`] that fixes the error variant to
 /// [`CallContractError`], and the result to `(bool, Option<A>)`.
 /// If the result is `Ok` then the boolean indicates whether the state was
@@ -690,6 +702,15 @@ pub type QueryAccountPublicKeysResult =
 /// A wrapper around [`Result`] that fixes the error variant to
 /// [`CheckAccountSignatureError`] and result to [`bool`].
 pub type CheckAccountSignatureResult = Result<bool, CheckAccountSignatureError>;
+
+/// A wrapper around [`Result`] that fixes the error variant to
+/// [`QueryContractModuleReferenceError`] and result to [`ModuleReference`].
+pub type QueryContractModuleReferenceResult =
+    Result<ModuleReference, QueryContractModuleReferenceError>;
+
+/// A wrapper around [`Result`] that fixes the error variant to
+/// [`QueryContractNameError`] and result to [`OwnedContractName`].
+pub type QueryContractNameResult = Result<OwnedContractName, QueryContractNameError>;
 
 /// A type representing the attributes, lazily acquired from the host.
 #[derive(Clone, Copy, Default)]

--- a/contract-testing/CHANGELOG.md
+++ b/contract-testing/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Add support for querying the module reference and contract name of an instance.
+  This functionality is only available on-chain from protocol version 7.
+
 ## 4.1.0
 
 - Fix a bug in debug output. The events emitted before some contract queries

--- a/contract-testing/src/constants.rs
+++ b/contract-testing/src/constants.rs
@@ -34,6 +34,20 @@ pub(crate) fn contract_instance_query_account_keys_return_cost(num_keys: u32) ->
     }
 }
 
+/// The cost of querying the contract module reference from a smart contract
+/// instance.
+pub(crate) const CONTRACT_INSTANCE_QUERY_CONTRACT_MODULE_REFERENCE_COST: Energy = Energy {
+    energy: 200,
+};
+
+/// The cost of querying the contract module name from a smart contract
+/// instance. While the length of a smart contract name is variable, it is at
+/// most 100 characters, so there  is no real benefit to varying the cost based
+/// on the length.
+pub(crate) const CONTRACT_INSTANCE_QUERY_CONTRACT_NAME_COST: Energy = Energy {
+    energy: 200,
+};
+
 /// Cost **in energy** of verification of an ed25519 signature.
 /// This should match the cost of
 /// [`verify_ed22519_cost`](concordium_smart_contract_engine::constants::verify_ed25519_cost)

--- a/contract-testing/src/impls.rs
+++ b/contract-testing/src/impls.rs
@@ -2052,6 +2052,21 @@ impl ContractInvokeError {
         }
     }
 
+    /// If the contract execution rejected the transaction, this returns the
+    /// code the contract used to signal the rejection.
+    pub fn reject_code(&self) -> Option<i32> {
+        match &self.kind {
+            ContractInvokeErrorKind::ExecutionError {
+                failure_kind:
+                    v1::InvokeFailure::ContractReject {
+                        code,
+                        ..
+                    },
+            } => Some(*code),
+            _ => None,
+        }
+    }
+
     /// Try to extract and parse the value returned into a type that implements
     /// [`Deserial`].
     ///

--- a/contract-testing/src/invocation/impls.rs
+++ b/contract-testing/src/invocation/impls.rs
@@ -29,6 +29,7 @@ use concordium_rust_sdk::{
         wasm::artifact::{self, CompiledFunction},
         DebugInfo, InterpreterEnergy,
     },
+    types::smart_contracts::ContractName,
 };
 use std::collections::{btree_map, BTreeMap};
 
@@ -234,7 +235,7 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                     energy,
                 },
                 instance_state,
-                v1::ReceiveParams::new_p6(),
+                v1::ReceiveParams::new_p7(),
             )
         })?;
         // Set up some data needed for recursively processing the receive until the end,
@@ -911,6 +912,64 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                                 response: Some(response),
                             });
                         }
+                        v1::Interrupt::QueryContractModuleReference {
+                            address,
+                        } => {
+                            let response = match self.contract_module_reference(address) {
+                                None => v1::InvokeResponse::Failure {
+                                    kind: v1::InvokeFailure::NonExistentContract,
+                                },
+                                Some(mod_ref) => v1::InvokeResponse::Success {
+                                    // Balance of contract querying. Won't change. Notice the
+                                    // `data.address`.
+                                    new_balance: self
+                                        .contract_balance_unchecked(invocation_data.address),
+                                    data:        Some(to_bytes(&mod_ref)),
+                                },
+                            };
+
+                            exit_ooe!(
+                                self.remaining_energy.tick_energy(
+                                    constants::CONTRACT_INSTANCE_QUERY_CONTRACT_BALANCE_COST,
+                                ),
+                                trace
+                            );
+                            trace_elements.push(invocation_data.debug_trace(trace));
+                            stack.push(Next::Resume {
+                                data: invocation_data,
+                                config,
+                                response: Some(response),
+                            });
+                        }
+                        v1::Interrupt::QueryContractName {
+                            address,
+                        } => {
+                            let response = match self.contract_name(address) {
+                                None => v1::InvokeResponse::Failure {
+                                    kind: v1::InvokeFailure::NonExistentContract,
+                                },
+                                Some(cname) => v1::InvokeResponse::Success {
+                                    // Balance of contract querying. Won't change. Notice the
+                                    // `data.address`.
+                                    new_balance: self
+                                        .contract_balance_unchecked(invocation_data.address),
+                                    data:        Some(cname.get_chain_name().into()),
+                                },
+                            };
+
+                            exit_ooe!(
+                                self.remaining_energy.tick_energy(
+                                    constants::CONTRACT_INSTANCE_QUERY_CONTRACT_BALANCE_COST,
+                                ),
+                                trace
+                            );
+                            trace_elements.push(invocation_data.debug_trace(trace));
+                            stack.push(Next::Resume {
+                                data: invocation_data,
+                                config,
+                                response: Some(response),
+                            });
+                        }
                     }
                 }
                 v1::ReceiveResult::Reject {
@@ -1186,6 +1245,29 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
             Some(changes) => Some(changes.current_balance()),
             None => self.chain.contracts.get(&address).map(|c| c.self_balance),
         }
+    }
+
+    /// Looks up the contract module reference from the topmost checkpoint on
+    /// the changeset. Or, alternatively, from persistence.
+    fn contract_module_reference(&self, address: ContractAddress) -> Option<ModuleReference> {
+        // The module reference can change in the event of a contract upgrade, so we
+        // need to look it up in the changeset first.
+        self.changeset
+            .current()
+            .contracts
+            .get(&address)
+            .and_then(|c| c.module)
+            .or_else(|| self.chain.contracts.get(&address).map(|c| c.module_reference))
+    }
+
+    /// Looks up the contract name from persistence. (Since the contract name
+    /// cannot change, and new contracts cannot be deployed within contract
+    /// invocations, this is sufficient to resolve the name of a contract.)
+    fn contract_name(&self, address: ContractAddress) -> Option<ContractName> {
+        // The contract name does not change as a result of upgrades (and contracts
+        // cannot deploy new contracts), so we always resolve the contract name in the
+        // immutable chain context.
+        self.chain.contracts.get(&address).map(|c| c.contract_name.as_contract_name())
     }
 
     /// Returns the contract module from the topmost checkpoint on

--- a/contract-testing/tests/contract_queries.rs
+++ b/contract-testing/tests/contract_queries.rs
@@ -265,7 +265,8 @@ fn test_module_ref_and_name() {
 }
 
 #[test]
-/// Test the interaction between upgrading a contract and querying the contract module reference.
+/// Test the interaction between upgrading a contract and querying the contract
+/// module reference.
 fn test_upgrade_module_ref() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(100);

--- a/contract-testing/tests/contract_queries.rs
+++ b/contract-testing/tests/contract_queries.rs
@@ -8,8 +8,8 @@ mod helpers;
 /// This test deploys three different smart contracts, from two different
 /// modules.  One of these contracts <0,0> has a function that queries and logs
 /// the module reference of a  specified contract address. Another <2,0> queries
-/// and logs the contract name of a specified  contract. Both functions are
-/// invoked for each instance, and for non-existant contract  addresses,
+/// and logs the contract name of a specified contract. Both functions are
+/// invoked for each instance, and for non-existant contract addresses,
 /// ensuring the values are as expected.
 ///
 /// The entrypoints are designed to succeed in the case of a match, fail with

--- a/contract-testing/tests/contract_queries.rs
+++ b/contract-testing/tests/contract_queries.rs
@@ -117,35 +117,35 @@ fn test_module_ref_and_name() {
         res.0, res_deploy_contract_inspection.module_reference,
         "Contract 0 should match contract inspection contract"
     );
-    assert_eq!(res.1, 776.into(), "Expected energy to get module reference '{}'", res.0);
+    assert_eq!(res.1, 775.into(), "Expected energy to get module reference '{}'", res.0);
     let res = get_module_ref(&mut chain, res_init_1.contract_address)
         .expect("Contract 1 should be valid");
     assert_eq!(
         res.0, res_deploy_account_balance.module_reference,
         "Contract 1 should match contract inspection contract"
     );
-    assert_eq!(res.1, 776.into(), "Expected energy to get module reference '{}'", res.0);
+    assert_eq!(res.1, 775.into(), "Expected energy to get module reference '{}'", res.0);
     let res = get_module_ref(&mut chain, res_init_2.contract_address)
         .expect("Contract 2 should be valid");
     assert_eq!(
         res.0, res_deploy_contract_inspection.module_reference,
         "Contract 2 should match contract inspection contract"
     );
-    assert_eq!(res.1, 776.into(), "Expected energy to get module reference '{}'", res.0);
+    assert_eq!(res.1, 775.into(), "Expected energy to get module reference '{}'", res.0);
     let err = get_module_ref(&mut chain, ContractAddress {
         index:    3,
         subindex: 0,
     })
     .expect_err("Contract <3,0> should be invalid");
     assert_eq!(err.reject_code(), Some(-1), "Rejection code for get_module_ref on <3,0>");
-    assert_eq!(err.energy_used, 744.into(), "Expected energy for failed get module ref.");
+    assert_eq!(err.energy_used, 743.into(), "Expected energy for failed get module ref.");
     let err = get_module_ref(&mut chain, ContractAddress {
         index:    1,
         subindex: 1,
     })
     .expect_err("Contract <0,1> should be invalid");
     assert_eq!(err.reject_code(), Some(-1), "Rejection code for get_module_ref on <0,1>");
-    assert_eq!(err.energy_used, 744.into(), "Expected energy for failed get module ref.");
+    assert_eq!(err.energy_used, 743.into(), "Expected energy for failed get module ref.");
 
     // Use contract 2 to check the contract name of the contracts.
     let get_name = |chain: &mut Chain,
@@ -183,7 +183,7 @@ fn test_module_ref_and_name() {
     );
     assert_eq!(
         res.1,
-        755.into(),
+        754.into(),
         "Expected energy for get_contract_name on {}",
         res.0.as_contract_name()
     );
@@ -196,7 +196,7 @@ fn test_module_ref_and_name() {
     );
     assert_eq!(
         res.1,
-        755.into(),
+        754.into(),
         "Expected energy for get_contract_name on {}",
         res.0.as_contract_name()
     );
@@ -209,7 +209,7 @@ fn test_module_ref_and_name() {
     );
     assert_eq!(
         res.1,
-        756.into(),
+        755.into(),
         "Expected energy for get_contract_name on {}",
         res.0.as_contract_name()
     );
@@ -219,14 +219,14 @@ fn test_module_ref_and_name() {
     })
     .expect_err("Contract <3,0> should be invalid");
     assert_eq!(err.reject_code(), Some(-1), "Rejection code for get_module_ref on <3,0>");
-    assert_eq!(err.energy_used, 742.into(), "Expected energy for failed get_contract_name");
+    assert_eq!(err.energy_used, 741.into(), "Expected energy for failed get_contract_name");
     let err = get_name(&mut chain, ContractAddress {
         index:    1,
         subindex: 1,
     })
     .expect_err("Contract <0,1> should be invalid");
     assert_eq!(err.reject_code(), Some(-1), "Rejection code for get_module_ref on <0,1>");
-    assert_eq!(err.energy_used, 742.into(), "Expected energy for failed get_contract_name");
+    assert_eq!(err.energy_used, 741.into(), "Expected energy for failed get_contract_name");
 }
 
 #[test]

--- a/contract-testing/tests/contract_queries.rs
+++ b/contract-testing/tests/contract_queries.rs
@@ -1,0 +1,361 @@
+//! This module contains tests for smart contract module reference and name
+//! queries. These tests match equivalent tests for the scheduler in the node.
+use std::io::Write;
+
+use concordium_smart_contract_testing::*;
+mod helpers;
+
+#[macro_export]
+/// Macro for a pattern that matches a [ContractInvokeError] where the contract
+/// rejects with the supplied error code.
+macro_rules! ContractInvokeErrorCode {
+    ($x:expr) => {
+        ContractInvokeError {
+            kind: ContractInvokeErrorKind::ExecutionError {
+                failure_kind: InvokeFailure::ContractReject {
+                    code: $x,
+                    ..
+                },
+            },
+            ..
+        }
+    };
+}
+
+#[test]
+/// This test deploys three different smart contracts, from two different
+/// modules. One of these contracts <0,0> has a function for checking if the
+/// module reference matches an expected value. Another <2,0> has a function for
+/// checking if the contract name matches an expected value. Both functions are
+/// invoked for each instance, and for non-existant contract addresses, ensuring
+/// the values are as expected.
+///
+/// The entrypoints are designed to succeed in the case of a match, fail with
+/// code -1 if there is a mismatch, and fail with code -2 if the contract
+/// address does not exist. If the protocol version does not support the
+/// contract inspection functionality, then the call should fail with
+/// a runtime exception.
+fn test_module_ref_and_name() {
+    let mut chain = Chain::new();
+    let initial_balance = Amount::from_ccd(100);
+    chain.create_account(Account::new(helpers::ACC_0, initial_balance));
+
+    // We use two contract modules for this test.
+    let mod_contract_inspection =
+        module_load_v1_raw(helpers::wasm_test_file("queries-contract-inspection.wasm"))
+            .expect("module should exist");
+    let mod_account_balance =
+        module_load_v1_raw(helpers::wasm_test_file("queries-account-balance.wasm"))
+            .expect("module should exist");
+
+    // Deploy the modules
+    let res_deploy_contract_inspection = chain
+        .module_deploy_v1(Signer::with_one_key(), helpers::ACC_0, mod_contract_inspection)
+        .expect("Deploying valid module should work");
+    let res_deploy_account_balance = chain
+        .module_deploy_v1(Signer::with_one_key(), helpers::ACC_0, mod_account_balance)
+        .expect("Deploying valid module should work");
+
+    // Initialise three contracts.
+    let res_init_0 = chain
+        .contract_init(
+            Signer::with_one_key(),
+            helpers::ACC_0,
+            Energy::from(100000),
+            InitContractPayload {
+                init_name: OwnedContractName::new_unchecked("init_contract".into()),
+                mod_ref:   res_deploy_contract_inspection.module_reference,
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
+        .expect("Initializing valid contract should work");
+    let res_init_1 = chain
+        .contract_init(
+            Signer::with_one_key(),
+            helpers::ACC_0,
+            Energy::from(100000),
+            InitContractPayload {
+                init_name: OwnedContractName::new_unchecked("init_contract".into()),
+                mod_ref:   res_deploy_account_balance.module_reference,
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
+        .expect("Initializing valid contract should work");
+    let res_init_2 = chain
+        .contract_init(
+            Signer::with_one_key(),
+            helpers::ACC_0,
+            Energy::from(100000),
+            InitContractPayload {
+                init_name: OwnedContractName::new_unchecked("init_contract2".into()),
+                mod_ref:   res_deploy_contract_inspection.module_reference,
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
+        .expect("Initializing valid contract should work");
+
+    // Use contract 0 to check the module addresses of the contracts.
+    let check_module_ref =
+        |chain: &mut Chain, address: ContractAddress, mod_ref: ModuleReference| {
+            let input_param = (address, mod_ref);
+            chain.contract_update(
+                Signer::with_one_key(),
+                helpers::ACC_0,
+                Address::Account(helpers::ACC_0),
+                Energy::from(100000),
+                UpdateContractPayload {
+                    address:      res_init_0.contract_address,
+                    receive_name: OwnedReceiveName::new_unchecked(
+                        "contract.check_module_reference".into(),
+                    ),
+                    message:      OwnedParameter::from_serial(&input_param)
+                        .expect("Parameter has valid size"),
+                    amount:       Amount::zero(),
+                },
+            )
+        };
+    let res = check_module_ref(
+        &mut chain,
+        res_init_0.contract_address,
+        res_deploy_contract_inspection.module_reference,
+    );
+    assert!(
+        matches!(res, Ok(..)),
+        "Contract 0 should match contract inspection contract, but result was: {:?}",
+        res
+    );
+    let res = check_module_ref(
+        &mut chain,
+        res_init_1.contract_address,
+        res_deploy_contract_inspection.module_reference,
+    );
+    assert!(
+        matches!(res, Err(ContractInvokeErrorCode!(-1))),
+        "Contract 1 should not match contract inspection contract, but result was: {:?}",
+        res
+    );
+    let res = check_module_ref(
+        &mut chain,
+        res_init_2.contract_address,
+        res_deploy_contract_inspection.module_reference,
+    );
+    assert!(
+        matches!(res, Ok(..)),
+        "Contract 0 should match contract inspection contract, but result was: {:?}",
+        res
+    );
+    let res = check_module_ref(
+        &mut chain,
+        ContractAddress {
+            index:    3,
+            subindex: 0,
+        },
+        res_deploy_contract_inspection.module_reference,
+    );
+    assert!(
+        matches!(res, Err(ContractInvokeErrorCode!(-2))),
+        "Contract <3,0> should not exist, but result was: {:?}",
+        res
+    );
+    let res = check_module_ref(
+        &mut chain,
+        ContractAddress {
+            index:    0,
+            subindex: 1,
+        },
+        res_deploy_contract_inspection.module_reference,
+    );
+    assert!(
+        matches!(res, Err(ContractInvokeErrorCode!(-2))),
+        "Contract <0,1> should not exist, but result was: {:?}",
+        res
+    );
+    let res = check_module_ref(
+        &mut chain,
+        res_init_1.contract_address,
+        res_deploy_account_balance.module_reference,
+    );
+    assert!(
+        matches!(res, Ok(..)),
+        "Contract 1 should match account balance contract, but result was: {:?}",
+        res
+    );
+
+    // Use contract 2 to check the contract name of the contracts.
+    let check_name = |chain: &mut Chain, address: ContractAddress, name: &str| {
+        let mut input_param = Vec::with_capacity(16 + name.len());
+        concordium_rust_sdk::base::contracts_common::Serial::serial(&address, &mut input_param)
+            .unwrap();
+        println!("{:?}", &input_param);
+        input_param.write_all(name.as_bytes()).unwrap();
+        let op = OwnedParameter::try_from(input_param);
+        println!("{:?}", &op);
+        chain.contract_update(
+            Signer::with_one_key(),
+            helpers::ACC_0,
+            Address::Account(helpers::ACC_0),
+            Energy::from(100000),
+            UpdateContractPayload {
+                address:      res_init_2.contract_address,
+                receive_name: OwnedReceiveName::new_unchecked("contract2.check_name".into()),
+                message:      op.expect("Parameter has valid size"),
+                amount:       Amount::zero(),
+            },
+        )
+    };
+    let res = check_name(&mut chain, res_init_0.contract_address, "init_contract");
+    assert!(
+        matches!(res, Ok(..)),
+        "Contract 0 should match 'init_contract', but result was: {:?}",
+        res
+    );
+    let res = check_name(&mut chain, res_init_1.contract_address, "init_contract");
+    assert!(
+        matches!(res, Ok(..)),
+        "Contract 1 should match 'init_contract', but result was: {:?}",
+        res
+    );
+    let res = check_name(&mut chain, res_init_2.contract_address, "init_contract");
+    assert!(
+        matches!(res, Err(ContractInvokeErrorCode!(-1))),
+        "Contract 2 should not match 'init_contract', but result was: {:?}",
+        res
+    );
+    let res = check_name(&mut chain, res_init_2.contract_address, "init_contract2");
+    assert!(
+        matches!(res, Ok(..)),
+        "Contract 2 should match 'init_contract2', but result was: {:?}",
+        res
+    );
+    let res = check_name(
+        &mut chain,
+        ContractAddress {
+            index:    3,
+            subindex: 0,
+        },
+        "init_contract",
+    );
+    assert!(
+        matches!(res, Err(ContractInvokeErrorCode!(-2))),
+        "Contract <3,0> should not exist, but result was: {:?}",
+        res
+    );
+    let res = check_name(&mut chain, res_init_0.contract_address, "init_contract2");
+    assert!(
+        matches!(res, Err(ContractInvokeErrorCode!(-1))),
+        "Contract 0 should not match 'init_contract2', but result was: {:?}",
+        res
+    );
+    let res = check_name(
+        &mut chain,
+        ContractAddress {
+            index:    0,
+            subindex: 1,
+        },
+        "init_contract2",
+    );
+    assert!(
+        matches!(res, Err(ContractInvokeErrorCode!(-2))),
+        "Contract <0,1> should not exist, but result was: {:?}",
+        res
+    );
+}
+
+#[test]
+fn test_upgrade_modeul_ref() {
+    let mut chain = Chain::new();
+    let initial_balance = Amount::from_ccd(100);
+    chain.create_account(Account::new(helpers::ACC_0, initial_balance));
+
+    // We use two contract modules for this test.
+    let mod_0 = module_load_v1_raw(helpers::wasm_test_file("upgrading-inspect-module0.wasm"))
+        .expect("module should exist");
+    let mod_1 = module_load_v1_raw(helpers::wasm_test_file("upgrading-inspect-module1.wasm"))
+        .expect("module should exist");
+
+    // Deploy the modules
+    let res_deploy_0 = chain
+        .module_deploy_v1(Signer::with_one_key(), helpers::ACC_0, mod_0)
+        .expect("Deploying valid module should work");
+    let res_deploy_1 = chain
+        .module_deploy_v1(Signer::with_one_key(), helpers::ACC_0, mod_1)
+        .expect("Deploying valid module should work");
+
+    // Initialise three contracts.
+    let res_init_0 = chain
+        .contract_init(
+            Signer::with_one_key(),
+            helpers::ACC_0,
+            Energy::from(100000),
+            InitContractPayload {
+                init_name: OwnedContractName::new_unchecked("init_contract".into()),
+                mod_ref:   res_deploy_0.module_reference,
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
+        .expect("Initializing valid contract should work");
+
+    let check_module_ref =
+        |chain: &mut Chain, address: ContractAddress, mod_ref: ModuleReference| {
+            let input_param = (address, mod_ref);
+            let op = OwnedParameter::from_serial(&input_param);
+            println!("{:?}", &op);
+            chain.contract_update(
+                Signer::with_one_key(),
+                helpers::ACC_0,
+                Address::Account(helpers::ACC_0),
+                Energy::from(100000),
+                UpdateContractPayload {
+                    address:      res_init_0.contract_address,
+                    receive_name: OwnedReceiveName::new_unchecked(
+                        "contract.check_module_reference".into(),
+                    ),
+                    message:      OwnedParameter::from_serial(&input_param)
+                        .expect("Parameter has valid size"),
+                    amount:       Amount::zero(),
+                },
+            )
+        };
+    let res =
+        check_module_ref(&mut chain, res_init_0.contract_address, res_deploy_0.module_reference);
+    assert!(matches!(res, Ok(..)), "Contract 0 should match contract 0, but result was: {:?}", res);
+    let res =
+        check_module_ref(&mut chain, res_init_0.contract_address, res_deploy_1.module_reference);
+    assert!(
+        matches!(res, Err(ContractInvokeErrorCode!(-1))),
+        "Contract 0 should not match contract 1, but result was: {:?}",
+        res
+    );
+    // Upgrade the contract. This also checks that the module reference changes
+    // after the upgrade.
+    let res = chain.contract_update(
+        Signer::with_one_key(),
+        helpers::ACC_0,
+        Address::Account(helpers::ACC_0),
+        Energy::from(100000),
+        UpdateContractPayload {
+            address:      res_init_0.contract_address,
+            receive_name: OwnedReceiveName::new_unchecked("contract.upgrade".into()),
+            message:      OwnedParameter::from_serial(&res_deploy_1.module_reference)
+                .expect("Parameter has valid size"),
+            amount:       Amount::zero(),
+        },
+    );
+    assert!(matches!(res, Ok(..)), "Contract upgrade should succeed, but result was: {:?}", res);
+
+    // Check the module reference after the update.
+    let res =
+        check_module_ref(&mut chain, res_init_0.contract_address, res_deploy_1.module_reference);
+    assert!(matches!(res, Ok(..)), "Contract 0 should match contract 1, but result was: {:?}", res);
+    let res =
+        check_module_ref(&mut chain, res_init_0.contract_address, res_deploy_0.module_reference);
+    assert!(
+        matches!(res, Err(ContractInvokeErrorCode!(-1))),
+        "Contract 0 should not match contract 0, but result was: {:?}",
+        res
+    );
+}

--- a/contract-testing/tests/contract_queries.rs
+++ b/contract-testing/tests/contract_queries.rs
@@ -265,7 +265,8 @@ fn test_module_ref_and_name() {
 }
 
 #[test]
-fn test_upgrade_modeul_ref() {
+/// Test the interaction between upgrading a contract and querying the contract module reference.
+fn test_upgrade_module_ref() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(100);
     chain.create_account(Account::new(helpers::ACC_0, initial_balance));

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,7 @@ The list of contracts is as follows:
 - [cis2-wccd](./cis2-wccd) An upgradable example implementation of the CIS-2 Concordium Token Standard
   containing a single fungible token which is a wrapped CCD.
 - [counter-notify](./counter-notify) A contract that works as a counter and can invoke another contract with the current counter value.
+- [factory](./factory) An example of implementing a factory pattern with smart contracts.
 - [fib](./fib) A contract that calculates and stores the nth Fibonacci number by recursively calling itself.
 - [icecream](./icecream) A contract for buying ice cream only when it is sunny. A weather service oracle smart contract is used.
 - [proxy](./proxy) A proxy contract that can be put in front of another contract. It works with V0 as well as V1 smart contracts.

--- a/examples/factory/Cargo.toml
+++ b/examples/factory/Cargo.toml
@@ -7,12 +7,12 @@ license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default = ["std", "wee_alloc"]
+default = ["std", "bump_alloc"]
 std = ["concordium-std/std"]
-wee_alloc = ["concordium-std/wee_alloc"]
+bump_alloc = ["concordium-std/bump_alloc"]
 
 [dependencies]
-concordium-std = { path = "../../concordium-std", version = "9.0", default-features = false, features = [
+concordium-std = { path = "../../concordium-std", version = "10.0", default-features = false, features = [
     "p7",
 ] }
 

--- a/examples/factory/Cargo.toml
+++ b/examples/factory/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "factory-smart-contract"
+version = "0.1.0"
+authors = ["Concordium <developers@concordium.com>"]
+edition = "2021"
+license = "MPL-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["std", "wee_alloc"]
+std = ["concordium-std/std"]
+wee_alloc = ["concordium-std/wee_alloc"]
+
+[dependencies]
+concordium-std = {path = "../../concordium-std", default-features = false}
+
+[dev-dependencies]
+concordium-smart-contract-testing = { path = "../../contract-testing" }
+
+[lib]
+crate-type=["cdylib", "rlib"]

--- a/examples/factory/Cargo.toml
+++ b/examples/factory/Cargo.toml
@@ -12,7 +12,7 @@ std = ["concordium-std/std"]
 wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
+concordium-std = {path = "../../concordium-std", default-features = false, features = ["p7"]}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }

--- a/examples/factory/Cargo.toml
+++ b/examples/factory/Cargo.toml
@@ -12,10 +12,12 @@ std = ["concordium-std/std"]
 wee_alloc = ["concordium-std/wee_alloc"]
 
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false, features = ["p7"]}
+concordium-std = { path = "../../concordium-std", version = "9.0", default-features = false, features = [
+    "p7",
+] }
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }
 
 [lib]
-crate-type=["cdylib", "rlib"]
+crate-type = ["cdylib", "rlib"]

--- a/examples/factory/src/lib.rs
+++ b/examples/factory/src/lib.rs
@@ -1,0 +1,304 @@
+//! An example demonstrating how a factory pattern can be implemented with smart
+//! contracts on Concordium.
+//!
+//! > **Important Note:** The factory pattern is not generally idiomatic on
+//! > Concordium. In many cases, a more appropriate solution is to incorporate
+//! > the factory and products into a single smart contract instance, rather
+//! > than having a separate instance for each product.
+//!
+//! # Description
+//!
+//! This example shows how a factory pattern can be implemented with smart
+//! contracts on Concordium. It consists of two smart contracts: the factory and
+//! the product.
+//!
+//! In a typical factory pattern, the factory contract provides a `produce`
+//! endpoint that constructs a new instance of the product contract. On
+//! Concordium, however, it is not possible to create a new smart contract
+//! instance within a receive method.
+//!
+//! To work around this, the new smart contract instance is first created in a
+//! separate transaction. The address of this new smart contract is then passed
+//! to the `produce` endpoint on the factory. As part of `produce`, the factory
+//! calls an `initialize` method on the product.
+//!
+//! In the typical factory pattern, the factory controls which contract is
+//! constructed and can be sure that the instance is newly constructed. In our
+//! implementation, the factory does not directly construct the product. This
+//! means that the factory **must check** that the supplied product is an
+//! instance of the expected product contract. This is achieved by checking the
+//! module reference and contract name match expected values. To ensure that the
+//! product is indeed newly constructed, the factory calls an `initialize`
+//! method on the product that will initialize its state, but fail if it has
+//! already been initialized.
+//!
+//! In this example, both the factory and product are defined in the same
+//! module, so the factory checks that the product's module reference is the
+//! same as the factory's. If the contracts were defined in separate modules,
+//! then the factory would need to know the module reference that products
+//! should use. This could be hard-coded in the contract, or set as a parameter
+//! when the factory is initialized.
+//!
+//! Since the construction and initialization of the product occur in two
+//! separate transactions, it is possible that a third party might try to hijack
+//! the process by inserting their own transaction to initialize the product
+//! (for instance, invoking a different factory instance than intended by the
+//! originator). To prevent this possibility, the product checks in its
+//! `initialize` method that the invoker of the `produce` transaction is the
+//! same account as created the product contract instance (i.e. the "owner").
+//!
+//! In this example the factory acts as a registry of all the products it has
+//! "produced", assigning each a fresh index and recording the contract address
+//! for each. The products are initialized with their index, and also keep a
+//! record of the address of the factory contract that produced them. In a
+//! practical application, the factory might supply additional paramaters when
+//! initializing the products.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod factory {
+    //! The factory smart contract.
+
+    use concordium_std::*;
+
+    /// The name of the constructor used to create the product contract.
+    const PRODUCT_INIT_NAME: &str = "init_product";
+    /// The entrypoint for initializing the product contract.
+    const PRODUCT_INITIALIZE_ENTRYPOINT: &str = "initialize";
+
+    #[derive(Serial, DeserialWithState)]
+    #[concordium(state_parameter = "S")]
+    /// The state of the factory contract.
+    /// This keeps a record of all of the product contracts.
+    pub struct FactoryState<S: HasStateApi = StateApi> {
+        /// The index that will be assigned to the next product contract.
+        /// Equivalently, the number of product contracts that have been
+        /// produced.
+        ///
+        /// Note, for all practical purposes, using a `u64` to count the
+        /// products cannot overflow. In particular, the blockchain does
+        /// not (currently) allow for more than 2^64 smart contracts.
+        next_product: u64,
+        /// Index of the product smart contract instances.
+        products:     StateMap<u64, ContractAddress, S>,
+    }
+
+    /// Errors
+    #[derive(Serialize, Debug, PartialEq, Eq, Reject, SchemaType)]
+    pub enum FactoryError {
+        /// Failed parsing the parameter.
+        #[from(ParseError)]
+        ParseParams,
+        /// [`produce`] was called with a non-existent product contract.
+        /// Or [`view_product`] was called with an indext for a non-existent
+        /// product.
+        NonExistentProduct,
+        /// The product was not of the correct module and contract name.
+        InvalidProduct,
+        /// The product could not be initialized, probably because it is already
+        /// initialized.
+        InitializeFailed,
+    }
+
+    /// Init function that creates a new factory.
+    /// The new factory will have no products, and new products will be assigned
+    /// indexes starting from 0.
+    #[init(contract = "factory")]
+    pub fn init(_ctx: &InitContext, state_builder: &mut StateBuilder) -> InitResult<FactoryState> {
+        // Creating `State`
+        let state = FactoryState {
+            next_product: 0,
+            products:     state_builder.new_map(),
+        };
+        Ok(state)
+    }
+
+    /// "Produce" a new instance of the product contract. This does not directly
+    /// create the instance, but requires it to be passed as a parameter.
+    /// The following checks take place:
+    ///
+    /// * The parameter *must* be a contract address. Otherwise
+    ///   [`FactoryError::ParseParams`] is returned.
+    ///
+    /// * The supplied contract address *must* point to an existing smart
+    ///   contract instance. Otherwise [`FactoryError::NonExistentProduct`] is
+    ///   returned.
+    ///
+    /// * The supplied instance *must* be an instance of the `product` contract
+    ///   defined in this module. Otherwise [`FactoryError::InvalidProduct`] is
+    ///   returned.
+    ///
+    /// * The supplied instance *must* be uninitialized. Moreover, the
+    ///   preconditions for [`crate::product::initialize`] must be met. (In
+    ///   particular, the invoker of this transaction must be the same account
+    ///   as created the product instance.) Otherwise
+    ///   [`FactoryError::InitializeFailed`] is returned.
+    ///
+    /// If successful, the product is assigned a fresh index (as part of the
+    /// initialization), and is recorded in the factory's index.
+    #[receive(contract = "factory", name = "produce", parameter = "ContractAddress", mutable)]
+    pub fn produce(
+        ctx: &ReceiveContext,
+        host: &mut Host<FactoryState>,
+    ) -> Result<(), FactoryError> {
+        let product_address = ctx.parameter_cursor().get()?;
+        // We can depend upon getting the module reference for our own contract.
+        let self_module_ref = host.contract_module_reference(ctx.self_address()).unwrap();
+        // Check the product module is the same as our own module.
+        let product_module_ref = host
+            .contract_module_reference(product_address)
+            .or(Err(FactoryError::NonExistentProduct))?;
+        if self_module_ref != product_module_ref {
+            Err(FactoryError::InvalidProduct)?;
+        }
+        // Check the product contract name is correct.
+        // As this module contains both the factory and product contracts, it is not
+        // enough to check just the module reference, because we want to ensure
+        // that the would-be product is not an instance of the factory contract.
+        let product_name =
+            host.contract_name(product_address).or(Err(FactoryError::NonExistentProduct))?;
+        if product_name != PRODUCT_INIT_NAME {
+            Err(FactoryError::InvalidProduct)?;
+        }
+        // Invoke the initialize entrypoint on the product passing in the index for this
+        // product.
+        let next_product = host.state().next_product;
+        host.invoke_contract(
+            &product_address,
+            &next_product,
+            EntrypointName::new_unchecked(PRODUCT_INITIALIZE_ENTRYPOINT),
+            Amount::zero(),
+        )
+        .or(Err(FactoryError::InitializeFailed))?;
+        // Update the state
+        let state = host.state_mut();
+        state.next_product = next_product + 1;
+        state.products.insert(next_product, product_address);
+        Ok(())
+    }
+
+    /// Get the number of product instances that have been successfully
+    /// initialized by this factory.
+    #[receive(contract = "factory", name = "view_product_count")]
+    pub fn view_product_count(
+        _ctx: &ReceiveContext,
+        host: &Host<FactoryState>,
+    ) -> Result<u64, FactoryError> {
+        Ok(host.state().next_product)
+    }
+
+    /// Get the contract address of the product instance for a particular index.
+    /// Indexes are assigned sequentially starting from 0.
+    #[receive(contract = "factory", name = "view_product", parameter = "u64")]
+    pub fn view_product(
+        ctx: &ReceiveContext,
+        host: &Host<FactoryState>,
+    ) -> Result<ContractAddress, FactoryError> {
+        let param: u64 = ctx.parameter_cursor().get()?;
+        let ca = host.state().products.get(&param).ok_or(FactoryError::NonExistentProduct)?;
+        Ok(ca.to_owned())
+    }
+}
+
+pub mod product {
+    //! The product smart contract.
+
+    use concordium_std::*;
+
+    /// Represents the state of a product after it has been initialized by the
+    /// factory.
+    #[derive(Debug, Serialize, SchemaType, Eq, PartialEq, PartialOrd, Clone)]
+    pub struct Product {
+        /// The factory that created the product.
+        pub factory: ContractAddress,
+        /// The index given to the product by the factory.
+        pub index:   u64,
+    }
+
+    /// The overall state of a product, which may or may not yet have been
+    /// initialized by a factory.
+    #[derive(Debug, Serialize, SchemaType, Eq, PartialEq, PartialOrd, Clone)]
+    pub enum ProductState {
+        /// The product has not yet been initialized by the factory.
+        Uninitialized,
+        /// The product has been initialised by the factory.
+        Initialized(Product),
+    }
+
+    /// Errors
+    #[derive(Serialize, Debug, PartialEq, Eq, Reject, SchemaType)]
+    pub enum ProductError {
+        /// Failed parsing the parameter.
+        #[from(ParseError)]
+        ParseParams,
+        /// The originator of the transaction does not match the owner of the
+        /// instance, and thus is not authorized to initialize the contract.
+        NotAuthorized,
+        /// The product was already initialized.
+        AlreadyInitialized,
+        /// [`initialize`] was not called by a factory contract.
+        NotInitializedByFactory,
+    }
+
+    /// Construct the product contract in the uninitialized state.
+    #[init(contract = "product")]
+    pub fn init(_ctx: &InitContext, _state_builder: &mut StateBuilder) -> InitResult<ProductState> {
+        Ok(ProductState::Uninitialized)
+    }
+
+    /// Initialize the product contract, supplying its index.
+    /// The following preconditions are checked:
+    ///
+    /// * The instance must not have already been initialized. Otherwise,
+    ///   [`ProductError::AlreadyInitialized`] is returned.
+    ///
+    /// * The account invoking the current transaction must be the same account
+    ///   that created the instance. Otherwise [`ProductError::NotAuthorized`]
+    ///   is returned.
+    ///
+    /// * The method must be called by another smart contract (the factory). If
+    ///   the caller is not a contract,
+    ///   [`ProductError::NotInitializedByFactory`] is returned.
+    ///
+    /// Note that beyond checking that the caller is a smart contract, this
+    /// method does not check further properties of the caller (e.g. that it is
+    /// any particular factory smart contract).
+    #[receive(contract = "product", name = "initialize", parameter = "u64", mutable)]
+    pub fn initialize(
+        ctx: &ReceiveContext,
+        host: &mut Host<ProductState>,
+    ) -> Result<(), ProductError> {
+        let state = host.state_mut();
+        // Check that the contract has not already been initialized.
+        if let ProductState::Initialized(_) = *state {
+            Err(ProductError::AlreadyInitialized)?;
+        }
+        // Check that the invoker is the owner of the contract.
+        if ctx.invoker() != ctx.owner() {
+            Err(ProductError::NotAuthorized)?;
+        }
+        // The index is supplied as a parameter by the factory.
+        let index: u64 = ctx.parameter_cursor().get()?;
+        // This endpoint should only be called by another smart contract, namely the
+        // factory, which we record in the state.
+        let factory = match ctx.sender() {
+            Address::Contract(ca) => ca,
+            _ => Err(ProductError::NotInitializedByFactory)?,
+        };
+        // Initialize the state.
+        let product = Product {
+            index,
+            factory,
+        };
+        *state = ProductState::Initialized(product);
+        Ok(())
+    }
+
+    #[receive(contract = "product", name = "view")]
+    pub fn view(
+        _ctx: &ReceiveContext,
+        host: &Host<ProductState>,
+    ) -> Result<ProductState, ProductError> {
+        Ok(host.state().to_owned())
+    }
+}

--- a/examples/factory/src/lib.rs
+++ b/examples/factory/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! To work around this, the new smart contract instance is first created in a
 //! separate transaction. The address of this new smart contract is then passed
-//! to the `produce` endpoint on the factory. As part of `produce`, the factory
+//! to the `produce` endpoint of the factory. As part of `produce`, the factory
 //! calls an `initialize` method on the product.
 //!
 //! In the typical factory pattern, the factory controls which contract is

--- a/examples/factory/tests/tests.rs
+++ b/examples/factory/tests/tests.rs
@@ -111,7 +111,9 @@ fn test_double_produce_second_factory() {
 }
 
 /// Test that `produce` fails when called with an instance of a contract other
-/// than the product.
+/// than the product, namely an instance of the factory contract.
+/// Note, this only tests the functionality that distinguishes on the contract
+/// name, not on the contract module reference.
 #[test]
 fn test_wrong_product() {
     let (mut chain, module_ref) = initialize_chain();

--- a/examples/factory/tests/tests.rs
+++ b/examples/factory/tests/tests.rs
@@ -1,0 +1,231 @@
+//! Tests for the factory smart contract.
+use concordium_smart_contract_testing::*;
+use concordium_std::{Cursor, Deserial};
+use factory_smart_contract::product::{Product, ProductState};
+
+/// The test accounts.
+const ALICE: AccountAddress = AccountAddress([0; 32]);
+const BOB: AccountAddress = AccountAddress([1; 32]);
+
+const SIGNER: Signer = Signer::with_one_key();
+const ACC_INITIAL_BALANCE: Amount = Amount::from_ccd(10000);
+
+/// Test the case of producing two products from one factory.
+#[test]
+fn test_success() {
+    let (mut chain, module_ref) = initialize_chain();
+    // Set up the factory instance.
+    let factory = create_factory(&mut chain, module_ref);
+
+    // Create a product instance.
+    let product = create_product(&mut chain, module_ref, ALICE);
+    // Check that it is uninitialized
+    let prod_state = view_product(&chain, product).expect("Get view of uninitialized product");
+    assert_eq!(prod_state, ProductState::Uninitialized);
+    // "Produce" the product with the factory.
+    call_produce(&mut chain, factory, product, ALICE).expect("Produce successful");
+    // Check that it is initialized as we expect.
+    let prod_state = view_product(&chain, product).expect("Get view of initialized product");
+    assert_eq!(
+        prod_state,
+        ProductState::Initialized(Product {
+            factory,
+            index: 0,
+        })
+    );
+
+    // Create and produce a second product (from a different account), and check the
+    // result.
+    let product2 = create_product(&mut chain, module_ref, BOB);
+    call_produce(&mut chain, factory, product2, BOB).expect("Produce successful");
+    let prod_state = view_product(&chain, product2).expect("Get view of initialized product");
+    assert_eq!(
+        prod_state,
+        ProductState::Initialized(Product {
+            factory,
+            index: 1,
+        })
+    );
+
+    // Check that the factory records having 2 products, and that they match what we
+    // expect.
+    assert_eq!(view_product_count(&chain, factory).expect("View product count successful"), 2);
+    assert_eq!(view_product_at(&chain, factory, 0).expect("View of product at index"), product);
+    assert_eq!(view_product_at(&chain, factory, 1).expect("View of product at index"), product2);
+}
+
+/// Test that a product instance cannot be produced using an account that did
+/// not create the product instance.
+#[test]
+fn test_not_authorized() {
+    let (mut chain, module_ref) = initialize_chain();
+    let factory = create_factory(&mut chain, module_ref);
+    // ALICE creates the product instance, but BOB invokes produce on the factory.
+    // This should fail.
+    let product = create_product(&mut chain, module_ref, ALICE);
+    call_produce(&mut chain, factory, product, BOB).expect_err(
+        "Should fail when product is called from a different account than the creator of the \
+         product.",
+    );
+}
+
+/// Test that a product cannot be produced twice (by the same factory).
+#[test]
+fn test_double_produce() {
+    let (mut chain, module_ref) = initialize_chain();
+    let factory = create_factory(&mut chain, module_ref);
+    let product = create_product(&mut chain, module_ref, ALICE);
+    call_produce(&mut chain, factory, product, ALICE).expect("Produce successful");
+    call_produce(&mut chain, factory, product, ALICE)
+        .expect_err("Should fail when product has already been initialized.");
+}
+
+/// Test that a product cannot be produced twice (by different factories).
+#[test]
+fn test_double_produce_second_factory() {
+    let (mut chain, module_ref) = initialize_chain();
+    let factory = create_factory(&mut chain, module_ref);
+    let product = create_product(&mut chain, module_ref, ALICE);
+    call_produce(&mut chain, factory, product, ALICE).expect("Produce successful");
+    let factory2 = create_factory(&mut chain, module_ref);
+    call_produce(&mut chain, factory2, product, ALICE)
+        .expect_err("Should fail when product has already been initialized.");
+}
+
+/// Test that `produce` fails when called with an instance of a contract other
+/// than the product.
+#[test]
+fn test_wrong_product() {
+    let (mut chain, module_ref) = initialize_chain();
+    let factory = create_factory(&mut chain, module_ref);
+    let factory2 = create_factory(&mut chain, module_ref);
+    call_produce(&mut chain, factory, factory2, ALICE)
+        .expect_err("Should fail with incorrect product contract");
+}
+
+/// Helper function to set up the chain with initial accounts, the module
+/// deployed.
+fn initialize_chain() -> (Chain, ModuleReference) {
+    let mut chain = Chain::new();
+
+    // Create some accounts on the chain.
+    chain.create_account(Account::new(ALICE, ACC_INITIAL_BALANCE));
+    chain.create_account(Account::new(BOB, ACC_INITIAL_BALANCE));
+
+    // Load and deploy the module.
+    let module = module_load_v1("concordium-out/module.wasm.v1").expect("Module exists");
+    let deployment = chain.module_deploy_v1(SIGNER, ALICE, module).expect("Deploy valid module");
+
+    (chain, deployment.module_reference)
+}
+
+/// Helper to create an instance of the factory smart contract.
+fn create_factory(chain: &mut Chain, module_ref: ModuleReference) -> ContractAddress {
+    chain
+        .contract_init(SIGNER, ALICE, Energy::from(10000), InitContractPayload {
+            amount:    Amount::zero(),
+            mod_ref:   module_ref,
+            init_name: OwnedContractName::new_unchecked("init_factory".to_string()),
+            param:     OwnedParameter::empty(),
+        })
+        .expect("Initialize factory")
+        .contract_address
+}
+
+/// Helper to create an instance of the product smart contract.
+fn create_product(
+    chain: &mut Chain,
+    module_ref: ModuleReference,
+    creator: AccountAddress,
+) -> ContractAddress {
+    chain
+        .contract_init(SIGNER, creator, Energy::from(10000), InitContractPayload {
+            amount:    Amount::zero(),
+            mod_ref:   module_ref,
+            init_name: OwnedContractName::new_unchecked("init_product".to_string()),
+            param:     OwnedParameter::empty(),
+        })
+        .expect("Initialize product")
+        .contract_address
+}
+
+/// Helper to call `produce` on the factory smart contract.
+fn call_produce(
+    chain: &mut Chain,
+    factory: ContractAddress,
+    product: ContractAddress,
+    invoker: AccountAddress,
+) -> Result<ContractInvokeSuccess, ContractInvokeError> {
+    chain.contract_update(
+        SIGNER,
+        invoker,
+        Address::Account(invoker),
+        Energy::from(100000),
+        UpdateContractPayload {
+            amount:       Amount::zero(),
+            address:      factory,
+            receive_name: OwnedReceiveName::new_unchecked("factory.produce".to_string()),
+            message:      OwnedParameter::from_serial(&product).unwrap(),
+        },
+    )
+}
+
+/// Helper to view the state of a product contract.
+fn view_product(
+    chain: &Chain,
+    product: ContractAddress,
+) -> Result<ProductState, ContractInvokeError> {
+    let success = chain.contract_invoke(
+        ALICE,
+        Address::Account(ALICE),
+        Energy::from(100000),
+        UpdateContractPayload {
+            amount:       Amount::zero(),
+            address:      product,
+            receive_name: OwnedReceiveName::new_unchecked("product.view".to_string()),
+            message:      OwnedParameter::empty(),
+        },
+    )?;
+    Ok(ProductState::deserial(&mut Cursor::new(success.return_value))
+        .expect("View result deserialization failure"))
+}
+
+/// Helper to view the total number of products that have been produced by a
+/// factory.
+fn view_product_count(chain: &Chain, factory: ContractAddress) -> Result<u64, ContractInvokeError> {
+    let success = chain.contract_invoke(
+        ALICE,
+        Address::Account(ALICE),
+        Energy::from(100000),
+        UpdateContractPayload {
+            amount:       Amount::zero(),
+            address:      factory,
+            receive_name: OwnedReceiveName::new_unchecked("factory.view_product_count".to_string()),
+            message:      OwnedParameter::empty(),
+        },
+    )?;
+    Ok(u64::deserial(&mut Cursor::new(success.return_value))
+        .expect("View result deserialization failure"))
+}
+
+/// Helper to view the address of a product assigned a particular index by a
+/// factory.
+fn view_product_at(
+    chain: &Chain,
+    factory: ContractAddress,
+    index: u64,
+) -> Result<ContractAddress, ContractInvokeError> {
+    let success = chain.contract_invoke(
+        ALICE,
+        Address::Account(ALICE),
+        Energy::from(100000),
+        UpdateContractPayload {
+            amount:       Amount::zero(),
+            address:      factory,
+            receive_name: OwnedReceiveName::new_unchecked("factory.view_product".to_string()),
+            message:      OwnedParameter::from_serial(&index).unwrap(),
+        },
+    )?;
+    Ok(ContractAddress::deserial(&mut Cursor::new(success.return_value))
+        .expect("View result deserialization failure"))
+}


### PR DESCRIPTION
## Purpose

Closes #399 
Depends on https://github.com/Concordium/concordium-rust-sdk/pull/183

Adds support for smart contracts to query the module reference and contract name of smart contract instances.

## Changes

- Add `contract_module_reference` and `contract_name` host functions to `concordium-std`.
- Add support for the new functionality in the testing library.
- Add tests for the implementation in the testing library matching the testing in the scheduler.
- Add a factory smart contract example that demonstrates and tests the functionality.

## Checklist

- [X] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
