### PR TITLE
Add support for loading the contract module under test

### DIFF
--- a/contract-testing/CHANGELOG.md
+++ b/contract-testing/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Integrate protocol version 7 cost semantics.
 - The `ContractInvokeSuccess` and `ContractInvokeError` have additional fields
   that record where parts of the energy was allocated during execution.
+- Add support for loading the contract under test with the `module_load_contract` function. The module path is exposed by `cargo-concordium` through the `CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH` environment variable.
 
 ## 4.2.0
 

--- a/contract-testing/CHANGELOG.md
+++ b/contract-testing/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Integrate protocol version 7 cost semantics.
 - The `ContractInvokeSuccess` and `ContractInvokeError` have additional fields
   that record where parts of the energy was allocated during execution.
-- Add support for loading the contract under test with the `module_load_contract` function. The module path is exposed by `cargo-concordium` through the `CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH` environment variable.
+- Add support for loading the contract under test with the `module_load_output` function. The module path is exposed by `cargo-concordium` through the `CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH` environment variable.
 
 ## 4.2.0
 

--- a/contract-testing/src/constants.rs
+++ b/contract-testing/src/constants.rs
@@ -75,3 +75,9 @@ pub(crate) const INITIALIZE_CONTRACT_INSTANCE_CREATE_COST: Energy = Energy {
 pub(crate) const UPDATE_CONTRACT_INSTANCE_BASE_COST: Energy = Energy {
     energy: 300,
 };
+
+/// The name of the environment variable that holds the path to the contract
+/// module file. To load the module, use the
+/// [`module_load_contract`](crate::module_load_contract) function.
+pub const CONTRACT_MODULE_OUTPUT_PATH_ENV_VAR: &'static str =
+    "CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH";

--- a/contract-testing/src/constants.rs
+++ b/contract-testing/src/constants.rs
@@ -78,5 +78,5 @@ pub(crate) const UPDATE_CONTRACT_INSTANCE_BASE_COST: Energy = Energy {
 
 /// The name of the environment variable that holds the path to the contract
 /// module file. To load the module, use the
-/// [`module_load_contract`](crate::module_load_contract) function.
+/// [`module_load_output`](crate::module_load_output) function.
 pub const CONTRACT_MODULE_OUTPUT_PATH_ENV_VAR: &str = "CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH";

--- a/contract-testing/src/constants.rs
+++ b/contract-testing/src/constants.rs
@@ -79,5 +79,4 @@ pub(crate) const UPDATE_CONTRACT_INSTANCE_BASE_COST: Energy = Energy {
 /// The name of the environment variable that holds the path to the contract
 /// module file. To load the module, use the
 /// [`module_load_contract`](crate::module_load_contract) function.
-pub const CONTRACT_MODULE_OUTPUT_PATH_ENV_VAR: &'static str =
-    "CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH";
+pub const CONTRACT_MODULE_OUTPUT_PATH_ENV_VAR: &str = "CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH";

--- a/contract-testing/src/impls.rs
+++ b/contract-testing/src/impls.rs
@@ -2060,7 +2060,8 @@ pub fn module_load_v1(module_path: impl AsRef<Path>) -> Result<WasmModule, Modul
     Ok(module)
 }
 
-pub fn module_load_contract() -> Result<WasmModule, ContractModuleLoadError> {
+/// Load the wasm module being tested output by `cargo concordium test`.
+pub fn module_load_output() -> Result<WasmModule, ContractModuleLoadError> {
     let module_path = env::var(CONTRACT_MODULE_OUTPUT_PATH_ENV_VAR)?;
     let module = module_load_v1(module_path)?;
     Ok(module)

--- a/contract-testing/src/impls.rs
+++ b/contract-testing/src/impls.rs
@@ -2061,7 +2061,7 @@ pub fn module_load_v1(module_path: impl AsRef<Path>) -> Result<WasmModule, Modul
 }
 
 /// Load the wasm module being tested output by `cargo concordium test`.
-pub fn module_load_output() -> Result<WasmModule, ContractModuleLoadError> {
+pub fn module_load_output() -> Result<WasmModule, OutputModuleLoadError> {
     let module_path = env::var(CONTRACT_MODULE_OUTPUT_PATH_ENV_VAR)?;
     let module = module_load_v1(module_path)?;
     Ok(module)

--- a/contract-testing/src/impls.rs
+++ b/contract-testing/src/impls.rs
@@ -2060,7 +2060,9 @@ pub fn module_load_v1(module_path: impl AsRef<Path>) -> Result<WasmModule, Modul
     Ok(module)
 }
 
-/// Load the current smart contract module output using the environment variable `CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH` which is set when running using `cargo concordium test`.
+/// Load the current smart contract module output using the environment variable
+/// `CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH` which is set when running using
+/// `cargo concordium test`.
 pub fn module_load_output() -> Result<WasmModule, OutputModuleLoadError> {
     let module_path = env::var(CONTRACT_MODULE_OUTPUT_PATH_ENV_VAR)?;
     let module = module_load_v1(module_path)?;

--- a/contract-testing/src/impls.rs
+++ b/contract-testing/src/impls.rs
@@ -2,6 +2,7 @@ use crate::{
     constants,
     invocation::{ChangeSet, EntrypointInvocationHandler, TestConfigurationError},
     types::*,
+    CONTRACT_MODULE_OUTPUT_PATH_ENV_VAR,
 };
 use anyhow::anyhow;
 use concordium_rust_sdk::{
@@ -37,6 +38,7 @@ use sdk::{
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
+    env,
     future::Future,
     path::Path,
     sync::Arc,
@@ -2055,6 +2057,12 @@ pub fn module_load_v1(module_path: impl AsRef<Path>) -> Result<WasmModule, Modul
             kind: ModuleLoadErrorKind::UnsupportedModuleVersion(module.version),
         });
     }
+    Ok(module)
+}
+
+pub fn module_load_contract() -> Result<WasmModule, ContractModuleLoadError> {
+    let module_path = env::var(CONTRACT_MODULE_OUTPUT_PATH_ENV_VAR)?;
+    let module = module_load_v1(module_path)?;
     Ok(module)
 }
 

--- a/contract-testing/src/impls.rs
+++ b/contract-testing/src/impls.rs
@@ -2060,7 +2060,7 @@ pub fn module_load_v1(module_path: impl AsRef<Path>) -> Result<WasmModule, Modul
     Ok(module)
 }
 
-/// Load the wasm module being tested output by `cargo concordium test`.
+/// Load the current smart contract module output using the environment variable `CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH` which is set when running using `cargo concordium test`.
 pub fn module_load_output() -> Result<WasmModule, OutputModuleLoadError> {
     let module_path = env::var(CONTRACT_MODULE_OUTPUT_PATH_ENV_VAR)?;
     let module = module_load_v1(module_path)?;

--- a/contract-testing/src/lib.rs
+++ b/contract-testing/src/lib.rs
@@ -89,7 +89,7 @@ mod impls;
 mod invocation;
 mod types;
 pub use constants::CONTRACT_MODULE_OUTPUT_PATH_ENV_VAR;
-pub use impls::{is_debug_enabled, module_load_contract, module_load_v1, module_load_v1_raw};
+pub use impls::{is_debug_enabled, module_load_output, module_load_v1, module_load_v1_raw};
 pub use types::*;
 
 // Re-export types.

--- a/contract-testing/src/lib.rs
+++ b/contract-testing/src/lib.rs
@@ -83,13 +83,13 @@
 //!     - deployment.transaction_fee
 //!     - initialization.transaction_fee
 //!     - update.transaction_fee));
-//!     
 //! ```
 mod constants;
 mod impls;
 mod invocation;
 mod types;
-pub use impls::{is_debug_enabled, module_load_v1, module_load_v1_raw};
+pub use constants::CONTRACT_MODULE_OUTPUT_PATH_ENV_VAR;
+pub use impls::{is_debug_enabled, module_load_contract, module_load_v1, module_load_v1_raw};
 pub use types::*;
 
 // Re-export types.

--- a/contract-testing/src/types.rs
+++ b/contract-testing/src/types.rs
@@ -27,6 +27,7 @@ use concordium_rust_sdk::{
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
+    env,
     path::PathBuf,
     sync::Arc,
 };
@@ -323,6 +324,17 @@ pub enum ModuleLoadErrorKind {
     /// The module version is not supported.
     #[error("The module has wasm version {0}, which is not supported")]
     UnsupportedModuleVersion(WasmVersion),
+}
+
+#[derive(Debug, Error)]
+pub enum ContractModuleLoadError {
+    #[error(
+        "Module path environment variable was not set or invalid. Please ensure that \
+         cargo-concordium is up-to-date. Details: {0}"
+    )]
+    MissingEnvVar(#[from] env::VarError),
+    #[error("{0}")]
+    ModuleLoad(#[from] ModuleLoadError),
 }
 
 /// The error produced when trying to read a smart contract

--- a/contract-testing/src/types.rs
+++ b/contract-testing/src/types.rs
@@ -327,7 +327,7 @@ pub enum ModuleLoadErrorKind {
 }
 
 #[derive(Debug, Error)]
-pub enum ContractModuleLoadError {
+pub enum OutputModuleLoadError {
     #[error(
         "Module path environment variable was not set or invalid. Please ensure that \
          cargo-concordium is up-to-date. Details: {0}"


### PR DESCRIPTION
## Purpose

Closes #383. Depends on https://github.com/Concordium/concordium-smart-contract-tools/pull/167.

## Changes

Reads the environment variable set by `cargo-concordium` though the convenience function `module_load_output`. This also means that the user needs to update `cargo-concordium`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.