### PR TITLE
Fix the concordium-contracts-common dependency of concordium-cis2

### DIFF
--- a/concordium-cis2/Cargo.toml
+++ b/concordium-cis2/Cargo.toml
@@ -27,7 +27,7 @@ default-features = false
 
 [dependencies.concordium-contracts-common]
 path = "../concordium-rust-sdk/concordium-base/smart-contracts/contracts-common/concordium-contracts-common"
-version = "*"
+version = "9.0"
 optional = true
 default-features = false
 


### PR DESCRIPTION
## Purpose

We can't release `concordium-cis2` without a proper version of the `concordium-contracts-common` dependency
