### PR TITLE
Fixing advisory alert for concordium-std

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Removed the native test `StateTrie`
+- Address security advisories and execute cargo update to upgrade the library dependencies below:
+  - advisory update: concordium-std, curve25519-dalek v3.2.1 - RUSTSEC-2024-0344
 
 ## concordium-std 10.1.0 (2024-04-04)
 

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -3,8 +3,6 @@
 ## Unreleased
 
 - Removed the native test `StateTrie`
-- Address security advisories and execute cargo update to upgrade the library dependencies below:
-  - advisory update: concordium-std, curve25519-dalek v3.2.1 - RUSTSEC-2024-0344
 
 ## concordium-std 10.1.0 (2024-04-04)
 

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -15,7 +15,7 @@ readme = "./README.md"
 sha2 = { version = "0.10", optional = true }
 sha3 = { version = "0.10", optional = true }
 secp256k1 = { version = "0.22", optional = true, features = ["lowmemory"] }
-ed25519-zebra = { version = "2.2", optional = true }
+ed25519-zebra = { version = "4.1.0", optional = true }
 quickcheck = {version = "1", optional = true }
 getrandom = { version = "0.2", features = ["custom"], optional = true }
 


### PR DESCRIPTION
## Purpose
Tackling this advisory update in concordium-std
Advisory Update: concordium-std, curve25519-dalek v3.2.1 - ID: RUSTSEC-2024-0344

## Changes
Upgraded the library ed25519-zebra v2.2.0 to version 4.1.0 as this contains the dependency of curve25519 >=4.1.3

## Checklist

- [ x ] My code follows the style of this project.
- [ x ] The code compiles without warnings.
- [ x ] I have performed a self-review of the changes.
- [ x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
