### PR TITLE
Fix event schema

### DIFF
--- a/examples/cis2-multi/src/lib.rs
+++ b/examples/cis2-multi/src/lib.rs
@@ -841,12 +841,7 @@ fn get_canonical_address(address: Address) -> ContractResult<Address> {
 // Contract functions
 
 /// Initialize contract instance with no token types.
-#[init(
-    contract = "cis2_multi",
-    parameter = "ContractTokenAmount",
-    event = "Cis2Event<ContractTokenId, ContractTokenAmount>",
-    enable_logger
-)]
+#[init(contract = "cis2_multi", parameter = "ContractTokenAmount", event = "Event", enable_logger)]
 fn contract_init(
     ctx: &InitContext,
     state_builder: &mut StateBuilder,

--- a/examples/nametoken/src/lib.rs
+++ b/examples/nametoken/src/lib.rs
@@ -503,7 +503,7 @@ pub fn build_token_metadata_url(token_id: &ContractTokenId) -> String {
 
 /// Initialize contract instance with no token types initially.
 /// Set the account that initialised the contract to be admin
-#[init(contract = "NameToken")]
+#[init(contract = "NameToken", event = "Cis2Event<ContractTokenId, ContractTokenAmount>")]
 fn contract_init(ctx: &InitContext, state_builder: &mut StateBuilder) -> InitResult<State> {
     // Construct the initial contract state.
     Ok(State::empty(ctx.init_origin(), state_builder))


### PR DESCRIPTION
## Purpose

The block explorer couldn't decode the event data from two example smart contracts.

- Cis2-multi: Wrong schema
- NameToken: Missing schema

## Changes

Fix schemas
