### PR TITLE
Add default reject error to documentation

### DIFF
--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -220,8 +220,9 @@
 //!
 //! | Variant | Error code |
 //! |---------|------------|
-//! | [()][1] | `-2147483647` |
-//! | [ParseError] | `-2147483646` |
+//! | [Unspecified (Default reject)] | `-2147483648` | // i32::MIN
+//! | [()][1] | `-2147483647` | // i32::MIN + 1
+//! | [ParseError] | `-2147483646` | // ...
 //! | [LogError::Full] | `-2147483645` |
 //! | [LogError::Malformed] | `-2147483644`
 //! | [NewContractNameError::MissingInitPrefix] | `-2147483643` |


### PR DESCRIPTION
## Purpose

`defaultReject` is an error code that is hardcoded in the `concordium-std` library but it was not documented.

https://github.com/Concordium/concordium-rust-smart-contracts/blob/main/concordium-std/src/types.rs#L787

## Changes

Add default reject error to documentation
