### PR TITLE
Update Rust SDK submodule

### DIFF
--- a/concordium-cis2/CHANGELOG.md
+++ b/concordium-cis2/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `FromStr` implementations for `TokenId` types.
 - Add a `serde` feature that derives `serde::Serialize` and `serde::Deserialize` for `TokenId` types, `TokenAmount` types, `OnReceivingCis2DataParams<T, A, D>`, `OnReceivingCis2Params<T, A>`, `AdditionalData`, and `Receiver`.
 - Fix `SchemaType` implementation of `OnReceivingCis2DataParams<T, A, D>` so that it matches `Serial` and `Deserial` implementations.
+- Updated the Concordium Rust SDK to support the changes introduced in protocol 7.
 
 ## concordium-cis2 6.1.0 (2024-02-22)
 

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased changes
+- Updated the Concordium Rust SDK to support the changes introduced in protocol 7.
 
 ## concordium-std 10.1.0 (2024-04-04)
 

--- a/contract-testing/CHANGELOG.md
+++ b/contract-testing/CHANGELOG.md
@@ -6,6 +6,7 @@
 - The `ContractInvokeSuccess` and `ContractInvokeError` have additional fields
   that record where parts of the energy was allocated during execution.
 - Add support for loading the contract under test with the `module_load_output` function. The module path is exposed by `cargo-concordium` through the `CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH` environment variable.
+- Updated the Concordium Rust SDK to support the changes introduced in protocol 7.
 
 ## 4.2.0
 
@@ -78,7 +79,7 @@
       - These are the elements that were previously returned in the `trace_elements` field.
       - There is also a version of the method which clones: `effective_trace_elements_cloned()`.
     - To migrate existing code, replace `some_update.trace_elements` with `some_update.effective_trace_elements_cloned()`.
-    - Add a helper method, `rollbacks_occurred()`, to determine whether any internal failures or rollbacks occurred. 
+    - Add a helper method, `rollbacks_occurred()`, to determine whether any internal failures or rollbacks occurred.
   - On the `ContractInvokeError` type:
     - Include the field `trace_elements` of type `Vec<DebugTraceElements>` with the trace elements that were hitherto discarded. (breaking change)
     - To migrate, include the new field or use `..` when pattern matching on the type.


### PR DESCRIPTION
## Purpose

Simply updates the Rust SDK submodule to point to the latest version with the changes for protocol version 7.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
