### PR TITLE
Use wasm32v1 target in concordium-std

### DIFF
--- a/concordium-cis2/Cargo.toml
+++ b/concordium-cis2/Cargo.toml
@@ -3,7 +3,7 @@ name = "concordium-cis2"
 version = "6.2.1-alpha.1"
 authors = ["Concordium <developers@concordium.com>"]
 rust-version = "1.85"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 description = "A collection of types for implementing CIS-2 Concordium Token Standard."
 homepage = "https://github.com/Concordium/concordium-rust-smart-contracts/"
@@ -13,7 +13,6 @@ readme = "./README.md"
 [dependencies.concordium-std]
 path = "../concordium-std"
 version = "10.0"
-default-features = false
 
 [dependencies.primitive-types]
 version = "0.11"
@@ -32,8 +31,6 @@ optional = true
 default-features = false
 
 [features]
-default = ["std"]
-std = ["concordium-std/std"]
 u256_amount = []
 serde = [
     "dep:serde",
@@ -44,14 +41,11 @@ serde = [
 [lib]
 crate-type = ["rlib"]
 
-[profile.release]
-opt-level = "s"
-
 [package.metadata.docs.rs]
 # This sets the default target to `wasm32-unknown-unknown` and only builds that
 # target on docs.rs. This is useful because the some parts of documentation only
 # exist on that platform.
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32v1-none"]
 # Default features to build documentation for.
 features = ["std", "u256_amount", "serde"]
 rustc-args = ["--cfg", "docsrs"]

--- a/concordium-cis2/src/lib.rs
+++ b/concordium-cis2/src/lib.rs
@@ -33,7 +33,8 @@
 //! [`TokenAmountU256`] is defined and implements the [`IsTokenAmount`]
 //! interface. The `serde` features derives `serde::Serialize` and
 //! `serde::Deserialize` for a variety of types.
-#![cfg_attr(not(feature = "std"), no_std)]
+
+#![no_std]
 
 mod cis2_client;
 pub use cis2_client::{Cis2Client, Cis2ClientError};
@@ -41,12 +42,9 @@ pub use cis2_client::{Cis2Client, Cis2ClientError};
 use concordium_std::{collections::BTreeMap, schema::SchemaType, *};
 // Re-export for backward compatibility.
 pub use concordium_std::MetadataUrl;
-#[cfg(not(feature = "std"))]
 use core::{fmt, ops, str::FromStr};
 #[cfg(feature = "serde")]
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
-#[cfg(feature = "std")]
-use std::{fmt, ops, str::FromStr};
 
 use convert::TryFrom;
 

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 - Removed the native test `StateTrie`
+- The crate now targets [`wasm32v1-none`](https://doc.rust-lang.org/rustc/platform-support/wasm32v1-none.html) as the supported WASM target. The crate also no longer has an `std` crate feature. 
+  Smart contracts using `concordium-std` should specify `#[no_std]` and compile to `wasm32v1-none`. 
+  The `concordium-std` crate still supports compiling to targets like x86 linux (for unit testing e.g.), in which case the crate will add the Rust `std` crate as a dependency.
+- The crate feature `p7` has been removed. The functionality it guarded (related to protocol P7) is unconditionally compiled.
+- The crate feature `crypto-primitives` has been removed. It had no effect anymore (was previously used by the now deprecated test infrastructure).
 
 ## concordium-std 10.1.0 (2024-04-04)
 

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -2,7 +2,7 @@
 name = "concordium-std"
 version = "10.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 rust-version = "1.85"
 license = "MPL-2.0"
 description = "A standard library for writing smart contracts for the Concordium blockchain in Rust."
@@ -10,12 +10,7 @@ homepage = "https://github.com/Concordium/concordium-rust-smart-contracts/"
 repository = "https://github.com/Concordium/concordium-rust-smart-contracts/"
 readme = "./README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-sha2 = { version = "0.10", optional = true }
-sha3 = { version = "0.10", optional = true }
-secp256k1 = { version = "0.22", optional = true, features = ["lowmemory"] }
-ed25519-zebra = { version = "4.1.0", optional = true }
 quickcheck = {version = "1", optional = true }
 getrandom = { version = "0.2", features = ["custom"], optional = true }
 
@@ -26,37 +21,30 @@ default-features = false
 features = ["smart-contract"]
 
 [features]
-default = ["std"]
-std = ["concordium-contracts-common/std"]
+default = ["bump_alloc"]
+# Enabling the wasm-test feature changes the #[concoridum_test] macro to output test functions callable from WASM interpreter
 wasm-test = ["concordium-contracts-common/wasm-test"]
 # Own internal wasm-tests leak out to the smart contracts using this library,
 # so a separate feature 'internal-wasm-test' is introduced for these.
-internal-wasm-test = ["wasm-test", "concordium-quickcheck"]
+internal-wasm-test = ["wasm-test"]
+#internal-wasm-test = ["wasm-test", "concordium-quickcheck"] # todo reenable property based tests as part of https://linear.app/concordium/issue/COR-2474/property-based-tests-on-wasm32-target
+# Make smart contract macros generate function in the smart contract that allows inspecting the schema of the contract functions.
 build-schema = ["concordium-contracts-common/build-schema"]
-crypto-primitives = ["sha2", "sha3", "secp256k1", "ed25519-zebra"]
-concordium-quickcheck = ["getrandom", "quickcheck", "concordium-contracts-common/concordium-quickcheck", "std"]
+concordium-quickcheck = ["getrandom", "quickcheck", "concordium-contracts-common/concordium-quickcheck"] # // decide what to do with this feature flag as part of https://linear.app/concordium/issue/COR-2474/property-based-tests-on-wasm32-target
+# Enabling debug feature changes the #[concoridum_dbg] macro to log messages via the WASM interpreter
 debug = []
+# Custom allocator. See module documentation for bump_alloc in this crate
 bump_alloc = []
-# p7 enables support for functionality introduced in protocol version 7.
-p7 = []
 
 [lib]
 # cdylib is needed below to compile into a wasm module with internal unit tests.
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"
-
 [dev-dependencies]
 trybuild = "1.0"
-# Don't unwind on panics, just trap.
-# panic = "abort"
-
-
 
 [package.metadata.docs.rs]
-# This sets the default target to `wasm32-unknown-unknown` and only builds that
+# This sets the default target to `wasm32v1-none` and only builds that
 # target on docs.rs. This is useful because the some parts of documentation only
 # exist on that platform.
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32v1-none"]

--- a/concordium-std/src/bump_alloc.rs
+++ b/concordium-std/src/bump_alloc.rs
@@ -39,7 +39,7 @@ impl PageCount {
 /// The number of pages returned from `memory_grow` to indicate out of memory.
 const ERROR_PAGE_COUNT: PageCount = PageCount(usize::MAX);
 
-extern "C" {
+unsafe extern "C" {
     /// A pointer to the `__heap_base` field defined in the Wasm files that
     /// specifies which memory address the heap starts at. Memory addresses
     /// prior to that are used for the data and the stack.
@@ -142,76 +142,80 @@ impl BumpAllocator {
 
 unsafe impl GlobalAlloc for BumpAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let heap_end = &mut *self.heap_end.get();
-        let next = &mut *self.next.get();
+        unsafe {
+            let heap_end = &mut *self.heap_end.get();
+            let next = &mut *self.next.get();
 
-        // On the first allocation, we need to replace the dummy values in the struct
-        // with the actual memory addresses of the `heap_start` and `heap_end` as well
-        // as the `next` and `last_alloc`.
-        //
-        // This is because the size of the data and stack sections (which are located
-        // before the beginning of the heap) and the initial size of the heap
-        // can be configured in the wasm.
-        if *heap_end == 0 {
-            // Get the base/start of the heap.
-            let heap_base = unsafe { &__heap_base as *const _ as usize };
-            // Get the actual size of the memory, which is also the end of the heap, as the
-            // heap is the last section in the memory.
-            let actual_size = self.memory_size().size_in_bytes();
-            // Replace all the dummy values.
-            *next = heap_base;
-            *self.heap_start.get() = heap_base;
-            *self.last_alloc.get() = heap_base;
-            *heap_end = actual_size;
-        }
-
-        // Align the address.
-        let alloc_start = align_up(*next, layout.align());
-        // Get the end of the allocation. This should always return `Some` as the
-        // contract memory is limited to much below usize::MAX.
-        let alloc_end = match alloc_start.checked_add(layout.size()) {
-            Some(end) => end,
-            None => return ptr::null_mut(),
-        };
-
-        // Check if we need to request more memory.
-        if alloc_end > *heap_end {
-            let space_needed = alloc_end - *heap_end;
-            let pages_to_request = pages_to_request(space_needed);
-            let previous_page_count = self.memory_grow(pages_to_request);
-            // Check if we are out of memory.
-            if previous_page_count == ERROR_PAGE_COUNT {
-                return ptr::null_mut();
+            // On the first allocation, we need to replace the dummy values in the struct
+            // with the actual memory addresses of the `heap_start` and `heap_end` as well
+            // as the `next` and `last_alloc`.
+            //
+            // This is because the size of the data and stack sections (which are located
+            // before the beginning of the heap) and the initial size of the heap
+            // can be configured in the wasm.
+            if *heap_end == 0 {
+                // Get the base/start of the heap.
+                let heap_base = &__heap_base as *const _ as usize;
+                // Get the actual size of the memory, which is also the end of the heap, as the
+                // heap is the last section in the memory.
+                let actual_size = self.memory_size().size_in_bytes();
+                // Replace all the dummy values.
+                *next = heap_base;
+                *self.heap_start.get() = heap_base;
+                *self.last_alloc.get() = heap_base;
+                *heap_end = actual_size;
             }
-            // Increase the heap size.
-            *heap_end += pages_to_request.size_in_bytes();
-        }
 
-        // Increment allocations counter.
-        *self.allocations.get() += 1;
-        // Remember the last address handed out, so that we may move `next` backwards if
-        // it is deallocated before a new allocation occurs.
-        *self.last_alloc.get() = alloc_start;
-        *next = alloc_end;
-        alloc_start as *mut u8
+            // Align the address.
+            let alloc_start = align_up(*next, layout.align());
+            // Get the end of the allocation. This should always return `Some` as the
+            // contract memory is limited to much below usize::MAX.
+            let alloc_end = match alloc_start.checked_add(layout.size()) {
+                Some(end) => end,
+                None => return ptr::null_mut(),
+            };
+
+            // Check if we need to request more memory.
+            if alloc_end > *heap_end {
+                let space_needed = alloc_end - *heap_end;
+                let pages_to_request = pages_to_request(space_needed);
+                let previous_page_count = self.memory_grow(pages_to_request);
+                // Check if we are out of memory.
+                if previous_page_count == ERROR_PAGE_COUNT {
+                    return ptr::null_mut();
+                }
+                // Increase the heap size.
+                *heap_end += pages_to_request.size_in_bytes();
+            }
+
+            // Increment allocations counter.
+            *self.allocations.get() += 1;
+            // Remember the last address handed out, so that we may move `next` backwards if
+            // it is deallocated before a new allocation occurs.
+            *self.last_alloc.get() = alloc_start;
+            *next = alloc_end;
+            alloc_start as *mut u8
+        }
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        let allocations = self.allocations.get();
-        let last_alloc = self.last_alloc.get();
-        let next = self.next.get();
-        // Decrease the allocation counter.
-        *allocations -= 1;
-        if *allocations == 0 {
-            // Reset next and last allocation so they point at the start of the heap if
-            // everything has been deallocated.
-            let heap_start = self.heap_start.get();
-            *next = *heap_start;
-            *last_alloc = *heap_start;
-        } else if *last_alloc as *mut u8 == ptr {
-            // Move next back to last alloc. This is a small optimization over the regular
-            // bump allocator.
-            *next = *last_alloc;
+        unsafe {
+            let allocations = self.allocations.get();
+            let last_alloc = self.last_alloc.get();
+            let next = self.next.get();
+            // Decrease the allocation counter.
+            *allocations -= 1;
+            if *allocations == 0 {
+                // Reset next and last allocation so they point at the start of the heap if
+                // everything has been deallocated.
+                let heap_start = self.heap_start.get();
+                *next = *heap_start;
+                *last_alloc = *heap_start;
+            } else if *last_alloc as *mut u8 == ptr {
+                // Move next back to last alloc. This is a small optimization over the regular
+                // bump allocator.
+                *next = *last_alloc;
+            }
         }
     }
 }

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -1,6 +1,6 @@
-#[cfg(feature = "p7")]
 use crate::vec;
 use crate::{
+    String,
     cell::UnsafeCell,
     convert::{self, TryInto},
     fmt,
@@ -12,7 +12,6 @@ use crate::{
     traits::*,
     types::*,
     vec::Vec,
-    String,
 };
 pub(crate) use concordium_contracts_common::*;
 
@@ -1920,10 +1919,8 @@ const INVOKE_CHECK_ACCOUNT_SIGNATURE_TAG: u32 = 5;
 /// Tag of the query account's public keys [prims::invoke].
 const INVOKE_QUERY_ACCOUNT_PUBLIC_KEYS_TAG: u32 = 6;
 /// Tag of the query contract module reference operation. See [prims::invoke].
-#[cfg(feature = "p7")]
 const INVOKE_QUERY_CONTRACT_MODULE_REFERENCE_TAG: u32 = 7;
 /// Tag of the query contract name operation. See [prims::invoke].
-#[cfg(feature = "p7")]
 const INVOKE_QUERY_CONTRACT_NAME_TAG: u32 = 8;
 
 /// Check whether the response code from calling `invoke` is encoding a failure
@@ -2171,7 +2168,6 @@ fn parse_query_exchange_rates_response_code(code: u64) -> ExternCallResponse {
 /// - In case of failure the 4th byte is used, and encodes the environment
 ///   failure where:
 ///    - '0x03' encodes missing contract.
-#[cfg(feature = "p7")]
 fn parse_query_contract_module_reference_response_code(
     code: u64,
 ) -> Result<ExternCallResponse, QueryContractModuleReferenceError> {
@@ -2195,7 +2191,6 @@ fn parse_query_contract_module_reference_response_code(
 /// - In case of failure the 4th byte is used, and encodes the environment
 ///   failure where:
 ///    - '0x03' encodes missing contract.
-#[cfg(feature = "p7")]
 fn parse_query_contract_name_response_code(
     code: u64,
 ) -> Result<OwnedContractName, QueryContractNameError> {
@@ -2337,7 +2332,6 @@ fn check_account_signature_worker(
 
 /// Helper factoring out the common behaviour of contract_module_reference for
 /// the two extern hosts below.
-#[cfg(feature = "p7")]
 fn query_contract_module_reference_worker(
     address: &ContractAddress,
 ) -> QueryContractModuleReferenceResult {
@@ -2355,7 +2349,6 @@ fn query_contract_module_reference_worker(
 
 /// Helper factoring out the common behaviour of contract_name for
 /// the two extern hosts below.
-#[cfg(feature = "p7")]
 fn query_contract_name_worker(address: &ContractAddress) -> QueryContractNameResult {
     let data = [address.index.to_le_bytes(), address.subindex.to_le_bytes()];
     let response = unsafe {
@@ -2639,7 +2632,6 @@ where
         check_account_signature_worker(address, signatures, data)
     }
 
-    #[cfg(feature = "p7")]
     #[inline(always)]
     fn contract_module_reference(
         &self,
@@ -2648,7 +2640,6 @@ where
         query_contract_module_reference_worker(&address)
     }
 
-    #[cfg(feature = "p7")]
     #[inline(always)]
     fn contract_name(&self, address: ContractAddress) -> QueryContractNameResult {
         query_contract_name_worker(&address)
@@ -2743,7 +2734,6 @@ impl HasHost<ExternStateApi> for ExternLowLevelHost {
         check_account_signature_worker(address, signatures, data)
     }
 
-    #[cfg(feature = "p7")]
     #[inline(always)]
     fn contract_module_reference(
         &self,
@@ -2752,7 +2742,6 @@ impl HasHost<ExternStateApi> for ExternLowLevelHost {
         query_contract_module_reference_worker(&address)
     }
 
-    #[cfg(feature = "p7")]
     #[inline(always)]
     fn contract_name(&self, address: ContractAddress) -> QueryContractNameResult {
         query_contract_name_worker(&address)
@@ -3005,9 +2994,6 @@ pub fn put_in_memory(input: &[u8]) -> *mut u8 {
     let mut bytes = to_bytes(&bytes_length);
     bytes.extend_from_slice(input);
     let ptr = bytes.as_mut_ptr();
-    #[cfg(feature = "std")]
-    ::std::mem::forget(bytes);
-    #[cfg(not(feature = "std"))]
     core::mem::forget(bytes);
     ptr
 }
@@ -3309,10 +3295,13 @@ mod tests {
 #[cfg(feature = "internal-wasm-test")]
 mod wasm_test {
     use crate::{
-        claim, claim_eq, concordium_test, to_bytes, Deletable, Deserial, DeserialWithState,
-        EntryRaw, HasStateApi, HasStateEntry, ParseResult, Serial, StateApi, StateBuilder,
-        StateError, StateMap, StateSet, INITIAL_NEXT_ITEM_PREFIX,
+        Deletable, Deserial, DeserialWithState, EntryRaw, HasStateApi, HasStateEntry,
+        INITIAL_NEXT_ITEM_PREFIX, ParseResult, Serial, StateApi, StateBuilder, StateError,
+        StateMap, StateSet, claim, claim_eq, concordium_test, to_bytes,
     };
+    use alloc::string::String;
+    use alloc::string::ToString;
+    use alloc::vec::Vec;
 
     const GENERIC_MAP_PREFIX: u64 = 1;
 
@@ -3562,16 +3551,20 @@ mod wasm_test {
             .insert(my_set_key, set)
             .expect("Insert failed");
 
-        claim!(state_builder
-            .get::<_, StateSet<u8, _>>(my_set_key)
-            .unwrap()
-            .unwrap()
-            .contains(&0),);
-        claim!(!state_builder
-            .get::<_, StateSet<u8, _>>(my_set_key)
-            .unwrap()
-            .unwrap()
-            .contains(&2),);
+        claim!(
+            state_builder
+                .get::<_, StateSet<u8, _>>(my_set_key)
+                .unwrap()
+                .unwrap()
+                .contains(&0),
+        );
+        claim!(
+            !state_builder
+                .get::<_, StateSet<u8, _>>(my_set_key)
+                .unwrap()
+                .unwrap()
+                .contains(&2),
+        );
 
         let set = state_builder
             .get::<_, StateSet<u8, _>>(my_set_key)

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -393,78 +393,51 @@
 //! [test_infrastructure]: ./test_infrastructure/index.html
 //! [concordium_smart_contract_testing]: https://docs.rs/concordium-smart-contract-testing
 
-#![cfg_attr(
-    not(feature = "std"),
-    no_std,
-    allow(internal_features),
-    feature(core_intrinsics)
-)]
+// For targets that are not wasm32v1, we compile with std. This enables compiling (which requires and allocator)
+// and also running pure unit tests.
+#![cfg_attr(target_arch = "wasm32", no_std)]
 
-#[cfg(not(feature = "std"))]
 pub extern crate alloc;
 
 /// Terminate execution immediately without panicking.
-/// When the `std` feature is enabled this is just [std::process::abort](https://doc.rust-lang.org/std/process/fn.abort.html).
-/// When `std` is not present and the target architecture is `wasm32` this will
+///
+/// On the target architecture is `wasm32` this will
 /// simply emit the [unreachable](https://doc.rust-lang.org/core/arch/wasm32/fn.unreachable.html) instruction.
-#[cfg(feature = "std")]
-pub use std::process::abort as trap;
-#[cfg(all(not(feature = "std"), target_arch = "wasm32"))]
+/// On other architectures where the `std` crate is available is just [std::process::abort](https://doc.rust-lang.org/std/process/fn.abort.html).
 #[inline(always)]
 pub fn trap() -> ! {
-    core::arch::wasm32::unreachable()
-}
-#[cfg(all(not(feature = "std"), not(target_arch = "wasm32")))]
-#[inline(always)]
-pub fn trap() -> ! {
-    core::intrinsics::abort()
-}
-
-#[cfg(not(feature = "std"))]
-#[panic_handler]
-fn abort_panic(_info: &core::panic::PanicInfo) -> ! {
     #[cfg(target_arch = "wasm32")]
     core::arch::wasm32::unreachable();
     #[cfg(not(target_arch = "wasm32"))]
-    loop {}
+    std::process::abort()
+}
+
+#[cfg(target_arch = "wasm32")]
+#[panic_handler]
+fn abort_panic(_info: &core::panic::PanicInfo) -> ! {
+    core::arch::wasm32::unreachable()
 }
 
 // Provide some re-exports to make it easier to use the library.
 // This should be expanded in the future.
 /// Re-export.
-#[cfg(not(feature = "std"))]
 pub use alloc::{
     borrow::ToOwned, boxed, boxed::Box, format, rc, string, string::String, string::ToString, vec,
     vec::Vec,
 };
 /// Re-export.
-#[cfg(not(feature = "std"))]
 pub use core::{cell, cmp, convert, fmt, hash, hint, iter, marker, mem, num, ops, result::*};
-#[cfg(feature = "std")]
-pub(crate) use std::vec;
-
-/// Re-export.
-#[cfg(feature = "std")]
-pub use std::{
-    boxed, boxed::Box, cell, cmp, convert, fmt, hash, hint, iter, marker, mem, num, ops, rc,
-    string::String, vec::Vec,
-};
 
 #[cfg(all(feature = "bump_alloc", target_arch = "wasm32"))]
 pub mod bump_alloc;
 
 #[cfg(all(feature = "bump_alloc", target_arch = "wasm32"))]
-#[cfg_attr(feature = "bump_alloc", global_allocator)]
+#[global_allocator]
 static ALLOC: crate::bump_alloc::BumpAllocator = unsafe { crate::bump_alloc::BumpAllocator::new() };
 
 /// Re-export.
 pub mod collections {
-    #[cfg(not(feature = "std"))]
-    use alloc::collections;
-    #[cfg(feature = "std")]
-    use std::collections;
-
-    pub use collections::*;
+    pub use alloc::collections::*;
     pub use concordium_contracts_common::{HashMap, HashSet};
 }
 
@@ -487,11 +460,6 @@ pub use types::*;
     note = "Deprecated in favor of [concordium-smart-contract-testing](https://docs.rs/concordium-smart-contract-testing)."
 )]
 pub mod test_infrastructure;
-
-#[cfg(all(feature = "debug", not(feature = "std")))]
-pub use alloc::format;
-#[cfg(all(feature = "debug", feature = "std"))]
-pub use std::format;
 
 #[macro_export]
 #[cfg(feature = "debug")]

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -15,7 +15,7 @@
 // Interface to the chain. These functions are assumed to be instantiated by
 // the scheduler with relevant primitives.
 #[cfg_attr(target_arch = "wasm32", link(wasm_import_module = "concordium"))]
-extern "C" {
+unsafe extern "C" {
     /// Invoke a host instruction. The arguments are
     ///
     /// - `tag`, which instruction to invoke
@@ -303,7 +303,7 @@ extern "C" {
 // available in a test environment.
 #[cfg_attr(target_arch = "wasm32", link(wasm_import_module = "concordium"))]
 #[cfg(feature = "wasm-test")]
-extern "C" {
+unsafe extern "C" {
     /// Set the slot time in milliseconds.
     /// The slot time represents the beginning of the smart contract's block.
     pub(crate) fn set_slot_time(slot_time: u64);
@@ -363,23 +363,23 @@ extern "C" {
 // This is necessary to compile to x86_64 during unit tests on Windows and OSX.
 #[cfg(not(target_arch = "wasm32"))]
 mod host_dummy_functions {
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     fn invoke(_tag: u32, _start: *const u8, _length: u32) -> u64 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     fn write_output(_start: *const u8, _length: u32, _offset: u32) -> u32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     fn upgrade(_module_ref: *const u8) -> u64 {
         unimplemented!("Dummy function! Not to be executed.")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn get_parameter_size(_i: u32) -> i32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn get_parameter_section(
         _i: u32,
         _param_bytes: *mut u8,
@@ -388,47 +388,47 @@ mod host_dummy_functions {
     ) -> i32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn get_policy_section(_policy_bytes: *mut u8, _length: u32, _offset: u32) -> u32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn log_event(_start: *const u8, _length: u32) -> i32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub(crate) fn state_lookup_entry(_key_start: *const u8, _key_length: u32) -> u64 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub(crate) fn state_create_entry(_key_start: *const u8, _key_length: u32) -> u64 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub(crate) fn state_delete_entry(_entry: u64) -> u32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub(crate) fn state_delete_prefix(_key_start: *const u8, _key_length: u32) -> u32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub(crate) fn state_iterate_prefix(_prefix_start: *const u8, _prefix_length: u32) -> u64 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub(crate) fn state_iterator_next(_iterator: u64) -> u64 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub(crate) fn state_iterator_delete(_iterator: u64) -> u32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub(crate) fn state_iterator_key_size(_iterator: u64) -> u32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub(crate) fn state_iterator_key_read(
         _iterator: u64,
         _start: *mut u8,
@@ -437,7 +437,7 @@ mod host_dummy_functions {
     ) -> u32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub(crate) fn state_entry_read(
         _entry: u64,
         _start: *mut u8,
@@ -446,7 +446,7 @@ mod host_dummy_functions {
     ) -> u32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub(crate) fn state_entry_write(
         _entry: u64,
         _start: *const u8,
@@ -455,53 +455,53 @@ mod host_dummy_functions {
     ) -> u32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub(crate) fn state_entry_resize(_entry: u64, _new_size: u32) -> u32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     pub(crate) fn state_entry_size(_entry: u64) -> u32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn get_init_origin(_start: *mut u8) {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn get_receive_invoker(_start: *mut u8) {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn get_receive_self_address(_start: *mut u8) {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn get_receive_self_balance() -> u64 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn get_receive_sender(_start: *mut u8) {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn get_receive_owner(_start: *mut u8) {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn get_receive_entrypoint_size() -> u32 {
         unimplemented!("Dummy function! Not to be executed")
     }
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn get_receive_entrypoint(_start: *mut u8) {
         unimplemented!("Dummy function! Not to be executed")
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn get_slot_time() -> u64 {
         unimplemented!("Dummy function! Not to be executed")
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     extern "C" fn verify_ed25519_signature(
         _public_key: *const u8,
         _signature: *const u8,
@@ -511,7 +511,7 @@ mod host_dummy_functions {
         unimplemented!("Dummy function! Not to be executed")
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     fn verify_ecdsa_secp256k1_signature(
         _public_key: *const u8,
         _signature: *const u8,
@@ -520,22 +520,22 @@ mod host_dummy_functions {
         unimplemented!("Dummy function! Not to be executed")
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     fn hash_sha2_256(_data: *const u8, _data_len: u32, _output: *mut u8) {
         unimplemented!("Dummy function! Not to be executed")
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     fn hash_sha3_256(_data: *const u8, _data_len: u32, _output: *mut u8) {
         unimplemented!("Dummy function! Not to be executed")
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     fn hash_keccak_256(_data: *const u8, _data_len: u32, _output: *mut u8) {
         unimplemented!("Dummy function! Not to be executed")
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     fn report_error(
         _msg_start: *const u8,
         _msg_length: u32,
@@ -547,7 +547,7 @@ mod host_dummy_functions {
         unimplemented!("Dummy function! Not to be executed")
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     fn debug_print(
         _msg_start: *const u8,
         _msg_length: u32,
@@ -559,7 +559,7 @@ mod host_dummy_functions {
         unimplemented!("Dummy function! Not to be executed")
     }
 
-    #[no_mangle]
+    #[unsafe(no_mangle)]
     fn get_random(_dest: *mut u8, _size: u32) {
         unimplemented!("Dummy function! Not to be executed")
     }

--- a/concordium-std/src/state_btree.rs
+++ b/concordium-std/src/state_btree.rs
@@ -1,7 +1,7 @@
 use crate::{
-    self as concordium_std, cmp::Ordering, marker::PhantomData, mem, prims, vec::Vec, Deletable,
-    Deserial, DeserialWithState, Get, HasStateApi, ParseResult, Read, Serial, Serialize, StateApi,
-    StateItemPrefix, StateMap, StateRef, StateRefMut, UnwrapAbort, Write, STATE_ITEM_PREFIX_SIZE,
+    self as concordium_std, Deletable, Deserial, DeserialWithState, Get, HasStateApi, ParseResult,
+    Read, STATE_ITEM_PREFIX_SIZE, Serial, Serialize, StateApi, StateItemPrefix, StateMap, StateRef,
+    StateRefMut, UnwrapAbort, Write, cmp::Ordering, marker::PhantomData, mem, prims, vec::Vec,
 };
 
 /// An ordered map based on [B-Tree](https://en.wikipedia.org/wiki/B-tree), where
@@ -1326,7 +1326,10 @@ where
 #[cfg(feature = "internal-wasm-test")]
 mod wasm_test_btree {
     use super::*;
-    use crate::{claim, claim_eq, concordium_test, StateApi, StateBuilder};
+    use crate::{StateApi, StateBuilder, claim, claim_eq, concordium_test};
+    use alloc::string::String;
+    use alloc::{format, vec};
+    use core::fmt;
 
     /// The invariants to check in a btree.
     /// Should only be used while debugging and testing the btree itself.
@@ -1434,7 +1437,7 @@ mod wasm_test_btree {
         /// Should only be used while debugging and testing the btree itself.
         pub(crate) fn debug(&self) -> String
         where
-            K: Serialize + std::fmt::Debug + Ord,
+            K: Serialize + fmt::Debug + Ord,
         {
             let Some(root_node_id) = self.root else {
                 return format!("no root");
@@ -1869,13 +1872,17 @@ mod wasm_test_btree {
     // The module is using `concordium_quickcheck` which is located in a deprecated
     // module.
     #[allow(deprecated)]
+    #[cfg(feature = "concordium-quickcheck")] // todo remove this conditional as part of https://linear.app/concordium/issue/COR-2474/property-based-tests-on-wasm32-target to reenable property testst
     mod quickcheck {
         use super::super::*;
         use crate::{
-            self as concordium_std, concordium_quickcheck, concordium_test, fail, StateApi,
-            StateBuilder, StateError,
+            self as concordium_std, StateApi, StateBuilder, StateError, concordium_quickcheck,
+            concordium_test, fail,
         };
         use ::quickcheck::{Arbitrary, Gen, TestResult};
+        use alloc::boxed::Box;
+        use alloc::string::String;
+        use alloc::{format, vec};
 
         /// Quickcheck inserting random items, check invariants on the tree and
         /// query every item ensuring the tree contains it.

--- a/concordium-std/src/test_env.rs
+++ b/concordium-std/src/test_env.rs
@@ -1,3 +1,5 @@
+use alloc::vec;
+use alloc::vec::Vec;
 use concordium_contracts_common::{
     AccountAddress, Address, Amount, ContractAddress, EntrypointName, Serial, SlotTime,
 };
@@ -65,11 +67,7 @@ impl TestEnv {
         let mut buf = vec![0; event_len.try_into().unwrap()];
         let bytes_written = unsafe { prims::get_event(index, buf.as_mut_ptr()) };
 
-        if bytes_written < 0 {
-            None
-        } else {
-            Some(buf)
-        }
+        if bytes_written < 0 { None } else { Some(buf) }
     }
 
     /// Set the address of the sender.
@@ -156,7 +154,7 @@ mod wasm_test {
         let original = Timestamp::from_timestamp_millis(10);
         TestEnv.set_slot_time(original);
         let stored = extern_chain_meta.block_time();
-        claim_eq!(original, stored)
+        claim_eq!(original, stored);
     }
 
     #[concordium_test]

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -5,11 +5,10 @@
 use crate::vec::Vec;
 use crate::{
     AccountSignatures, CallContractResult, CheckAccountSignatureResult, EntryRaw, ExchangeRates,
-    HashKeccak256, HashSha2256, HashSha3256, Key, OccupiedEntryRaw,
-    PublicKeyEcdsaSecp256k1, PublicKeyEd25519, QueryAccountBalanceResult,
-    QueryAccountPublicKeysResult, QueryContractBalanceResult, ReadOnlyCallContractResult,
-    SignatureEcdsaSecp256k1, SignatureEd25519, StateBuilder, TransferResult, UpgradeResult,
-    VacantEntryRaw,
+    HashKeccak256, HashSha2256, HashSha3256, Key, OccupiedEntryRaw, PublicKeyEcdsaSecp256k1,
+    PublicKeyEd25519, QueryAccountBalanceResult, QueryAccountPublicKeysResult,
+    QueryContractBalanceResult, ReadOnlyCallContractResult, SignatureEcdsaSecp256k1,
+    SignatureEd25519, StateBuilder, TransferResult, UpgradeResult, VacantEntryRaw,
     types::{LogError, StateError},
 };
 use crate::{QueryContractModuleReferenceResult, QueryContractNameResult};

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -2,17 +2,16 @@
 //! This allows setting-up mock objects for testing individual
 //! contract invocations.
 
-#[cfg(not(feature = "std"))]
 use crate::vec::Vec;
 use crate::{
-    types::{LogError, StateError},
     AccountSignatures, CallContractResult, CheckAccountSignatureResult, EntryRaw, ExchangeRates,
-    HashKeccak256, HashSha2256, HashSha3256, Key, OccupiedEntryRaw, PublicKeyEcdsaSecp256k1,
-    PublicKeyEd25519, QueryAccountBalanceResult, QueryAccountPublicKeysResult,
-    QueryContractBalanceResult, ReadOnlyCallContractResult, SignatureEcdsaSecp256k1,
-    SignatureEd25519, StateBuilder, TransferResult, UpgradeResult, VacantEntryRaw,
+    HashKeccak256, HashSha2256, HashSha3256, Key, OccupiedEntryRaw,
+    PublicKeyEcdsaSecp256k1, PublicKeyEd25519, QueryAccountBalanceResult,
+    QueryAccountPublicKeysResult, QueryContractBalanceResult, ReadOnlyCallContractResult,
+    SignatureEcdsaSecp256k1, SignatureEd25519, StateBuilder, TransferResult, UpgradeResult,
+    VacantEntryRaw,
+    types::{LogError, StateError},
 };
-#[cfg(feature = "p7")]
 use crate::{QueryContractModuleReferenceResult, QueryContractNameResult};
 use concordium_contracts_common::*;
 
@@ -539,14 +538,12 @@ pub trait HasHost<State>: Sized {
     ///
     /// Note: after a successful [`Self::upgrade`], this will return the new
     /// module reference.
-    #[cfg(feature = "p7")]
     fn contract_module_reference(
         &self,
         address: ContractAddress,
     ) -> QueryContractModuleReferenceResult;
 
     /// Get the contract name of a contract instance.
-    #[cfg(feature = "p7")]
     fn contract_name(&self, address: ContractAddress) -> QueryContractNameResult;
 
     /// Get an immutable reference to the contract state.

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cell::UnsafeCell, marker::PhantomData, num::NonZeroU32, Cursor, HasStateApi, Serial, Vec,
+    Cursor, HasStateApi, Serial, Vec, cell::UnsafeCell, marker::PhantomData, num::NonZeroU32,
 };
 use concordium_contracts_common::{
     AccountBalance, Amount, ModuleReference, OwnedContractName, ParseError,
@@ -822,7 +822,7 @@ macro_rules! fail {
     };
     ($($arg:tt)*) => {
         {
-            let msg = alloc::format!($($arg)*);
+            let msg = $crate::alloc::format!($($arg)*);
             #[allow(deprecated)]
             $crate::test_infrastructure::report_error(&msg, file!(), line!(), column!());
             panic!("{}", msg)

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -811,7 +811,6 @@ macro_rules! ensure_ne {
 /// It reports back error information to the host.
 /// Used only in testing with
 /// [`test_infrastructure`](crate::test_infrastructure).
-#[cfg(feature = "std")]
 #[macro_export]
 macro_rules! fail {
     () => {
@@ -823,31 +822,7 @@ macro_rules! fail {
     };
     ($($arg:tt)*) => {
         {
-            let msg = format!($($arg)*);
-            #[allow(deprecated)]
-            $crate::test_infrastructure::report_error(&msg, file!(), line!(), column!());
-            panic!("{}", msg)
-        }
-    };
-}
-
-/// The `fail` macro is used for testing as a substitute for the panic macro.
-/// It reports back error information to the host.
-/// Used only in testing with
-/// [`test_infrastructure`](crate::test_infrastructure).
-#[cfg(not(feature = "std"))]
-#[macro_export]
-macro_rules! fail {
-    () => {
-        {
-            #[allow(deprecated)]
-            $crate::test_infrastructure::report_error("", file!(), line!(), column!());
-            panic!()
-        }
-    };
-    ($($arg:tt)*) => {
-        {
-            let msg = &$crate::alloc::format!($($arg)*);
+            let msg = alloc::format!($($arg)*);
             #[allow(deprecated)]
             $crate::test_infrastructure::report_error(&msg, file!(), line!(), column!());
             panic!("{}", msg)

--- a/contract-testing/Cargo.toml
+++ b/contract-testing/Cargo.toml
@@ -13,21 +13,12 @@ exclude = ["tests"]                                                             
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-concordium-rust-sdk = { version = "8.0.0", path = "../concordium-rust-sdk" }
+concordium-rust-sdk = { version = "9.0.0", path = "../concordium-rust-sdk" }
 tokio = { version = "1.28", features = ["rt-multi-thread", "time"] }
-sha2 = "0.10"
 anyhow = "1"
-# Pinned to version `1.6.0`, since otherwise rust version `1.73` would refuse to build.
-base64ct = "=1.6.0"
-thiserror = "1.0"
-num-bigint = "0.4"
+thiserror = "2.0.0"
+num-bigint = "0.5.1"
 num-integer = "0.1"
-
-# Pin versions to be compatible with 1.73. Remove pins when MSRV is pumped
-rayon = ">=1.0, <1.11"
-rayon-core = ">=1.0, <1.13"
-serde_with = ">=3.0, <3.13"
-ed25519-dalek = ">=2.0, <2.2.0"
 
 [dev-dependencies]
 rand = "0.8"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,39 @@
+[workspace]
+resolver = "3"
+
+members = [
+    "account-signature-checks",
+    "auction",
+    "bump-alloc-tests",
+    "cis2-dynamic-nft",
+    "cis2-multi",
+    "cis2-multi-royalties",
+    "cis2-nft",
+    "cis2-wccd",
+    "cis3-nft-sponsored-txs",
+    "cis5-smart-contract-wallet",
+    "counter-notify",
+    "credential-registry",
+    "eSealing",
+    "factory",
+    "fib",
+    "icecream",
+    "memo",
+    "nametoken",
+    "offchain-transfers",
+    "piggy-bank/part1",
+    "piggy-bank/part2",
+    "proxy",
+    "recorder",
+    "signature-verifier",
+    "smart-contract-upgrade/contract-version1",
+    "smart-contract-upgrade/contract-version2",
+    "sponsored-tx-enabled-auction",
+    "transfer-policy-check",
+    "two-step-transfer",
+    "voting",
+]
+
+[profile.release]
+opt-level = "s"
+codegen-units = 1

--- a/examples/account-signature-checks/Cargo.toml
+++ b/examples/account-signature-checks/Cargo.toml
@@ -3,22 +3,15 @@
 [package]
 name = "account_signature_checks"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 authors = [ "Concordium <developers@concordium.com>" ]
 description = "An example of how to check account signatures"
 
-[features]
-default = ["std"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
+concordium-std = {path = "../../concordium-std"}
 
 [lib]
 crate-type=["cdylib", "rlib"]
 
-[profile.release]
-opt-level = "s"
-codegen-units = 1
+

--- a/examples/account-signature-checks/src/lib.rs
+++ b/examples/account-signature-checks/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 //! A basic example showing how to retrieve account keys, and check account
 //! signatures.

--- a/examples/auction/Cargo.toml
+++ b/examples/auction/Cargo.toml
@@ -2,17 +2,11 @@
 name = "auction-smart-contract"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
+concordium-std = {path = "../../concordium-std"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }

--- a/examples/auction/src/lib.rs
+++ b/examples/auction/src/lib.rs
@@ -25,7 +25,7 @@
 //! `Contract` instances are created by deploying a smart contract
 //! module and initializing it.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 use concordium_std::*;
 

--- a/examples/bump-alloc-tests/Cargo.toml
+++ b/examples/bump-alloc-tests/Cargo.toml
@@ -2,18 +2,11 @@
 name = "bump_alloc_tests"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false, features = ["bump_alloc"]}
+concordium-std = {path = "../../concordium-std", features = ["bump_alloc"] }
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }

--- a/examples/bump-alloc-tests/src/lib.rs
+++ b/examples/bump-alloc-tests/src/lib.rs
@@ -6,7 +6,7 @@
 //! altering the test. Some of the tests fail if the black boxes are removed,
 //! other's simply do not work as intended, which is only visible by logs from
 //! the allocator.
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 use concordium_std::{collections::BTreeMap, hint::black_box, *};
 
 type State = ();

--- a/examples/cis2-dynamic-nft/Cargo.toml
+++ b/examples/cis2-dynamic-nft/Cargo.toml
@@ -2,18 +2,13 @@
 name = "cis2_dynamic_nft"
 version = "0.1.0"
 authors = [ "Concordium <developers@concordium.com>" ]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 description = "An example implementation of the CIS-2 Concordium Token Standard containing dynamic NFTs"
 
-[features]
-default = ["std"]
-std = ["concordium-std/std", "concordium-cis2/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
-concordium-cis2 = {path = "../../concordium-cis2", default-features = false}
+concordium-std = {path = "../../concordium-std"}
+concordium-cis2 = {path = "../../concordium-cis2"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }
@@ -21,7 +16,3 @@ concordium-std-derive = { path = "../../concordium-std-derive" }
 
 [lib]
 crate-type=["cdylib", "rlib"]
-
-[profile.release]
-codegen-units = 1
-opt-level = "s"

--- a/examples/cis2-dynamic-nft/src/lib.rs
+++ b/examples/cis2-dynamic-nft/src/lib.rs
@@ -35,7 +35,7 @@
 //! This function is not very useful and is only there to showcase a simple
 //! implementation of a token receive hook.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 use concordium_cis2::*;
 use concordium_std::*;

--- a/examples/cis2-multi-royalties/Cargo.toml
+++ b/examples/cis2-multi-royalties/Cargo.toml
@@ -2,17 +2,12 @@
 name = "cis2-multi-royalties"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std", "concordium-cis2/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
-concordium-cis2 = {path = "../../concordium-cis2", default-features = false}
+concordium-std = {path = "../../concordium-std"}
+concordium-cis2 = {path = "../../concordium-cis2"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }
@@ -20,7 +15,3 @@ concordium-std-derive = { path = "../../concordium-std-derive" }
 
 [lib]
 crate-type=["cdylib", "rlib"]
-
-[profile.release]
-codegen-units = 1
-opt-level = "s"

--- a/examples/cis2-multi-royalties/src/lib.rs
+++ b/examples/cis2-multi-royalties/src/lib.rs
@@ -34,7 +34,7 @@
 //! whether royalties are paid and how much are configured in the State
 //! initialisation.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 use concordium_cis2::*;
 use concordium_std::*;
 

--- a/examples/cis2-multi/Cargo.toml
+++ b/examples/cis2-multi/Cargo.toml
@@ -2,17 +2,12 @@
 name = "cis2-multi"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std", "concordium-cis2/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
-concordium-cis2 = {path = "../../concordium-cis2", default-features = false}
+concordium-std = {path = "../../concordium-std"}
+concordium-cis2 = {path = "../../concordium-cis2"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = {path = "../../contract-testing"}
@@ -21,7 +16,3 @@ rand = "0.8"
 
 [lib]
 crate-type=["cdylib", "rlib"]
-
-[profile.release]
-codegen-units = 1
-opt-level = "s"

--- a/examples/cis2-multi/src/lib.rs
+++ b/examples/cis2-multi/src/lib.rs
@@ -115,7 +115,7 @@
 //! migration function added to e.g. change the shape of the smart contract
 //! state from `contract-version1` to `contract-version2`.
 //! https://github.com/Concordium/concordium-rust-smart-contracts/blob/main/examples/smart-contract-upgrade/contract-version2/src/lib.rs
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 use concordium_cis2::*;
 use concordium_std::{collections::BTreeMap, EntrypointName, *};
 

--- a/examples/cis2-nft/Cargo.toml
+++ b/examples/cis2-nft/Cargo.toml
@@ -2,18 +2,13 @@
 name = "cis2_nft"
 version = "0.1.0"
 authors = [ "Concordium <developers@concordium.com>" ]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 description = "cis2-nft-project"
 
-[features]
-default = ["std"]
-std = ["concordium-std/std", "concordium-cis2/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
-concordium-cis2 = {path = "../../concordium-cis2", default-features = false}
+concordium-std = {path = "../../concordium-std"}
+concordium-cis2 = {path = "../../concordium-cis2"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = {path = "../../contract-testing"}
@@ -21,7 +16,3 @@ concordium-std-derive = {path = "../../concordium-std-derive"}
 
 [lib]
 crate-type=["cdylib", "rlib"]
-
-[profile.release]
-codegen-units = 1
-opt-level = "s"

--- a/examples/cis2-nft/src/lib.rs
+++ b/examples/cis2-nft/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! Tests are located in `./tests/tests.rs`.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 use concordium_cis2::*;
 use concordium_std::*;

--- a/examples/cis2-wccd/Cargo.toml
+++ b/examples/cis2-wccd/Cargo.toml
@@ -2,17 +2,12 @@
 name = "cis2_wccd"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std", "concordium-cis2/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
-concordium-cis2 = {path = "../../concordium-cis2", default-features = false}
+concordium-std = {path = "../../concordium-std"}
+concordium-cis2 = {path = "../../concordium-cis2"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }
@@ -21,6 +16,4 @@ concordium-std-derive = { path = "../../concordium-std-derive" }
 [lib]
 crate-type=["cdylib", "rlib"]
 
-[profile.release]
-opt-level = "s"
-codegen-units = 1
+

--- a/examples/cis2-wccd/src/lib.rs
+++ b/examples/cis2-wccd/src/lib.rs
@@ -32,7 +32,7 @@
 //!
 //! The admin address can pause/unpause the protocol, set implementors, transfer
 //! the admin address to a new address, and update the metadata URL.
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 use concordium_cis2::{Cis2Event, *};
 use concordium_std::*;
 

--- a/examples/cis3-nft-sponsored-txs/Cargo.toml
+++ b/examples/cis3-nft-sponsored-txs/Cargo.toml
@@ -2,17 +2,12 @@
 name = "cis3_nft_sponsored_txs"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std", "concordium-cis2/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
-concordium-cis2 = {path = "../../concordium-cis2", default-features = false}
+concordium-std = {path = "../../concordium-std"}
+concordium-cis2 = {path = "../../concordium-cis2"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }
@@ -21,8 +16,3 @@ rand = "0.8"
 
 [lib]
 crate-type=["cdylib", "rlib"]
-
-[profile.release]
-panic = "abort"
-opt-level = "s"
-codegen-units = 1

--- a/examples/cis3-nft-sponsored-txs/src/lib.rs
+++ b/examples/cis3-nft-sponsored-txs/src/lib.rs
@@ -54,7 +54,7 @@
 //! (that have exactly one credential and exactly one public key for that
 //! credential), the signaturesMaps/publicKeyMaps in this contract, will have
 //! only one value at key 0 in the inner and outer maps.
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 use concordium_cis2::*;
 use concordium_std::{collections::BTreeMap, EntrypointName, *};

--- a/examples/cis5-smart-contract-wallet/Cargo.toml
+++ b/examples/cis5-smart-contract-wallet/Cargo.toml
@@ -2,13 +2,10 @@
 name = "smart-contract-wallet"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
 [features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std", "concordium-cis2/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
 serde = [
     "concordium-contracts-common/derive-serde",
     "concordium-cis2/serde",
@@ -16,14 +13,14 @@ serde = [
 ]
 
 [dependencies]
-concordium-std = { path = "../../concordium-std", default-features = false }
-concordium-cis2 = { path = "../../concordium-cis2", default-features = false, features = [
+concordium-std = { path = "../../concordium-std" }
+concordium-cis2 = { path = "../../concordium-cis2", features = [
     "u256_amount",
 ] }
 serde = { version = "1.0", optional = true, default-features = false, features = [
     "derive",
 ] }
-concordium-contracts-common = "*"
+concordium-contracts-common = { path = "../../concordium-rust-sdk/concordium-base/smart-contracts/contracts-common/concordium-contracts-common", default-features = false }
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }
@@ -33,7 +30,3 @@ rand = "0.8"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-
-[profile.release]
-codegen-units = 1
-opt-level = "s"

--- a/examples/cis5-smart-contract-wallet/src/lib.rs
+++ b/examples/cis5-smart-contract-wallet/src/lib.rs
@@ -39,6 +39,9 @@
 //! The public key accounts in this smart contract wallet can't submit the
 //! transactions on chain themselves, but rely on someone with a native account
 //! (third-party) to do so.
+
+#![no_std]
+
 use concordium_cis2::{self as cis2, *};
 use concordium_std::*;
 #[cfg(feature = "serde")]

--- a/examples/counter-notify/Cargo.toml
+++ b/examples/counter-notify/Cargo.toml
@@ -2,18 +2,11 @@
 name = "counter-notify"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
+concordium-std = {path = "../../concordium-std"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }

--- a/examples/counter-notify/src/lib.rs
+++ b/examples/counter-notify/src/lib.rs
@@ -8,7 +8,7 @@
 //!  - `reentrancy-attacker`
 //!    - A contract that tries to make an reentrancy attack on the
 //!      `counter-notify` contract.
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 use concordium_std::*;
 
 type State = u64;

--- a/examples/credential-registry/Cargo.toml
+++ b/examples/credential-registry/Cargo.toml
@@ -1,23 +1,14 @@
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [package]
 name = "credential_registry"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 authors = [ "Concordium <developers@concordium.com>" ]
 description = "Example-credential-registry"
 
-[features]
-default = ["std", "crypto-primitives", "bump_alloc"]
-std = ["concordium-std/std", "concordium-cis2/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-crypto-primitives = ["concordium-std/crypto-primitives"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", version = "10.0", default-features = false, features = ["concordium-quickcheck"]}
-concordium-cis2 = {path = "../../concordium-cis2", version = "6.2.1-alpha.1", default-features = false}
-quickcheck = {version = "1"}
+concordium-std = {path = "../../concordium-std"}
+concordium-cis2 = {path = "../../concordium-cis2"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = {path = "../../contract-testing"}
@@ -26,6 +17,4 @@ concordium-std-derive = {path = "../../concordium-std-derive"}
 [lib]
 crate-type=["cdylib", "rlib"]
 
-[profile.release]
-opt-level = "s"
-codegen-units = 1
+

--- a/examples/credential-registry/src/lib.rs
+++ b/examples/credential-registry/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../README.md")]
+
+#![no_std]
+
 use concordium_cis2::*;
 use concordium_std::*;
 

--- a/examples/eSealing/Cargo.toml
+++ b/examples/eSealing/Cargo.toml
@@ -2,16 +2,11 @@
 name = "e_sealing"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
+concordium-std = {path = "../../concordium-std"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }
@@ -20,6 +15,4 @@ concordium-std-derive = { path = "../../concordium-std-derive" }
 [lib]
 crate-type=["cdylib", "rlib"]
 
-[profile.release]
-opt-level = "s"
-codegen-units = 1
+

--- a/examples/eSealing/src/lib.rs
+++ b/examples/eSealing/src/lib.rs
@@ -16,7 +16,7 @@
 //! different witness) would not prove that the second witness is also in
 //! possession of that file because the second witness could have read the
 //! file hash during the initial registration transaction from the blockchain.
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 use concordium_std::*;
 
 /// The different errors the contract can produce.

--- a/examples/factory/Cargo.toml
+++ b/examples/factory/Cargo.toml
@@ -2,19 +2,11 @@
 name = "factory-smart-contract"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = { path = "../../concordium-std", version = "10.0", default-features = false, features = [
-    "p7",
-] }
+concordium-std = { path = "../../concordium-std" }
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }

--- a/examples/factory/src/lib.rs
+++ b/examples/factory/src/lib.rs
@@ -156,7 +156,7 @@
 //! system of the chain enforces isolation. As always, the balance of risks
 //! should be considered when choosing the approach for any application.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 pub mod factory {
     //! The factory smart contract.

--- a/examples/fib/Cargo.toml
+++ b/examples/fib/Cargo.toml
@@ -2,18 +2,11 @@
 name = "fib"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
+concordium-std = {path = "../../concordium-std"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing"}

--- a/examples/fib/src/lib.rs
+++ b/examples/fib/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 use concordium_std::*;
 
 #[derive(Serialize, Clone)]

--- a/examples/icecream/Cargo.toml
+++ b/examples/icecream/Cargo.toml
@@ -2,10 +2,8 @@
 name = "icecream"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 concordium-std = {path = "../../concordium-std"}
@@ -13,11 +11,6 @@ concordium-std = {path = "../../concordium-std"}
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }
 concordium-std-derive = { path = "../../concordium-std-derive" }
-
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/icecream/src/lib.rs
+++ b/examples/icecream/src/lib.rs
@@ -34,7 +34,7 @@
 //! It has `get` and `set` receive functions, which either return or set the
 //! weather. Only the owner can update the weather.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 use concordium_std::*;
 
 #[derive(Serialize, SchemaType, Clone)]

--- a/examples/memo/Cargo.toml
+++ b/examples/memo/Cargo.toml
@@ -2,24 +2,11 @@
 name = "memo-proxy-contract"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-# concordium-std = "*"
 concordium-std = {path = "../../concordium-std"}
-
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]
-
-
-[profile.release]
-opt-level = 3
-panic = "abort"

--- a/examples/memo/src/lib.rs
+++ b/examples/memo/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 use concordium_std::*;
 
 /// # Implementation of a smart contract that can receive transfers with a memo

--- a/examples/nametoken/Cargo.toml
+++ b/examples/nametoken/Cargo.toml
@@ -2,17 +2,12 @@
 name = "nametoken"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std", "concordium-cis2/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
-concordium-cis2 = {path = "../../concordium-cis2", default-features = false}
+concordium-std = {path = "../../concordium-std"}
+concordium-cis2 = {path = "../../concordium-cis2"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }
@@ -20,7 +15,3 @@ concordium-std-derive = { path = "../../concordium-std-derive" }
 
 [lib]
 crate-type=["cdylib", "rlib"]
-
-[profile.release]
-codegen-units = 1
-opt-level = "s"

--- a/examples/nametoken/src/lib.rs
+++ b/examples/nametoken/src/lib.rs
@@ -40,7 +40,7 @@
 //! This example demonstrates how to use crypto primitives (hashing) and
 //! lazy-loaded data.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 use concordium_cis2::*;
 use concordium_std::*;

--- a/examples/offchain-transfers/Cargo.toml
+++ b/examples/offchain-transfers/Cargo.toml
@@ -2,21 +2,13 @@
 name = "offchain-transfer"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2018"
+edition = "2024"
 license = "MPL-2.0"
 description = "Offchain transfer settlement smart contract."
 readme = "./README.md"
 
-[features]
-default = ["std"]
-std = ["concordium-std/std"]
-
 [dependencies]
-byteorder = "1.3"
-concordium-std = {path = "../../concordium-std", default-features = false}
+concordium-std = {path = "../../concordium-std"}
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-
-[profile.release]
-opt-level = 3

--- a/examples/offchain-transfers/src/lib.rs
+++ b/examples/offchain-transfers/src/lib.rs
@@ -54,9 +54,11 @@
  *
  */
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+extern crate alloc;
+
+use alloc::collections::BTreeSet;
 use concordium_std::*;
-use std::{collections::HashSet, convert::TryInto};
 
 /// Unique identifier for settlements
 pub type SettlementID = u64;
@@ -449,7 +451,7 @@ fn is_settlement_valid<S: HasStateApi>(
     // check whether all senders have sufficient funds with respect to the updated
     // state first get of all senders (to avoid duplicate checks) and then
     // check for each sender in set
-    let mut sender_addresses = HashSet::new();
+    let mut sender_addresses = BTreeSet::new();
     for send_transfer in settlement.transfer.send_transfers.iter() {
         sender_addresses.insert(send_transfer.address);
     }

--- a/examples/piggy-bank/part1/Cargo.toml
+++ b/examples/piggy-bank/part1/Cargo.toml
@@ -2,7 +2,7 @@
 name = "piggy-bank-part1"
 version = "0.1.1"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 description = "Piggy bank smart contract part 1."
 homepage = "https://github.com/concordium/concordium-rust-smart-contracts"
@@ -12,15 +12,5 @@ readme = "../README.md"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies.concordium-std]
-version = "10"
 path = "../../../concordium-std"
-default-features = false
-
-[profile.release]
-opt-level = 3

--- a/examples/piggy-bank/part1/src/lib.rs
+++ b/examples/piggy-bank/part1/src/lib.rs
@@ -13,6 +13,8 @@
 //! - The `mutable` attribute.
 //! - Invoking a transfer with the host.
 
+#![no_std]
+
 // Pulling in everything from the smart contract standard library.
 use concordium_std::*;
 

--- a/examples/piggy-bank/part2/Cargo.toml
+++ b/examples/piggy-bank/part2/Cargo.toml
@@ -2,7 +2,7 @@
 name = "piggy-bank-part2"
 version = "0.1.1"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 description = "Piggy bank smart contract part 2."
 homepage = "https://github.com/concordium/concordium-rust-smart-contracts"
@@ -12,19 +12,9 @@ readme = "../README.md"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies.concordium-std]
-version = "10"
 path = "../../../concordium-std"
-default-features = false
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../../contract-testing" }
 concordium-std-derive = { path = "../../../concordium-std-derive" }
-
-[profile.release]
-opt-level = 3

--- a/examples/piggy-bank/part2/src/lib.rs
+++ b/examples/piggy-bank/part2/src/lib.rs
@@ -15,6 +15,8 @@
 //! - Integration testing (in the `/tests/tests.rs file`)
 //! - Custom errors.
 
+#![no_std]
+
 // Pulling in everything from the smart contract standard library.
 use concordium_std::*;
 

--- a/examples/proxy/Cargo.toml
+++ b/examples/proxy/Cargo.toml
@@ -2,16 +2,8 @@
 name = "proxy"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std", "bump_alloc"]
-
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
 
 [dependencies]
 concordium-std = {path = "../../concordium-std"}
@@ -22,9 +14,3 @@ concordium-smart-contract-testing = { path = "../../contract-testing" }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-
-[profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = 3
-# Don't unwind on panics, just trap.
-# panic = "abort"

--- a/examples/proxy/src/lib.rs
+++ b/examples/proxy/src/lib.rs
@@ -19,6 +19,9 @@
 //! appends ", world" to the parameter and returns it.
 //!
 //! The tests are located in `/tests/tests.rs`.
+
+#![no_std]
+
 use concordium_std::*;
 
 /// The contract behind this proxy.

--- a/examples/recorder/Cargo.toml
+++ b/examples/recorder/Cargo.toml
@@ -2,18 +2,11 @@
 name = "recorder"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
+concordium-std = {path = "../../concordium-std"}
 concordium-std-derive = { path = "../../concordium-std-derive" }
 
 [dev-dependencies]

--- a/examples/recorder/src/lib.rs
+++ b/examples/recorder/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 //! A simple contract that records account addresses, and has
 //! an entrypoint to invoke transfers to all those addresses.

--- a/examples/signature-verifier/Cargo.toml
+++ b/examples/signature-verifier/Cargo.toml
@@ -2,10 +2,8 @@
 name = "signature-verifier"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 concordium-std = {path = "../../concordium-std"}
@@ -15,11 +13,6 @@ concordium-smart-contract-testing = { path = "../../contract-testing" }
 concordium-std-derive = { path = "../../concordium-std-derive" }
 ed25519-dalek = { version = "2.0", features = ["rand_core"]  }
 rand = "0.8.5"
-
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
 
 [lib]
 crate-type=["cdylib", "rlib"]

--- a/examples/signature-verifier/src/lib.rs
+++ b/examples/signature-verifier/src/lib.rs
@@ -4,6 +4,7 @@
 //! signature. It shows off how to use the `crypto_primitives` attribute, which
 //! gives the function access to the cryptographic primitives from the
 //! [`HasCryptoPrimitives`] trait.
+#![no_std]
 use concordium_std::*;
 
 type State = ();

--- a/examples/smart-contract-upgrade/contract-version1/Cargo.toml
+++ b/examples/smart-contract-upgrade/contract-version1/Cargo.toml
@@ -1,20 +1,13 @@
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [package]
-name = "smart_contract_upgrade"
+name = "smart_contract_upgrade1"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 authors = ["Concordium <developers@concordium.com>"]
 description = "An example of how to upgrade a smart contract. The state is migrated during the upgrade."
 
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../../concordium-std", default-features = false}
+concordium-std = {path = "../../../concordium-std"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../../contract-testing" }
@@ -23,6 +16,4 @@ concordium-std-derive = { path = "../../../concordium-std-derive" }
 [lib]
 crate-type=["cdylib", "rlib"]
 
-[profile.release]
-opt-level = "s"
-codegen-units = 1
+

--- a/examples/smart-contract-upgrade/contract-version1/src/lib.rs
+++ b/examples/smart-contract-upgrade/contract-version1/src/lib.rs
@@ -22,6 +22,7 @@
 //! `contract-version2` includes a `migration` function
 //! that converts the shape of the smart contract state from `contract-version1`
 //! to `contract-version2`.
+#![no_std]
 use concordium_std::*;
 
 /// The smart contract state.

--- a/examples/smart-contract-upgrade/contract-version1/tests/tests.rs
+++ b/examples/smart-contract-upgrade/contract-version1/tests/tests.rs
@@ -17,7 +17,7 @@
 use concordium_smart_contract_testing::*;
 use concordium_std::Deserial;
 use concordium_std_derive::*;
-use smart_contract_upgrade::UpgradeParams;
+use smart_contract_upgrade1::UpgradeParams;
 
 const ACC_ADDR_OWNER: AccountAddress =
     account_address!("2xBpaHottqhwFZURMZW4uZduQvpxNDSy46iXMYs9kceNGaPpZX");

--- a/examples/smart-contract-upgrade/contract-version2/Cargo.toml
+++ b/examples/smart-contract-upgrade/contract-version2/Cargo.toml
@@ -1,24 +1,17 @@
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [package]
-name = "smart_contract_upgrade"
+name = "smart_contract_upgrade2"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 authors = ["Concordium <developers@concordium.com>"]
 description = "An example of how to upgrade a smart contract. The state is migrated during the upgrade."
 
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../../concordium-std", default-features = false}
+concordium-std = {path = "../../../concordium-std"}
 
 [lib]
 crate-type=["cdylib", "rlib"]
 
-[profile.release]
-opt-level = "s"
-codegen-units = 1
+

--- a/examples/smart-contract-upgrade/contract-version2/src/lib.rs
+++ b/examples/smart-contract-upgrade/contract-version2/src/lib.rs
@@ -22,6 +22,7 @@
 //! `contract-version2` includes a `migration` function
 //! that converts the shape of the smart contract state from `contract-version1`
 //! to `contract-version2`.
+#![no_std]
 use concordium_std::*;
 
 /// The smart contract state.

--- a/examples/sponsored-tx-enabled-auction/Cargo.toml
+++ b/examples/sponsored-tx-enabled-auction/Cargo.toml
@@ -2,17 +2,12 @@
 name = "sponsored-tx-enabled-auction"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std", "concordium-cis2/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
-concordium-cis2 = {path = "../../concordium-cis2", default-features = false}
+concordium-std = {path = "../../concordium-std"}
+concordium-cis2 = {path = "../../concordium-cis2"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }

--- a/examples/sponsored-tx-enabled-auction/src/lib.rs
+++ b/examples/sponsored-tx-enabled-auction/src/lib.rs
@@ -36,7 +36,7 @@
 //! auction. The creator of that auction receives the highest bid when the
 //! auction is finalized and the item is marked as sold to the highest bidder.
 //! This can be done only once.
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 use concordium_cis2::{Cis2Client, *};
 use concordium_std::{collections::BTreeMap, *};

--- a/examples/transfer-policy-check/Cargo.toml
+++ b/examples/transfer-policy-check/Cargo.toml
@@ -2,26 +2,15 @@
 name = "transfer-policy-check"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
+concordium-std = {path = "../../concordium-std"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }
 concordium-std-derive = { path = "../../concordium-std-derive" }
 
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [lib]
 crate-type=["cdylib", "rlib"]
-
-[profile.release]
-opt-level = 3
-panic = "abort"

--- a/examples/transfer-policy-check/src/lib.rs
+++ b/examples/transfer-policy-check/src/lib.rs
@@ -12,7 +12,7 @@
  * will be forwarded to the account address held in the state. Otherwise,
  * the receive function will reject with `ContractError::NotLocalSender`.
  */
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 use concordium_std::*;
 
 type State = AccountAddress;

--- a/examples/two-step-transfer/Cargo.toml
+++ b/examples/two-step-transfer/Cargo.toml
@@ -2,31 +2,18 @@
 name = "two-step-transfer"
 version = "0.1.1"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 description = "Two-step transfer smart contract."
 homepage = "https://github.com/concordium/concordium-rust-smart-contracts"
 repository = "https://github.com/concordium/concordium-rust-smart-contracts"
 readme = "../README.md"
 
-[features]
-default = ["std", "bump_alloc"]
-
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies.concordium-std]
-version = "*"
 path = "../../concordium-std"
-default-features = false
-features = ["concordium-quickcheck"]
 
 [dev-dependencies]
-concordium-std = { version = "*", path = "../../concordium-std" }
-concordium-std-derive = { path = "../../concordium-std-derive" }
+concordium-std = { path = "../../concordium-std" }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-
-[profile.release]
-opt-level = 3

--- a/examples/two-step-transfer/src/lib.rs
+++ b/examples/two-step-transfer/src/lib.rs
@@ -28,7 +28,7 @@
  * cancel it, iff it is still outstanding.
  */
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 use concordium_std::{collections::*, *};
 

--- a/examples/voting/Cargo.toml
+++ b/examples/voting/Cargo.toml
@@ -2,26 +2,15 @@
 name = "voting-contract"
 version = "0.1.0"
 authors = ["Concordium <developers@concordium.com>"]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-concordium-std = {path = "../../concordium-std", default-features = false}
+concordium-std = {path = "../../concordium-std"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = { path = "../../contract-testing" }
 concordium-std-derive = { path = "../../concordium-std-derive" }
 
-[features]
-default = ["std", "bump_alloc"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [lib]
 crate-type=["cdylib", "rlib"]
-
-[profile.release]
-opt-level = 3
-panic = "abort"

--- a/examples/voting/src/lib.rs
+++ b/examples/voting/src/lib.rs
@@ -15,7 +15,7 @@
 //!  - Tallying votes for a requested voting option (`getNumberOfVotes`
 //!    function).
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 use concordium_std::*;
 

--- a/templates/cis2-nft/Cargo.toml
+++ b/templates/cis2-nft/Cargo.toml
@@ -2,18 +2,13 @@
 name = "{{crate_name}}"
 version = "0.1.0"
 authors = [ "{{authors}}" ]
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 description = "{{description}}"
 
-[features]
-default = ["std"]
-std = ["concordium-std/std", "concordium-cis2/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = {version = "10.1", default-features = false}
-concordium-cis2 = {version = "6.2", default-features = false}
+concordium-std = {version = "10.1"}
+concordium-cis2 = {version = "6.2"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = "4.3"

--- a/templates/cis2-nft/cargo-generate.toml
+++ b/templates/cis2-nft/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">= 0.17.0, < 0.24.0"
+cargo_generate_version = ">= 0.17.0"
 
 [placeholders]
 description = { type="string", prompt="Description for the project?" }

--- a/templates/cis2-nft/src/lib.rs
+++ b/templates/cis2-nft/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! Tests are located in `./tests/tests.rs`.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 use concordium_cis2::*;
 use concordium_std::*;

--- a/templates/credential-registry/Cargo.toml
+++ b/templates/credential-registry/Cargo.toml
@@ -3,21 +3,14 @@
 [package]
 name = "{{crate_name}}"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 authors = [ "{{authors}}" ]
 description = "{{description}}"
 
-[features]
-default = ["std", "crypto-primitives", "bump_alloc"]
-std = ["concordium-std/std", "concordium-cis2/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-crypto-primitives = ["concordium-std/crypto-primitives"]
-
 [dependencies]
-concordium-std = {version = "10.1", default-features = false, features = ["concordium-quickcheck"]}
-concordium-cis2 = {version = "6.2", default-features = false}
-quickcheck = {version = "1"}
+concordium-std = {version = "10.1"}
+concordium-cis2 = {version = "6.2"}
 
 [dev-dependencies]
 concordium-smart-contract-testing = "4.3"

--- a/templates/credential-registry/cargo-generate.toml
+++ b/templates/credential-registry/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">= 0.17.0, < 0.24.0"
+cargo_generate_version = ">= 0.17.0"
 
 [hooks]
 pre = ["pre-script.rhai"] # a script for setting default values for the variables when `template_type = default`

--- a/templates/credential-registry/src/lib.rs
+++ b/templates/credential-registry/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../README.md")]
+
+#![no_std]
+
 use concordium_cis2::*;
 use concordium_std::*;
 

--- a/templates/default/Cargo.toml
+++ b/templates/default/Cargo.toml
@@ -3,17 +3,12 @@
 [package]
 name = "{{ crate_name }}"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 authors = ["{{ authors }}"]
 
-[features]
-default = ["std"]
-std = ["concordium-std/std"]
-bump_alloc = ["concordium-std/bump_alloc"]
-
 [dependencies]
-concordium-std = { version = "10.1", default-features = false }
+concordium-std = { version = "10.1" }
 
 [dev-dependencies]
 concordium-smart-contract-testing = "4.3"

--- a/templates/default/cargo-generate.toml
+++ b/templates/default/cargo-generate.toml
@@ -1,2 +1,2 @@
 [template]
-cargo_generate_version = ">= 0.17.0, < 0.24.0"
+cargo_generate_version = ">= 0.17.0"

--- a/templates/default/deploy-scripts/Cargo.toml
+++ b/templates/default/deploy-scripts/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "deploy_scripts"
 version = "1.0.0"
 

--- a/templates/default/src/lib.rs
+++ b/templates/default/src/lib.rs
@@ -1,6 +1,6 @@
 //! # Concordium V1 Smart Contract Template
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 use concordium_std::*;
 use core::fmt::Debug;


### PR DESCRIPTION
## Purpose

Change concordium to use the `wasm32v1-none` target instead of `wasm32-unknown-unknown`

## Changes

* removed the `std` feature, the compile target wasm32 or now solely decides how concordium-std is implemented
* updated all examples 
* updated templates (https://linear.app/concordium/issue/COR-2478/update-templates will follow up)
* removed old "p7" feature
* removed the feature "crypto-primitives" which was not used for anything (was used for testing in the old infrastructure before)
* disabled property based tests for now, will be addressed in https://linear.app/concordium/issue/COR-2474/property-based-tests-on-wasm32-target
* bump_alloc is used as default allocator for now, https://linear.app/concordium/issue/COR-2473/implement-a-default-allocator-for-concordium-std-on-wasm32 will set another as default

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
