### PR TITLE
Allow cargo-generate 0.21.

### DIFF
--- a/templates/cis2-nft/cargo-generate.toml
+++ b/templates/cis2-nft/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">= 0.17.0, < 0.21.0"
+cargo_generate_version = ">= 0.17.0, < 0.22.0"
 
 [placeholders]
 description = { type="string", prompt="Description for the project?" }

--- a/templates/credential-registry/cargo-generate.toml
+++ b/templates/credential-registry/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">= 0.17.0, < 0.21.0"
+cargo_generate_version = ">= 0.17.0, < 0.22.0"
 
 [hooks]
 pre = ["pre-script.rhai"] # a script for setting default values for the variables when `template_type = default`

--- a/templates/default/cargo-generate.toml
+++ b/templates/default/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">= 0.17.0, < 0.21.0"
+cargo_generate_version = ">= 0.17.0, < 0.22.0"
 
 [placeholders]
 description = { type="string", prompt="Description for the project?" }


### PR DESCRIPTION
## Purpose

Fixes #429 

## Changes

Allow cargo generate 0.21. The changes from 0.20.* are not important https://github.com/cargo-generate/cargo-generate/releases/tag/v0.21.0

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
