### PR TITLE
Added functions in the primitive interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,10 @@ Cargo.lock
 
 *.wasm.v1
 *.wasm.v0
+
+# Editor specific
+**/.helix
+
+# Nix artifacts
+**/*.nix
+**/flake.lock

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Added the following functions in the primitive interface:
+  - `set_slot_time`
+  - `set_receive_self_address`
+  - `set_receive_self_balance`
+
 ## concordium-std 10.1.0 (2024-04-04)
 
 - Add support for querying the module reference and contract name of an instance,

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -288,6 +288,10 @@ extern "C" {
         column: u32,
     );
 
+    /// TODO
+    #[cfg(all(feature = "wasm-test", target_arch = "wasm32"))]
+    pub(crate) fn set_slot_time(slot_time: u64);
+
     #[cfg(feature = "debug")]
     /// Emit text together with the source location.
     /// This is used as the equivalent of the `dbg!` macro when the
@@ -511,5 +515,20 @@ mod host_dummy_functions {
     #[no_mangle]
     fn get_random(_dest: *mut u8, _size: u32) {
         unimplemented!("Dummy function! Not to be executed")
+    }
+}
+
+#[cfg(feature = "internal-wasm-test")]
+mod wasm_test {
+    use super::*;
+    use crate::{claim_eq, concordium_test};
+
+    #[concordium_test]
+    fn test() {
+        let slot_time = unsafe {
+            set_slot_time(10);
+            get_slot_time()
+        };
+        claim_eq!(slot_time, 10)
     }
 }


### PR DESCRIPTION
## Purpose

See the related issue (#96)

Also see the accompanying PR ()  

Tested using this script, that compiles `cargo concordium` and runs the unit tests in `concordium-std`:

```bash
CONCORDIUM_STD_PATH="/path/to/concordium-std"
CARGO_CONCORDIUM_PATH="/path/to/cargo-concordium/Cargo.toml"

pushd "$CONCORDIUM_STD_PATH"
cargo run --manifest-path "$CARGO_CONCORDIUM_PATH" -- concordium test --only-unit-tests -- --features internal-wasm-test
popd
```

## Changes

- Added the following functions in the primitive interface and added unit tests:
  - `set_slot_time`
  - `set_receive_self_address`
  - `set_receive_self_balance`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.