### PR TITLE
Change to use type with no length prepended in the CCD receive hook mechanism

### DIFF
--- a/examples/cis5-smart-contract-wallet/src/lib.rs
+++ b/examples/cis5-smart-contract-wallet/src/lib.rs
@@ -539,7 +539,6 @@ pub struct TokenAmount {
 /// to represent any input parameter (no matter the length serialization of that
 /// input parameter) of the receiving contract.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(SerdeSerialize, SerdeDeserialize))]
 pub struct NoLengthPrependedBytes<'a>(&'a [u8]);
 
 /// The `NoLengthPrependedBytes` is serialized as plain bytes without the length

--- a/examples/cis5-smart-contract-wallet/src/lib.rs
+++ b/examples/cis5-smart-contract-wallet/src/lib.rs
@@ -534,22 +534,6 @@ pub struct TokenAmount {
     pub cis2_token_contract_address: ContractAddress,
 }
 
-/// Additional information to include with the CCD hook transfer. This is a type
-/// without the length of the bytes prepended when serializing. It can be used
-/// to represent any input parameter (no matter the length serialization of that
-/// input parameter) of the receiving contract.
-#[derive(Debug, Clone)]
-pub struct NoLengthPrependedBytes<'a>(&'a [u8]);
-
-/// The `NoLengthPrependedBytes` is serialized as plain bytes without the length
-/// being prepended.
-impl Serial for NoLengthPrependedBytes<'_> {
-    fn serial<W: Write>(&self, out: &mut W) -> Result<(), W::Err> {
-        out.write_all(self.0)?;
-        Ok(())
-    }
-}
-
 /// A single withdrawal of CCD or some amount of tokens.
 #[derive(Serialize, Clone, SchemaType)]
 #[cfg_attr(feature = "serde", derive(SerdeSerialize, SerdeDeserialize))]
@@ -808,12 +792,10 @@ fn withdraw_ccd(
                     Address::Account(account_address)
                 }
                 Receiver::Contract(contract_address, function) => {
-                    let receiving_contract_input_parameter = NoLengthPrependedBytes(data.as_ref());
-
                     // If the receiver is a contract: invoke the receive hook function.
-                    host.invoke_contract(
+                    host.invoke_contract_raw(
                         &contract_address,
-                        &receiving_contract_input_parameter,
+                        Parameter::new_unchecked(data.as_ref()),
                         function.as_entrypoint_name(),
                         withdraw_amount,
                     )?;


### PR DESCRIPTION
## Purpose

When a smart contract receives CCD via the receive hook mechanism from the smart contract wallet, we want to be able to represent any smart contract input parameter of the receiving smart contract. As such, it is problematic to use `AdditionalData`/ `Vec<u8>` types for the transfer since they all prepend the bytes with their length. The receiving smart contract input parameter might have no (or a different amount of) bytes prepended representing the length of the input parameter as such we send raw bytes now to be able to represent the input parameter of any receiving smart contract. 

## Changes

Send raw bytes in the CCD receive hook mechanism.