### PR TITLE
Allow 0.20 version of cargo generate.

### DIFF
--- a/templates/cis2-nft/cargo-generate.toml
+++ b/templates/cis2-nft/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">= 0.17.0, < 0.20.0"
+cargo_generate_version = ">= 0.17.0, < 0.21.0"
 
 [placeholders]
 description = { type="string", prompt="Description for the project?" }

--- a/templates/credential-registry/cargo-generate.toml
+++ b/templates/credential-registry/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">= 0.17.0, < 0.20.0"
+cargo_generate_version = ">= 0.17.0, < 0.21.0"
 
 [hooks]
 pre = ["pre-script.rhai"] # a script for setting default values for the variables when `template_type = default`

--- a/templates/default/cargo-generate.toml
+++ b/templates/default/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">= 0.17.0, < 0.20.0"
+cargo_generate_version = ">= 0.17.0, < 0.21.0"
 
 [placeholders]
 description = { type="string", prompt="Description for the project?" }


### PR DESCRIPTION
## Purpose

Fixes #415 

The update is safe since 0.20 is a maintenace release https://github.com/cargo-generate/cargo-generate/releases/tag/v0.20.0

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
