### PR TITLE
Simplify voting example and default template

### DIFF
--- a/examples/voting/src/lib.rs
+++ b/examples/voting/src/lib.rs
@@ -2,98 +2,46 @@
 //!
 //! # Description
 //! A contract that allows for conducting an election with several voting
-//! options. An `end_time` is set when the election is initialized. Only
+//! options. A deadline is set when the election is initialized. Only
 //! accounts are eligible to vote. Each account can change its
-//! selected voting option as often as it desires until the `end_time` is
-//! reached. No voting will be possible after the `end_time`.
+//! selected voting option as often as it desires until the deadline is
+//! reached. No voting will be possible after the deadline.
 //!
 //! # Operations
 //! The contract allows for
-//!  - `initializing` the election;
-//!  - `vote` for one of the voting options;
-//!  - `getNumberOfVotes` for a requested voting option;
-//!  - `view` general information about the election.
+//!  - Initializing the election.
+//!  - Viewing general information about the election.
+//!  - Voting for one of the voting options.
+//!  - Tallying votes for a requested voting option.
 //!
-//! Note: Vec<VotingOption> (among other variables) is an input parameter to the
-//! `init` function. Since there is a limit to the parameter size (65535 Bytes),
-//! the size of the Vec<VotingOption> is limited.
-//! https://developer.concordium.software/en/mainnet/smart-contracts/general/contract-instances.html#limits
+//! Note: There is a limit to the size of function parameters (65535 Bytes),
+//! thus the number of voting options is large, but limited.
+//! Read more here: <https://developer.concordium.software/en/mainnet/smart-contracts/general/contract-instances.html#limits>
+
 #![cfg_attr(not(feature = "std"), no_std)]
+
 use concordium_std::*;
 
-/// The human-readable description of a voting option.
-pub type VotingOption = String;
-/// The voting options are stored in a vector. The vector index is used to refer
-/// to a specific voting option.
-pub type VoteIndex = u32;
-/// Number of votes.
-pub type VoteCount = u32;
-
-/// The parameter type for the contract function `vote`.
-/// Takes a `vote_index` that the account wants to vote for.
+/// Configuration for a single election.
 #[derive(Serialize, SchemaType, Debug, PartialEq, Eq)]
-pub struct VoteParameter {
-    /// Voting option index to vote for.
-    pub vote_index: VoteIndex,
-}
-
-/// The parameter type for the contract function `init`.
-/// Takes a description, the voting options, and the `end_time` to start the
-/// election.
-#[derive(Serialize, SchemaType, Debug, PartialEq, Eq)]
-pub struct InitParameter {
+pub struct ElectionConfig {
     /// The description of the election.
     pub description: String,
-    /// A vector of all voting options.
-    pub options:     Vec<VotingOption>,
-    /// The last timestamp that an account can vote.
-    /// The election is open from the point in time that this smart contract is
-    /// initialized until the `end_time`.
-    pub end_time:    Timestamp,
+    /// All the voting options.
+    pub options:     Vec<String>,
+    /// The last timestamp at which an account can vote.
+    /// An election is open from the point in time that the smart contract is
+    /// initialized until the deadline.
+    pub deadline:    Timestamp,
 }
 
-/// The `return_value` type of the contract function `view`.
-/// Returns a description, the `end_time`, the voting options as a vector, and
-/// the number of voting options of the current election.
-#[derive(Serialize, SchemaType, Debug, PartialEq, Eq)]
-pub struct VotingView {
-    /// The description of the election.
-    pub description: String,
-    /// The last timestamp that an account can vote.
-    /// The election is open from the point in time that this smart contract is
-    /// initialized until the `end_time`.
-    pub end_time:    Timestamp,
-    /// A vector of all voting options.
-    pub options:     Vec<VotingOption>,
-    /// The number of voting options.
-    pub num_options: u32,
-}
-
-/// The contract state
-#[derive(Serial, DeserialWithState)]
-#[concordium(state_parameter = "S")]
-struct State<S: HasStateApi = StateApi> {
-    /// The description of the election.
-    /// `StateBox` allows for lazy loading data. This is helpful
-    /// in the situations when one wants to do a partial update not touching
-    /// this field, which can be large.
-    description: StateBox<String, S>,
-    /// The map connects a voter to the index of the voted-for voting option.
-    ballots:     StateMap<AccountAddress, VoteIndex, S>,
-    /// The map connects the index of a voting option to the number of votes
-    /// it received so far.
-    tally:       StateMap<VoteIndex, VoteCount, S>,
-    /// The last timestamp that an account can vote.
-    /// The election is open from the point in time that this smart contract is
-    /// initialized until the `end_time`.
-    end_time:    Timestamp,
-    /// A vector of all voting options.
-    /// `StateBox` allows for lazy loading data. This is helpful
-    /// in the situations when one wants to do a partial update not touching
-    /// this field, which can be large.
-    options:     StateBox<Vec<VotingOption>, S>,
-    /// The number of voting options.
-    num_options: u32,
+/// The voting smart contract state.
+#[derive(Serialize, SchemaType)]
+struct State {
+    /// The configuration of the election.
+    config:  ElectionConfig,
+    /// A map from voters to options, specifying who has voted for what.
+    ballots: HashMap<AccountAddress, String>,
 }
 
 /// The different errors that the `vote` function can produce.
@@ -108,8 +56,8 @@ pub enum VotingError {
     LogMalformed,
     /// Raised when the vote is placed after the election has ended.
     VotingFinished,
-    /// Raised when voting for a voting index that does not exist.
-    InvalidVoteIndex,
+    /// Raised when voting for an option that does not exist.
+    InvalidVote,
     /// Raised when a smart contract tries to participate in the election. Only
     /// accounts are allowed to vote.
     ContractVoter,
@@ -125,53 +73,36 @@ impl From<LogError> for VotingError {
     }
 }
 
-/// A custom alias type for the `Result` type with the error type fixed to
-/// `VotingError`.
-pub type VotingResult<T> = Result<T, VotingError>;
-
-/// The event is logged when a new (or replacement) vote is cast by an account.
+/// A vote event. The event is logged when a new (or replacement) vote is cast
+/// by an account.
 #[derive(Debug, Serialize, SchemaType, PartialEq, Eq)]
-pub struct VoteEvent {
+pub struct Vote {
     /// The account that casts the vote.
-    pub voter:      AccountAddress,
-    /// The index of the voting option that the account is voting for.
-    pub vote_index: VoteIndex,
-}
-
-/// The event logged by this smart contract.
-#[derive(Debug, Serialize, SchemaType, PartialEq, Eq)]
-pub enum Event {
-    /// The event is logged when a new (or replacement) vote is cast by an
-    /// account.
-    Vote(VoteEvent),
+    pub voter:  AccountAddress,
+    /// The voting option that the account is voting for.
+    pub option: String,
 }
 
 // Contract functions
 
 /// Initialize the contract instance and start the election.
-/// A description, the vector of all voting options, and an `end_time`
+/// A description, the vector of all voting options, and an `deadline`
 /// have to be provided.
-#[init(contract = "voting", parameter = "InitParameter", event = "Event")]
-fn init(ctx: &InitContext, state_builder: &mut StateBuilder) -> InitResult<State> {
+#[init(contract = "voting", parameter = "ElectionConfig", event = "Vote")]
+fn init(ctx: &InitContext, _state_builder: &mut StateBuilder) -> InitResult<State> {
     // Parse the parameter.
-    let param: InitParameter = ctx.parameter_cursor().get()?;
-    // Calculate the number of voting options.
-    let num_options = param.options.len() as u32;
+    let config: ElectionConfig = ctx.parameter_cursor().get()?;
 
     // Set the state.
     Ok(State {
-        description: state_builder.new_box(param.description),
-        ballots: state_builder.new_map(),
-        tally: state_builder.new_map(),
-        end_time: param.end_time,
-        options: state_builder.new_box(param.options),
-        num_options,
+        config,
+        ballots: HashMap::default(),
     })
 }
 
 /// Enables accounts to vote for a specific voting option. Each account can
 /// change its selected voting option with this function as often as it desires
-/// until the `end_time` is reached.
+/// until the `deadline` is reached.
 ///
 /// A valid vote produces an `Event::Vote` event.
 /// This is also the case if the account recasts its vote for another, or even
@@ -181,22 +112,25 @@ fn init(ctx: &InitContext, state_builder: &mut StateBuilder) -> InitResult<State
 /// It rejects if:
 /// - It fails to parse the parameter.
 /// - A contract tries to vote.
-/// - It is past the `end_time`.
+/// - It is past the `deadline`.
 #[receive(
     contract = "voting",
     name = "vote",
     mutable,
     enable_logger,
-    parameter = "VoteParameter",
+    parameter = "String",
     error = "VotingError"
 )]
 fn vote(
     ctx: &ReceiveContext,
     host: &mut Host<State>,
     logger: &mut impl HasLogger,
-) -> VotingResult<()> {
+) -> Result<(), VotingError> {
     // Check that the election hasn't finished yet.
-    ensure!(ctx.metadata().slot_time() <= host.state().end_time, VotingError::VotingFinished);
+    ensure!(
+        ctx.metadata().slot_time() <= host.state().config.deadline,
+        VotingError::VotingFinished
+    );
 
     // Ensure that the sender is an account.
     let acc = match ctx.sender() {
@@ -204,35 +138,24 @@ fn vote(
         Address::Contract(_) => return Err(VotingError::ContractVoter),
     };
 
-    // Parse the parameter.
-    let param: VoteParameter = ctx.parameter_cursor().get()?;
+    // Parse the option.
+    let vote_option: String = ctx.parameter_cursor().get()?;
 
-    let new_vote_index = param.vote_index;
-
-    // Check that vote is in range
-    ensure!(new_vote_index < host.state().num_options, VotingError::InvalidVoteIndex);
-
-    if let Some(old_vote_index) = host.state().ballots.get(&acc) {
-        let old_vote_index = *old_vote_index;
-        // Update the tally for the `old_vote_index` by reducing one vote.
-        *host.state_mut().tally.entry(old_vote_index).or_insert(1) -= 1;
-    };
+    // Check that the vote option is valid (exists).
+    ensure!(host.state().config.options.contains(&vote_option), VotingError::InvalidVote);
 
     // Insert or replace the vote for the account.
     host.state_mut()
         .ballots
         .entry(acc)
-        .and_modify(|old_vote_index| *old_vote_index = new_vote_index)
-        .or_insert(new_vote_index);
-
-    // Update the tally for the `new_vote_index` with one additional vote.
-    *host.state_mut().tally.entry(new_vote_index).or_insert(0) += 1;
+        .and_modify(|old_vote_option| old_vote_option.clone_from(&vote_option))
+        .or_insert(vote_option.clone());
 
     // Log event for the vote.
-    logger.log(&Event::Vote(VoteEvent {
-        voter:      acc,
-        vote_index: new_vote_index,
-    }))?;
+    logger.log(&Vote {
+        voter:  acc,
+        option: vote_option,
+    })?;
 
     Ok(())
 }
@@ -244,36 +167,32 @@ fn vote(
 #[receive(
     contract = "voting",
     name = "getNumberOfVotes",
-    parameter = "VoteParameter",
-    return_value = "VoteCount"
+    parameter = "String",
+    return_value = "u32"
 )]
-fn get_votes(ctx: &ReceiveContext, host: &Host<State>) -> ReceiveResult<VoteCount> {
-    // Parse the parameter.
-    let param: VoteIndex = ctx.parameter_cursor().get()?;
+fn get_votes(ctx: &ReceiveContext, host: &Host<State>) -> ReceiveResult<u32> {
+    // Parse the vote option.
+    let vote_option: String = ctx.parameter_cursor().get()?;
 
-    // Get the number of votes from the tally.
-    let result = match host.state().tally.get(&param) {
-        Some(votes) => *votes,
-        None => 0,
-    };
+    // Count the number of votes for this option.
+    let count =
+        host.state().ballots.iter().filter(|&(_voter, option)| *option == vote_option).count();
 
-    Ok(result)
+    Ok(count as u32)
 }
 
 /// Get the election information.
-#[receive(contract = "voting", name = "view", return_value = "VotingView")]
-fn view(_ctx: &ReceiveContext, host: &Host<State>) -> ReceiveResult<VotingView> {
+#[receive(contract = "voting", name = "view", return_value = "ElectionConfig")]
+fn view(_ctx: &ReceiveContext, host: &Host<State>) -> ReceiveResult<ElectionConfig> {
     // Get information from the state.
-    let description = host.state().description.clone();
-    let end_time = host.state().end_time;
-    let num_options = host.state().num_options;
-    let options = host.state().options.clone();
+    let description = host.state().config.description.clone();
+    let options = host.state().config.options.clone();
+    let deadline = host.state().config.deadline;
 
     // Return the election information.
-    Ok(VotingView {
+    Ok(ElectionConfig {
         description,
-        end_time,
+        deadline,
         options,
-        num_options,
     })
 }

--- a/examples/voting/tests/tests.rs
+++ b/examples/voting/tests/tests.rs
@@ -241,11 +241,11 @@ fn check_event(
     voter: AccountAddress,
     vote_option: impl Into<String>,
 ) {
-    let events: Vec<Vote> = update
+    let events: Vec<VoteEvent> = update
         .events()
         .flat_map(|(_addr, events)| events.iter().map(|e| e.parse().expect("Deserialize event")))
         .collect();
-    assert_eq!(events, [Vote {
+    assert_eq!(events, [VoteEvent {
         voter,
         option: vote_option.into(),
     }]);

--- a/templates/README.md
+++ b/templates/README.md
@@ -51,20 +51,20 @@ cargo concordium test
 
 ## The `default` Template
 
-This template generates some smart contract boilerplate code. The boilerplate code has an empty ``State`` struct and three functions (`init`, `receive`, and `view`).
-- The `init` function is used to deploy and initialize your module on-chain.
-- The `view` function returns the state of the smart contract which is currently empty (fill the state struct with some custom state variables).
-- The `receive` function can be invoked with the boolean parameter ``throw_error``. If the function is invoked with `throw_error == true`, the receive function will throw a custom error. If the function is invoked with `throw_error == false`, the receive function executes successfully. Add some custom logic to the ``receive`` function.
+This template generates some smart contract boilerplate code. The boilerplate code has an example ``State`` struct and three functions (`init`, `receive`, and `view`).
+- The `init` function is used to deploy and initialize your module on-chain. It has an example custom input parameter.
+- The `view` function returns the state of the smart contract.
+- The `receive` function can be invoked with the boolean parameter ``return_error``. If the function is invoked with `return_error == true`, the receive function will return a custom error. If the function is invoked with `return_error == false`, the receive function executes successfully. You can customize the logic of the ``receive`` function as you see fit.
 
 ### Simulating the deployment of the module
 
 <img src="./resources/simulation_init.gif" width="1000" height="350"/>
 
 ```
-cargo concordium run init --module ./my_concordium_project.wasm.v1 --contract my_concordium_project --context contextInit.json --out-bin state.bin
+cargo concordium run init --module ./my_concordium_project.wasm.v1 --contract my_concordium_project --context contextInit.json --out-bin state.bin --parameter-json input.json
 ```
 
-This command simulates the deployment of your smart contract module. You require a ``contextInit.json`` file similar to the following one:
+This command simulates the deployment of your smart contract module. You need a ``contextInit.json`` file and a ``input.json`` file. The ``contextInit.json`` file should look like this:
 
 ```
 {
@@ -77,6 +77,14 @@ This command simulates the deployment of your smart contract module. You require
         "createdAt": "202012",
         "validTo": "202109"
     }]
+}
+```
+
+The ``input.json`` file should look like this:
+
+```
+{
+    "num": 42
 }
 ```
 
@@ -111,25 +119,29 @@ This command simulates an invoke to the ``view`` function of your smart contract
 }
 ```
 
-### Simulating the receive function with the input parameter `throw_error == false`
+### Simulating the receive function with the input parameter `return_error == false`
 
 <img src="./resources/simulation_receive_throw_error_false.gif" width="1000" height="350"/>
 
 ```
-cargo concordium run update --entrypoint receive --module ./my_concordium_project.wasm.v1 --parameter-json throwErrorFalse.json --state-bin state.bin --contract my_concordium_project --context contextUpdate.json
+cargo concordium run update --entrypoint receive --module ./my_concordium_project.wasm.v1 --parameter-json returnErrorFalse.json --state-bin state.bin --contract my_concordium_project --context contextUpdate.json
 ```
 
-This command simulates an invoke to the ``receive`` function of your smart contract module with the input parameter `throw_error == false`.
+Where the contents of ``returnErrorFalse.json`` is simply `false`.
 
-### Simulating the receive function with the input parameter `throw_error == true`
+This command simulates an invoke to the ``receive`` function of your smart contract module with the input parameter `return_error == false`.
+
+### Simulating the receive function with the input parameter `return_error == true`
 
 <img src="./resources/simulation_receive_throw_error_true.gif" width="1000" height="350"/>
 
 ```
-cargo concordium run update --entrypoint receive --module ./my_concordium_project.wasm.v1 --parameter-json throwErrorTrue.json --state-bin state.bin --contract my_concordium_project --context contextUpdate.json
+cargo concordium run update --entrypoint receive --module ./my_concordium_project.wasm.v1 --parameter-json returnErrorTrue.json --state-bin state.bin --contract my_concordium_project --context contextUpdate.json
 ```
 
-This command simulates an invoke to the ``receive`` function of your smart contract module with the input parameter `throw_error == true`.
+Where the contents of ``returnErrorTrue.json`` is simply ``true``.
+
+This command simulates an invoke to the ``receive`` function of your smart contract module with the input parameter `return_error == true`.
 
 ## The `cis2-nft` Template
 

--- a/templates/default/Cargo.toml
+++ b/templates/default/Cargo.toml
@@ -1,12 +1,11 @@
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [package]
-name = "{{crate_name}}"
+name = "{{ crate_name }}"
 version = "0.1.0"
 edition = "2021"
 license = "MPL-2.0"
-authors = [ "{{authors}}" ]
-description = "{{description}}"
+authors = ["{{ authors }}"]
 
 [features]
 default = ["std"]
@@ -14,13 +13,13 @@ std = ["concordium-std/std"]
 bump_alloc = ["concordium-std/bump_alloc"]
 
 [dependencies]
-concordium-std = {version = "10.0", default-features = false}
+concordium-std = { version = "10.0", default-features = false }
 
 [dev-dependencies]
 concordium-smart-contract-testing = "4.2"
 
 [lib]
-crate-type=["cdylib", "rlib"]
+crate-type = ["cdylib", "rlib"]
 
 [profile.release]
 opt-level = "s"

--- a/templates/default/cargo-generate.toml
+++ b/templates/default/cargo-generate.toml
@@ -1,5 +1,2 @@
 [template]
 cargo_generate_version = ">= 0.17.0, < 0.22.0"
-
-[placeholders]
-description = { type="string", prompt="Description for the project?" }

--- a/templates/default/deploy-scripts/Cargo.toml
+++ b/templates/default/deploy-scripts/Cargo.toml
@@ -12,4 +12,4 @@ clap = { version = "4", features = ["derive", "env"]}
 concordium-rust-sdk="4.2"
 tokio = {version = "1.18", features = ["rt", "macros", "rt-multi-thread"] }
 tonic = {version = "0.10", features = ["tls", "tls-roots"]} # Use system trust roots.
-{{crate_name}} = {path = "../"}
+{{ crate_name }} = { path = "../" }

--- a/templates/default/deploy-scripts/src/main.rs
+++ b/templates/default/deploy-scripts/src/main.rs
@@ -102,7 +102,10 @@ async fn main() -> Result<(), Error> {
     // Write your own deployment/initialization script below. An example is given
     // here.
 
-    let param: OwnedParameter = OwnedParameter::empty(); // Example
+    // You can easily import a type from the smart contract like so:
+    use default::CustomInputParameter; // Example
+
+    let param = OwnedParameter::from_serial(&CustomInputParameter { num: 42 })?; // Example
 
     let init_method_name: &str = "init_{{crate_name}}"; // Example
 
@@ -118,14 +121,9 @@ async fn main() -> Result<(), Error> {
         .await
         .context("Failed to initialize the contract.")?; // Example
 
-    // This is how you can use a type from your smart contract.
-    use {{crate_name}}::MyInputType; // Example
-
-    let input_parameter: MyInputType = false; // Example
-
     // Create a successful transaction.
-
-    let bytes = contracts_common::to_bytes(&input_parameter); // Example
+    // The input parameter to the receive function is in this example a bool.
+    let bytes = contracts_common::to_bytes(&false); // Example
 
     let update_payload = transactions::UpdateContractPayload {
         amount: Amount::from_ccd(0),

--- a/templates/default/src/lib.rs
+++ b/templates/default/src/lib.rs
@@ -16,7 +16,7 @@ pub struct State {
 /// Errors that may be emitted by this smart contract.
 #[derive(Debug, PartialEq, Eq, Reject, Serialize, SchemaType)]
 pub enum Error {
-    /// Failed parsing the parameter.
+    /// Failed parsing the input parameter.
     #[from(ParseError)]
     ParseParams,
     /// Add variants to this enum to be able to return custom errors from the smart contract.
@@ -43,7 +43,7 @@ fn init(ctx: &InitContext, _state_builder: &mut StateBuilder) -> InitResult<Stat
     })
 }
 
-/// Receive function. The input parameter in this example is a boolean variable `return_error`.
+/// Receive function. The input parameter in this function is the boolean variable `return_error`.
 ///  If `return_error == true`, the receive function will return a custom error.
 ///  If `return_error == false`, the receive function executes successfully.
 #[receive(

--- a/templates/default/src/lib.rs
+++ b/templates/default/src/lib.rs
@@ -1,58 +1,59 @@
+//! # Concordium V1 Smart Contract Template
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
-//! # A Concordium V1 smart contract
 use concordium_std::*;
 use core::fmt::Debug;
 
-/// Your smart contract state.
+/// The state of the smart contract.
 #[derive(Serialize, SchemaType)]
 pub struct State {
-    // Your state
+    // Add fields to this type to hold state in the smart contract.
 }
 
-/// Your smart contract errors.
+/// Errors that may be emitted by this smart contract.
 #[derive(Debug, PartialEq, Eq, Reject, Serialize, SchemaType)]
 pub enum Error {
     /// Failed parsing the parameter.
     #[from(ParseError)]
     ParseParams,
-    /// Your error
-    YourError,
+    /// Add variants to this enum to be able to return custom errors from the smart contract.
+    CustomError,
 }
 
-/// Init function that creates a new smart contract.
-#[init(contract = "{{crate_name}}")]
+/// Creates a new instance of the smart contract.
+#[init(contract = "{{ crate_name }}")]
 fn init(_ctx: &InitContext, _state_builder: &mut StateBuilder) -> InitResult<State> {
-    // Your code
-
+    // Create the initial state of the smart contract here.
     Ok(State {})
 }
 
-pub type MyInputType = bool;
-
-/// Receive function. The input parameter is the boolean variable `throw_error`.
-///  If `throw_error == true`, the receive function will throw a custom error.
-///  If `throw_error == false`, the receive function executes successfully.
+/// Receive function. The input parameter in this example is a boolean variable `return_error`.
+///  If `return_error == true`, the receive function will return a custom error.
+///  If `return_error == false`, the receive function executes successfully.
 #[receive(
-    contract = "{{crate_name}}",
+    contract = "{{ crate_name }}",
     name = "receive",
-    parameter = "MyInputType",
+    // You can use any other type than bool here, bool is used here only as an example.
+    parameter = "bool",
     error = "Error",
     mutable
 )]
 fn receive(ctx: &ReceiveContext, _host: &mut Host<State>) -> Result<(), Error> {
-    // Your code
+    // Parse input and apply any other logic relevant for this function of the smart contract.
+    // You can mutate the smart contract state here via host.state_mut(), since the receive attribute has the mutable flag.
+    // You can return any of your custom error variants from above.
 
-    let throw_error = ctx.parameter_cursor().get()?; // Returns Error::ParseError on failure
-    if throw_error {
-        Err(Error::YourError)
+    let return_error = ctx.parameter_cursor().get()?; // Returns Error::ParseError on failure.
+    if return_error {
+        Err(Error::CustomError)
     } else {
         Ok(())
     }
 }
 
-/// View function that returns the content of the state.
-#[receive(contract = "{{crate_name}}", name = "view", return_value = "State")]
-fn view<'b>(_ctx: &ReceiveContext, host: &'b Host<State>) -> ReceiveResult<&'b State> {
+/// Returns the state of the smart contract.
+#[receive(contract = "{{ crate_name }}", name = "view", return_value = "State")]
+fn view<'a>(_ctx: &ReceiveContext, host: &'a Host<State>) -> ReceiveResult<&'a State> {
     Ok(host.state())
 }

--- a/templates/default/src/lib.rs
+++ b/templates/default/src/lib.rs
@@ -9,6 +9,8 @@ use core::fmt::Debug;
 #[derive(Serialize, SchemaType)]
 pub struct State {
     // Add fields to this type to hold state in the smart contract.
+    // This field is just an example.
+    custom_state_field: i8,
 }
 
 /// Errors that may be emitted by this smart contract.
@@ -21,11 +23,24 @@ pub enum Error {
     CustomError,
 }
 
+/// Any type implementing Serialize and SchemaType can be
+/// used as an input parameter to a smart contract function.
+#[derive(Serialize, SchemaType)]
+pub struct CustomInputParameter {
+    /// Just an example, you could have any fields here.
+    pub num: i8,
+}
+
 /// Creates a new instance of the smart contract.
-#[init(contract = "{{ crate_name }}")]
-fn init(_ctx: &InitContext, _state_builder: &mut StateBuilder) -> InitResult<State> {
+#[init(contract = "{{ crate_name }}", parameter = "CustomInputParameter")]
+fn init(ctx: &InitContext, _state_builder: &mut StateBuilder) -> InitResult<State> {
+    let param: CustomInputParameter = ctx.parameter_cursor().get()?;
+
     // Create the initial state of the smart contract here.
-    Ok(State {})
+    // This state can then be used in the other functions.
+    Ok(State {
+        custom_state_field: param.num,
+    })
 }
 
 /// Receive function. The input parameter in this example is a boolean variable `return_error`.

--- a/templates/default/tests/tests.rs
+++ b/templates/default/tests/tests.rs
@@ -30,7 +30,7 @@ fn test_throw_no_error() {
 }
 
 /// Test that invoking the `receive` endpoint with the `true` parameter
-/// results in the `YourError` being thrown.
+/// results in the `CustomError` being thrown.
 #[test]
 fn test_throw_error() {
     let (mut chain, init) = initialize();
@@ -45,9 +45,9 @@ fn test_throw_error() {
         })
         .expect_err("Update fails with `true` as input.");
 
-    // Check that the contract returned `YourError`.
+    // Check that the contract returned `CustomError`.
     let error: Error = update.parse_return_value().expect("Deserialize `Error`");
-    assert_eq!(error, Error::YourError);
+    assert_eq!(error, Error::CustomError);
 }
 
 /// Helper method for initializing the contract.


### PR DESCRIPTION
## Purpose

To simplify the voting example smart contract to make the online tutorial easier to follow.

## Changes

- Simplifies the voting example smart contract, making it basically 2/3s the size of what it was (although it may not be as efficient, but it is a tutorial and I feel that simplicity in this case is more important than performance optimization).
- Slight rewrite of the default template.
- Simplification of the default template by not requiring a description field (it is not a required field in the ``Cargo.toml``).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
