### PR TITLE
Release support for protocol 7

### DIFF
--- a/concordium-cis2/CHANGELOG.md
+++ b/concordium-cis2/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased changes
+## concordium-cis2 6.2.0 (2024-09-17)
 
 - Bump MSRV to 1.72
 - Add `FromStr` implementations for `TokenId` types.

--- a/concordium-cis2/CHANGELOG.md
+++ b/concordium-cis2/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## concordium-cis2 6.2.0 (2024-09-17)
+## concordium-cis2 6.2.0 (2024-09-19)
 
 - Bump MSRV to 1.72
 - Add `FromStr` implementations for `TokenId` types.

--- a/concordium-cis2/Cargo.toml
+++ b/concordium-cis2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-cis2"
-version = "6.1.0"
+version = "6.2.0"
 authors = ["Concordium <developers@concordium.com>"]
 rust-version = "1.73"
 edition = "2021"

--- a/concordium-cis2/src/cis2_client.rs
+++ b/concordium-cis2/src/cis2_client.rs
@@ -538,9 +538,7 @@ mod test {
             };
 
             // Return a response with operator true.
-            Ok((false, OperatorOfQueryResponse {
-                0: vec![true],
-            }))
+            Ok((false, OperatorOfQueryResponse(vec![true])))
         }
 
         host.setup_mock_entrypoint(
@@ -551,9 +549,9 @@ mod test {
 
         let client = Cis2Client::new(cis_contract_address);
         let res: Result<bool, Cis2ClientError<()>> =
-            client.operator_of(&mut host, owner, current_contract_address);
+            client.operator_of(&host, owner, current_contract_address);
 
-        assert_eq!(res.unwrap(), true);
+        assert!(res.unwrap());
     }
 
     #[test]

--- a/concordium-cis2/src/cis2_client.rs
+++ b/concordium-cis2/src/cis2_client.rs
@@ -389,6 +389,11 @@ impl Cis2Client {
 
 #[cfg(test)]
 mod test {
+    #![expect(
+        deprecated,
+        reason = "concordium_std::test_infrastructure is deprecated and should on the long term be replaced with concordium-smart-contract-testing, see also https://github.com/Concordium/concordium-rust-smart-contracts/issues/341"
+    )]
+
     use crate::*;
     use concordium_std::test_infrastructure::*;
 

--- a/concordium-cis2/src/cis2_client.rs
+++ b/concordium-cis2/src/cis2_client.rs
@@ -389,10 +389,8 @@ impl Cis2Client {
 
 #[cfg(test)]
 mod test {
-    #![expect(
-        deprecated,
-        reason = "concordium_std::test_infrastructure is deprecated and should on the long term be replaced with concordium-smart-contract-testing, see also https://github.com/Concordium/concordium-rust-smart-contracts/issues/341"
-    )]
+    // concordium_std::test_infrastructure is deprecated and should on the long term be replaced with concordium-smart-contract-testing, see also https://github.com/Concordium/concordium-rust-smart-contracts/issues/341
+    #![allow(deprecated)]
 
     use crate::*;
     use concordium_std::test_infrastructure::*;

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -322,7 +322,7 @@
 //! to do the following two steps:
 //!
 //! 1. Replace the usage of deprecated traits with their concrete alternatives
-//! and remove generics.
+//!    and remove generics.
 //!
 //!    For init methods:
 //!    ```no_run
@@ -372,8 +372,8 @@
 //!    ```
 //!
 //!    If you use logging, crypto-primitives, or similar, you must also
-//! replace those uses of traits with concrete types. E.g. replacing `&mut impl
-//! HasLogger` with `&mut Logger`.
+//!    replace those uses of traits with concrete types. E.g. replacing `&mut impl
+//!    HasLogger` with `&mut Logger`.
 //!
 //! 2. Migrate your tests to use the new testing library.
 //!

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -372,8 +372,8 @@
 //!    ```
 //!
 //!    If you use logging, crypto-primitives, or similar, you must also
-//!    replace those uses of traits with concrete types. E.g. replacing `&mut impl
-//!    HasLogger` with `&mut Logger`.
+//!    replace those uses of traits with concrete types. E.g. replacing `&mut
+//!    impl HasLogger` with `&mut Logger`.
 //!
 //! 2. Migrate your tests to use the new testing library.
 //!

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -157,11 +157,13 @@ extern "C" {
     /// either
     /// - u32::MAX if the iterator has already been deleted
     /// - the amount of data that was copied. This will never be more than the
-    ///   supplied length. Before the first call to the [state_iterator_next]
-    ///   function this returns (sections of) the key that was used to create
-    ///   the iterator. After [state_iterator_next] returns (the encoding of)
-    ///   [None] this method returns (sections of) the key at the first node
-    ///   returned by the iterator.
+    ///   supplied length.
+    ///
+    /// Before the first call to the [state_iterator_next]
+    /// function this returns (sections of) the key that was used to create
+    /// the iterator. After [state_iterator_next] returns (the encoding of)
+    /// [None] this method returns (sections of) the key at the first node
+    /// returned by the iterator.
     pub fn state_iterator_key_read(iterator: u64, start: *mut u8, length: u32, offset: u32) -> u32;
 
     // Operations on the entry.

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -126,8 +126,8 @@ extern "C" {
     /// - all but second bit set to 1 if there is no value in the state with the
     ///   given key
     /// - otherwise the first bit is 0, and the remaining bits are the iterator
-    ///   identifier
-    /// that may be used in subsequent calls to advance it, or to get its key.
+    ///   identifier that may be used in subsequent calls to advance it, or to
+    ///   get its key.
     pub fn state_iterate_prefix(prefix_start: *const u8, prefix_length: u32) -> u64;
 
     /// Return the next entry along the iterator, and advance the iterator.
@@ -135,9 +135,8 @@ extern "C" {
     /// - u64::MAX if the iterator does not exist (it was deleted, or the ID is
     ///   invalid)
     /// - all but the second bit set to 1 if no more entries are left, the
-    ///   iterator
-    /// is exhausted. All further calls will yield the same until the iterator
-    /// is deleted.
+    ///   iterator is exhausted. All further calls will yield the same until
+    ///   the iterator is deleted.
     /// - otherwise the first bit is 0, and the remaining bits encode an entry
     ///   identifier that can be passed to any of the entry methods.
     pub fn state_iterator_next(iterator: u64) -> u64;
@@ -159,11 +158,11 @@ extern "C" {
     /// - u32::MAX if the iterator has already been deleted
     /// - the amount of data that was copied. This will never be more than the
     ///   supplied length.
-    /// Before the first call to the [state_iterator_next] function this returns
-    /// (sections of) the key that was used to create the iterator. After
-    /// [state_iterator_next] returns (the encoding of) [None] this method
-    /// returns (sections of) the key at the first node returned by the
-    /// iterator.
+    ///   Before the first call to the [state_iterator_next] function this returns
+    ///   (sections of) the key that was used to create the iterator. After
+    ///   [state_iterator_next] returns (the encoding of) [None] this method
+    ///   returns (sections of) the key at the first node returned by the
+    ///   iterator.
     pub fn state_iterator_key_read(iterator: u64, start: *mut u8, length: u32, offset: u32) -> u32;
 
     // Operations on the entry.
@@ -175,7 +174,7 @@ extern "C" {
     /// offset ... where to start reading in the entry
     /// The return value is
     /// - u32::MAX if the entry does not exist (has been invalidated, or never
-    /// existed). In this case no data is written.
+    ///   existed). In this case no data is written.
     /// - amount of data that was read. This is never more than length.
     pub fn state_entry_read(entry: u64, start: *mut u8, length: u32, offset: u32) -> u32;
 
@@ -186,14 +185,14 @@ extern "C" {
     /// offset ... where to start writing in the entry
     /// The return value is
     /// - u32::MAX if the entry does not exist (has been invalidated, or never
-    /// existed). In this case no data is written.
+    ///   existed). In this case no data is written.
     /// - amount of data that was written. This is never more than length.
     pub fn state_entry_write(entry: u64, start: *const u8, length: u32, offset: u32) -> u32;
 
     /// Return the current size of the entry in bytes.
     /// The return value is either
     /// - u32::MAX if the entry does not exist (has been invalidated, or never
-    /// existed). In this case no data is written.
+    ///   existed). In this case no data is written.
     /// - or the size of the entry.
     pub fn state_entry_size(entry: u64) -> u32;
 

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -135,8 +135,8 @@ extern "C" {
     /// - u64::MAX if the iterator does not exist (it was deleted, or the ID is
     ///   invalid)
     /// - all but the second bit set to 1 if no more entries are left, the
-    ///   iterator is exhausted. All further calls will yield the same until
-    ///   the iterator is deleted.
+    ///   iterator is exhausted. All further calls will yield the same until the
+    ///   iterator is deleted.
     /// - otherwise the first bit is 0, and the remaining bits encode an entry
     ///   identifier that can be passed to any of the entry methods.
     pub fn state_iterator_next(iterator: u64) -> u64;
@@ -157,12 +157,11 @@ extern "C" {
     /// either
     /// - u32::MAX if the iterator has already been deleted
     /// - the amount of data that was copied. This will never be more than the
-    ///   supplied length.
-    ///   Before the first call to the [state_iterator_next] function this returns
-    ///   (sections of) the key that was used to create the iterator. After
-    ///   [state_iterator_next] returns (the encoding of) [None] this method
-    ///   returns (sections of) the key at the first node returned by the
-    ///   iterator.
+    ///   supplied length. Before the first call to the [state_iterator_next]
+    ///   function this returns (sections of) the key that was used to create
+    ///   the iterator. After [state_iterator_next] returns (the encoding of)
+    ///   [None] this method returns (sections of) the key at the first node
+    ///   returned by the iterator.
     pub fn state_iterator_key_read(iterator: u64, start: *mut u8, length: u32, offset: u32) -> u32;
 
     // Operations on the entry.

--- a/concordium-std/src/state_btree.rs
+++ b/concordium-std/src/state_btree.rs
@@ -505,9 +505,7 @@ impl<const M: usize, K> StateBTreeSet<K, M> {
     pub fn higher(&self, key: &K) -> Option<StateRef<K>>
     where
         K: Serialize + Ord, {
-        let Some(root_node_id) = self.root else {
-            return None;
-        };
+        let root_node_id = self.root?;
 
         let mut node = self.get_node(root_node_id);
         let mut higher_so_far = None;
@@ -543,9 +541,7 @@ impl<const M: usize, K> StateBTreeSet<K, M> {
     pub fn eq_or_higher(&self, key: &K) -> Option<StateRef<K>>
     where
         K: Serialize + Ord, {
-        let Some(root_node_id) = self.root else {
-            return None;
-        };
+        let root_node_id = self.root?;
 
         let mut node = self.get_node(root_node_id);
         let mut higher_so_far = None;
@@ -581,9 +577,7 @@ impl<const M: usize, K> StateBTreeSet<K, M> {
     pub fn lower(&self, key: &K) -> Option<StateRef<K>>
     where
         K: Serialize + Ord, {
-        let Some(root_node_id) = self.root else {
-            return None;
-        };
+        let root_node_id = self.root?;
 
         let mut node = self.get_node(root_node_id);
         let mut lower_so_far = None;
@@ -614,9 +608,7 @@ impl<const M: usize, K> StateBTreeSet<K, M> {
     pub fn eq_or_lower(&self, key: &K) -> Option<StateRef<K>>
     where
         K: Serialize + Ord, {
-        let Some(root_node_id) = self.root else {
-            return None;
-        };
+        let root_node_id = self.root?;
 
         let mut node = self.get_node(root_node_id);
         let mut lower_so_far = None;
@@ -651,9 +643,7 @@ impl<const M: usize, K> StateBTreeSet<K, M> {
     pub fn first(&self) -> Option<StateRef<K>>
     where
         K: Serialize + Ord, {
-        let Some(root_node_id) = self.root else {
-            return None;
-        };
+        let root_node_id = self.root?;
         let mut root = self.get_node(root_node_id);
         if root.is_leaf() {
             Some(StateRef::new(root.keys.swap_remove(0)))
@@ -667,9 +657,7 @@ impl<const M: usize, K> StateBTreeSet<K, M> {
     pub fn last(&self) -> Option<StateRef<K>>
     where
         K: Serialize + Ord, {
-        let Some(root_node_id) = self.root else {
-            return None;
-        };
+        let root_node_id = self.root?;
         let mut root = self.get_node(root_node_id);
         if root.is_leaf() {
             Some(StateRef::new(root.keys.pop().unwrap_abort()))

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -780,9 +780,9 @@ type MockFnHash<T> = Box<dyn FnMut(&[u8]) -> T>;
 /// two different ways:
 ///
 /// 1. By setting up mock responses for the functions you need, for example with
-/// the `setup_hash_sha_256_mock` method.
+///    the `setup_hash_sha_256_mock` method.
 /// 2. Or, by using the actual implementations. For this, you need to enable the
-/// "crypto-primitives" feature.
+///    "crypto-primitives" feature.
 pub struct TestCryptoPrimitives {
     #[cfg(not(feature = "crypto-primitives"))]
     verify_ed25519_signature_mock:         RefCell<Option<MockFnVerifyEd25519>>,
@@ -1928,17 +1928,15 @@ pub fn concordium_qc<A: Testable>(num_tests: u64, f: A) {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod test {
-
-    use super::TestStateApi;
     use crate::{
         cell::RefCell,
         rc::Rc,
-        test_infrastructure::{TestStateBuilder, TestStateEntry},
-        Deletable, EntryRaw, HasStateApi, HasStateEntry, StateBTreeSet, StateMap, StateSet,
-        INITIAL_NEXT_ITEM_PREFIX,
+        test_infrastructure::TestStateEntry,
+        HasStateEntry,
     };
-    use concordium_contracts_common::{to_bytes, Deserial, Read, Seek, SeekFrom, Write};
+    use concordium_contracts_common::{Read, Seek, SeekFrom, Write};
 
     #[test]
     fn test_testhost_balance_queries_reflect_transfers() {

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -1930,12 +1930,7 @@ pub fn concordium_qc<A: Testable>(num_tests: u64, f: A) {
 #[cfg(test)]
 #[allow(deprecated)]
 mod test {
-    use crate::{
-        cell::RefCell,
-        rc::Rc,
-        test_infrastructure::TestStateEntry,
-        HasStateEntry,
-    };
+    use crate::{cell::RefCell, rc::Rc, test_infrastructure::TestStateEntry, HasStateEntry};
     use concordium_contracts_common::{Read, Seek, SeekFrom, Write};
 
     #[test]

--- a/contract-testing/CHANGELOG.md
+++ b/contract-testing/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased changes
+## 4.3.0
 
 - Integrate protocol version 7 cost semantics.
 - The `ContractInvokeSuccess` and `ContractInvokeError` have additional fields

--- a/contract-testing/Cargo.toml
+++ b/contract-testing/Cargo.toml
@@ -8,12 +8,12 @@ readme = "README.md"
 description = "A companion crate to `concordium-std` that supports off-chain end-to-end testing of smart contracts."
 homepage = "https://github.com/Concordium/concordium-rust-smart-contracts"
 repository = "https://github.com/Concordium/concordium-rust-smart-contracts"
-exclude = ["tests"] # Do not publish tests.
+exclude = ["tests"]                                                                                                  # Do not publish tests.
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-concordium-rust-sdk = {version = "4", path = "../concordium-rust-sdk"}
+concordium-rust-sdk = { version = "5", path = "../concordium-rust-sdk" }
 tokio = { version = "1.28", features = ["rt-multi-thread", "time"] }
 sha2 = "0.10"
 anyhow = "1"

--- a/contract-testing/Cargo.toml
+++ b/contract-testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-smart-contract-testing"
-version = "4.2.0"
+version = "4.3.0"
 edition = "2021"
 rust-version = "1.73"
 license = "MPL-2.0"

--- a/contract-testing/src/impls.rs
+++ b/contract-testing/src/impls.rs
@@ -636,7 +636,7 @@ impl Chain {
     ///  - `sender`: The account paying for the transaction. Will also become
     ///    the owner of the contract created.
     ///  - `energy_reserved`: Amount of energy reserved for executing the init
-    ///   method.
+    ///    method.
     ///  - `payload`:
     ///    - `amount`: The initial balance of the contract. Subtracted from the
     ///      `sender` account.
@@ -750,7 +750,7 @@ impl Chain {
 
         // Ensure the module contains the provided init name.
         let init_name = payload.init_name.as_contract_name().get_chain_name();
-        if module.artifact.export.get(init_name).is_none() {
+        if !module.artifact.export.contains_key(init_name) {
             return Err(ContractInitErrorKind::ContractNotPresentInModule {
                 name: payload.init_name,
             });
@@ -1742,7 +1742,7 @@ impl Chain {
     /// This method also queries the block info for one of two reasons:
     /// 1) If `query_block` is provided, its existence is checked.
     /// 2) Otherwise, the last final block is queried to get its blockhash which
-    /// will be saved in [`ExternalNodeConnection`].
+    ///    will be saved in [`ExternalNodeConnection`].
     fn setup_external_node_connection(
         &mut self,
         endpoint: Endpoint,

--- a/contract-testing/tests/upgrades.rs
+++ b/contract-testing/tests/upgrades.rs
@@ -525,9 +525,9 @@ fn test_reject() {
             ..
         } => match failure_kind {
             InvokeFailure::ContractReject {
-                code,
+                code: -1,
                 ..
-            } if code == -1 => (),
+            } => (),
             _ => panic!("Expected ContractReject with code == -1"),
         },
         _ => panic!("Expected Err(ContractUpdateError::ExecutionError)"),


### PR DESCRIPTION
## Changes

Updates the Rust SDK to the 5.0.0 release and bumps the versions of concordium-cis2 (6.2.0) and concordium_smart_contract_testing (4.3.0). Also gets rid of some lint warnings where possible.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
