### PR TITLE
Allow cargo generate version 0.22

### DIFF
--- a/templates/cis2-nft/cargo-generate.toml
+++ b/templates/cis2-nft/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">= 0.17.0, < 0.22.0"
+cargo_generate_version = ">= 0.17.0, < 0.23.0"
 
 [placeholders]
 description = { type="string", prompt="Description for the project?" }

--- a/templates/credential-registry/cargo-generate.toml
+++ b/templates/credential-registry/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">= 0.17.0, < 0.22.0"
+cargo_generate_version = ">= 0.17.0, < 0.23.0"
 
 [hooks]
 pre = ["pre-script.rhai"] # a script for setting default values for the variables when `template_type = default`

--- a/templates/default/cargo-generate.toml
+++ b/templates/default/cargo-generate.toml
@@ -1,2 +1,2 @@
 [template]
-cargo_generate_version = ">= 0.17.0, < 0.22.0"
+cargo_generate_version = ">= 0.17.0, < 0.23.0"

--- a/templates/default/deploy-scripts/src/main.rs
+++ b/templates/default/deploy-scripts/src/main.rs
@@ -103,7 +103,7 @@ async fn main() -> Result<(), Error> {
     // here.
 
     // You can easily import a type from the smart contract like so:
-    use default::CustomInputParameter; // Example
+    use {{crate_name}}::CustomInputParameter; // Example
 
     let param = OwnedParameter::from_serial(&CustomInputParameter { num: 42 })?; // Example
 

--- a/templates/default/tests/tests.rs
+++ b/templates/default/tests/tests.rs
@@ -69,14 +69,21 @@ fn initialize() -> (Chain, ContractInitSuccess) {
     // Deploy the module.
     let deployment = chain.module_deploy_v1(SIGNER, ALICE, module).expect("Deploy valid module");
 
+    let parameter = CustomInputParameter { num: 0 };
+
     // Initialize the contract.
     let init = chain
-        .contract_init(SIGNER, ALICE, Energy::from(10_000), InitContractPayload {
-            amount:    Amount::zero(),
-            mod_ref:   deployment.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_{{crate_name}}".to_string()),
-            param:     OwnedParameter::empty(),
-        })
+        .contract_init(
+            SIGNER,
+            ALICE,
+            Energy::from(10_000),
+            InitContractPayload {
+                amount: Amount::zero(),
+                mod_ref: deployment.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_{{crate_name}}".to_string()),
+                param: OwnedParameter::from_serial(&parameter).expect("Parameter is valid."),
+            },
+        )
         .expect("Initializing contract");
 
     (chain, init)


### PR DESCRIPTION
# Purpose

Fixes https://github.com/Concordium/concordium-rust-smart-contracts/issues/442

# Changes

- Allow cargo-generate 0.22. The changes from 0.21.*/0.22.0 are not important https://github.com/cargo-generate/cargo-generate/releases/tag/v0.22.0.
https://github.com/cargo-generate/cargo-generate/releases.
- Fix some remaining tests/naming that were not updated after the rewrite of the `default` template https://github.com/Concordium/concordium-rust-smart-contracts/pull/441.