### PR TITLE
Fix `SchemaType` implementation of `OnReceivingCis2DataParams<T, A, D>`

### DIFF
--- a/concordium-cis2/CHANGELOG.md
+++ b/concordium-cis2/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased changes
 
 - Bump MSRV to 1.72
+- Fix `SchemaType` implementation of `OnReceivingCis2DataParams<T, A, D>` so that it matches `Serial` and `Deserial` implementations.
 
 ## concordium-cis2 6.1.0 (2024-02-22)
 
@@ -31,7 +32,7 @@
 ## concordium-cis2 4.0.0 (2023-06-16)
 
 - Bump concordium-std to version 7.
-p
+
 ## concordium-cis2 3.1.0 (2023-05-08)
 
 - Derive `PartialEq` and `Eq` for the `MetadataUrl` from the CIS2 library.


### PR DESCRIPTION
## Purpose

Closes #420.

## Changes

Added a manual implementation of `SchemaType` for `OnReceivingCis2DataParams<T, A, D>` that matches the `Serial` and `Deserial` implementations

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.