### PR TITLE
Set default low level state type on StateMap and StateSet

### DIFF
--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -8,6 +8,8 @@
   The `concordium-std` crate still supports compiling to targets like x86 linux (for unit testing e.g.), in which case the crate will add the Rust `std` crate as a dependency.
 - The crate feature `p7` has been removed. The functionality it guarded (related to protocol P7) is unconditionally compiled.
 - The crate feature `crypto-primitives` has been removed. It had no effect anymore (was previously used by the now deprecated test infrastructure).
+- The types `StateMap` and `StateSet` and related types no longer requires the low-level state type to be specified. 
+  The type parameter `S` for the low-level state type now has default `StateApi`. 
 
 ## concordium-std 10.1.0 (2024-04-04)
 

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -25,18 +25,17 @@ use core::{fmt, str::FromStr};
 ///
 /// ## Type parameters
 ///
-/// The map `StateMap<K, V, S>` is parametrized by the type of _keys_ `K`, the
-/// type of _values_ `V` and the type of the low-level state `S`. In line with
+/// The map `StateMap<K, V>` is parametrized by the type of _keys_ `K` and the
+/// type of _values_ `V`. In line with
 /// other Rust collections, e.g., [`BTreeMap`][btm] and [`HashMap`][hm]
 /// constructing the statemap via [`new_map`](StateBuilder::new_map) does not
 /// require anything specific from `K` and `V`. However most operations do
-/// require that `K` is serializable and `V` can be stored and loaded in the
-/// context of the low-level state `S`.
+/// require that `K` is serializable and `V` can be stored and loaded.
 ///
 /// This concretely means that `K` must implement
 /// [`Serialize`](crate::Serialize) and `V` has to implement
 /// [`Serial`](crate::Serial) and
-/// [`DeserialWithState<S>`](crate::DeserialWithState). In practice, this means
+/// [`DeserialWithState`](crate::DeserialWithState). In practice, this means
 /// that keys must be _flat_, meaning that it cannot have any references to the
 /// low-level state. This is almost all types, except [`StateBox`], [`StateMap`]
 /// and [`StateSet`] and types containing these.
@@ -48,9 +47,8 @@ use core::{fmt, str::FromStr};
 /// ```rust
 /// # use concordium_std::*;
 /// #[derive(Serial, DeserialWithState)]
-/// #[concordium(state_parameter = "S")]
-/// struct MyState<S: HasStateApi = StateApi> {
-///     inner: StateMap<u64, u64, S>,
+/// struct MyState {
+///     inner: StateMap<u64, u64>,
 /// }
 /// #[init(contract = "mycontract")]
 /// fn contract_init(_ctx: &InitContext, state_builder: &mut StateBuilder) -> InitResult<MyState> {
@@ -69,6 +67,12 @@ use core::{fmt, str::FromStr};
 /// }
 /// ```
 ///
+/// ### Low-level state type
+///
+/// The third type parameter has a default type that
+/// specifies the type of the low-level state `S`.
+/// Generally, there should be no need to specify it manually.
+///
 /// ## **Caution**
 ///
 /// `StateMap`s must be explicitly deleted when they are no longer needed,
@@ -76,8 +80,8 @@ use core::{fmt, str::FromStr};
 ///
 /// ```no_run
 /// # use concordium_std::*;
-/// struct MyState<S: HasStateApi = StateApi> {
-///     inner: StateMap<u64, u64, S>,
+/// struct MyState {
+///     inner: StateMap<u64, u64>,
 /// }
 /// fn incorrect_replace(state_builder: &mut StateBuilder, state: &mut MyState) {
 ///     // The following is incorrect. The old value of `inner` is not properly deleted.
@@ -90,8 +94,8 @@ use core::{fmt, str::FromStr};
 ///
 /// ```no_run
 /// # use concordium_std::*;
-/// # struct MyState<S: HasStateApi = StateApi> {
-/// #    inner: StateMap<u64, u64, S>
+/// # struct MyState {
+/// #    inner: StateMap<u64, u64>
 /// # }
 /// fn correct_replace(state_builder: &mut StateBuilder, state: &mut MyState) {
 ///     state.inner.clear_flat();
@@ -100,8 +104,8 @@ use core::{fmt, str::FromStr};
 /// Or alternatively
 /// ```no_run
 /// # use concordium_std::*;
-/// # struct MyState<S: HasStateApi = StateApi> {
-/// #    inner: StateMap<u64, u64, S>
+/// # struct MyState {
+/// #    inner: StateMap<u64, u64>
 /// # }
 /// fn correct_replace(state_builder: &mut StateBuilder, state: &mut MyState) {
 ///     let old_map = mem::replace(&mut state.inner, state_builder.new_map());
@@ -109,9 +113,10 @@ use core::{fmt, str::FromStr};
 /// }
 /// ```
 ///
+///
 /// [hm]: crate::collections::HashMap
 /// [btm]: crate::collections::BTreeMap
-pub struct StateMap<K, V, S> {
+pub struct StateMap<K, V, S = ExternStateApi> {
     pub(crate) _marker_key: PhantomData<K>,
     pub(crate) _marker_value: PhantomData<V>,
     pub(crate) prefix: StateItemPrefix,
@@ -125,7 +130,7 @@ pub struct StateMap<K, V, S> {
 ///
 /// This `struct` is created by the [`iter`][StateMap::iter] method on
 /// [`StateMap`]. See its documentation for more.
-pub struct StateMapIter<'a, K, V, S: HasStateApi> {
+pub struct StateMapIter<'a, K, V, S: HasStateApi = ExternStateApi> {
     pub(crate) state_iter: Option<S::IterType>,
     pub(crate) state_api: S,
     pub(crate) _lifetime_marker: PhantomData<&'a (K, V)>,
@@ -138,7 +143,7 @@ pub struct StateMapIter<'a, K, V, S: HasStateApi> {
 ///
 /// This `struct` is created by the [`iter_mut`][StateMap::iter_mut] method on
 /// [`StateMap`]. See its documentation for more.
-pub struct StateMapIterMut<'a, K, V, S: HasStateApi> {
+pub struct StateMapIterMut<'a, K, V, S: HasStateApi = ExternStateApi> {
     pub(crate) state_iter: Option<S::IterType>,
     pub(crate) state_api: S,
     pub(crate) _lifetime_marker: PhantomData<&'a mut (K, V)>,
@@ -163,14 +168,14 @@ pub struct StateMapIterMut<'a, K, V, S: HasStateApi> {
 ///
 /// ## Type parameters
 ///
-/// The set `StateSet<T, S>` is parametrized by the type of _values_ `T`, and
-/// the type of the low-level state `S`. In line with other Rust collections,
+/// The set `StateSet<T>` is parametrized by the type of _values_ `T`.
+/// In line with other Rust collections,
 /// e.g., [`BTreeSet`][bts] and [`HashSet`][hs] constructing the stateset via
 /// [`new_set`](StateBuilder::new_set) does not require anything specific from
 /// `T`. However most operations do require that `T` implements
 /// [`Serialize`](crate::Serialize).
 ///
-/// Since `StateSet<T, S>` itself **does not** implement
+/// Since `StateSet<T>` itself **does not** implement
 /// [`Serialize`](crate::Serialize) **sets cannot be nested**. If this is really
 /// required then a custom solution should be devised using the operations on
 /// `S` (see [HasStateApi](crate::HasStateApi)).
@@ -179,9 +184,8 @@ pub struct StateMapIterMut<'a, K, V, S: HasStateApi> {
 /// ```rust
 /// # use concordium_std::*;
 /// #[derive(Serial, DeserialWithState)]
-/// #[concordium(state_parameter = "S")]
-/// struct MyState<S: HasStateApi = StateApi> {
-///     inner: StateSet<u64, S>,
+/// struct MyState {
+///     inner: StateSet<u64>,
 /// }
 /// #[init(contract = "mycontract")]
 /// fn contract_init(_ctx: &InitContext, state_builder: &mut StateBuilder) -> InitResult<MyState> {
@@ -197,6 +201,12 @@ pub struct StateMapIterMut<'a, K, V, S: HasStateApi> {
 /// }
 /// ```
 ///
+/// ### Low-level state type
+///
+/// The second type parameter has a default type that
+/// specifies the type of the low-level state `S`.
+/// Generally, there should be no need to specify it manually.
+///
 /// ## **Caution**
 ///
 /// `StateSet`s must be explicitly deleted when they are no longer needed,
@@ -204,8 +214,8 @@ pub struct StateMapIterMut<'a, K, V, S: HasStateApi> {
 ///
 /// ```no_run
 /// # use concordium_std::*;
-/// struct MyState<S: HasStateApi = StateApi> {
-///     inner: StateSet<u64, S>,
+/// struct MyState {
+///     inner: StateSet<u64>,
 /// }
 /// fn incorrect_replace(state_builder: &mut StateBuilder, state: &mut MyState) {
 ///     // The following is incorrect. The old value of `inner` is not properly deleted.
@@ -218,8 +228,8 @@ pub struct StateMapIterMut<'a, K, V, S: HasStateApi> {
 ///
 /// ```no_run
 /// # use concordium_std::*;
-/// # struct MyState<S: HasStateApi = StateApi> {
-/// #    inner: StateSet<u64, S>
+/// # struct MyState {
+/// #    inner: StateSet<u64>
 /// # }
 /// fn correct_replace(state_builder: &mut StateBuilder, state: &mut MyState) {
 ///     state.inner.clear();
@@ -228,8 +238,8 @@ pub struct StateMapIterMut<'a, K, V, S: HasStateApi> {
 /// Or alternatively
 /// ```no_run
 /// # use concordium_std::*;
-/// # struct MyState<S: HasStateApi = StateApi> {
-/// #    inner: StateSet<u64, S>
+/// # struct MyState {
+/// #    inner: StateSet<u64>
 /// # }
 /// fn correct_replace(state_builder: &mut StateBuilder, state: &mut MyState) {
 ///     let old_set = mem::replace(&mut state.inner, state_builder.new_set());
@@ -239,7 +249,7 @@ pub struct StateMapIterMut<'a, K, V, S: HasStateApi> {
 ///
 /// [hs]: crate::collections::HashSet
 /// [bts]: crate::collections::BTreeSet
-pub struct StateSet<T, S> {
+pub struct StateSet<T, S = ExternStateApi> {
     pub(crate) _marker: PhantomData<T>,
     pub(crate) prefix: StateItemPrefix,
     pub(crate) state_api: S,
@@ -251,7 +261,7 @@ pub struct StateSet<T, S> {
 ///
 /// This `struct` is created by the [`iter`][StateSet::iter] method on
 /// [`StateSet`]. See its documentation for more.
-pub struct StateSetIter<'a, T, S: HasStateApi> {
+pub struct StateSetIter<'a, T, S: HasStateApi = ExternStateApi> {
     pub(crate) state_iter: Option<S::IterType>,
     pub(crate) state_api: S,
     pub(crate) _marker_lifetime: PhantomData<&'a T>,
@@ -267,8 +277,9 @@ pub struct StateSetIter<'a, T, S: HasStateApi> {
 /// receive method.
 ///
 /// The type parameter `T` is the type stored in the box. The type parameter `S`
-/// is the state.
-pub struct StateBox<T: Serial, S: HasStateApi> {
+/// has a default type that specifies the type of the low-level state, and
+/// there should generally be no need to specify it manually.
+pub struct StateBox<T: Serial, S: HasStateApi = ExternStateApi> {
     pub(crate) state_api: S,
     pub(crate) inner: UnsafeCell<StateBoxInner<T, S>>,
 }
@@ -316,13 +327,13 @@ impl<V> crate::ops::Deref for StateRef<'_, V> {
 }
 
 #[derive(Debug)]
-/// The [`StateRefMut<_, V, _>`] behaves like `&mut V`, by analogy with other
+/// The [`StateRefMut`] behaves like `&mut V`, by analogy with other
 /// standard library RAII guards like [`RefMut`](std::cell::RefMut).
 /// The type implements [`DerefMut`](crate::ops::DerefMut) which allows the
 /// value to be mutated. Additionally, the [`Drop`](Drop) implementation ensures
 /// that the value is properly stored in the contract state maintained by the
 /// node.
-pub struct StateRefMut<'a, V: Serial, S: HasStateApi> {
+pub struct StateRefMut<'a, V: Serial, S: HasStateApi = ExternStateApi> {
     /// This is set as an `UnsafeCell`, to be able to get a mutable reference to
     /// the entry without `StateRefMut` being mutable.
     pub(crate) entry: UnsafeCell<S::EntryType>,
@@ -372,7 +383,7 @@ pub struct StateEntry {
 ///
 /// Differs from [`VacantEntry`] in that this has access to the raw bytes stored
 /// in the state via a [`HasStateEntry`][crate::HasStateEntry] type.
-pub struct VacantEntryRaw<S> {
+pub struct VacantEntryRaw<S = ExternStateApi> {
     pub(crate) key: Key,
     pub(crate) state_api: S,
 }
@@ -383,7 +394,7 @@ pub struct VacantEntryRaw<S> {
 ///
 /// Differs from [`OccupiedEntry`] in that this has access to the raw bytes
 /// stored in the state via a [`HasStateEntry`][crate::HasStateEntry] type.
-pub struct OccupiedEntryRaw<StateApi: HasStateApi> {
+pub struct OccupiedEntryRaw<StateApi: HasStateApi = ExternStateApi> {
     pub(crate) state_entry: StateApi::EntryType,
 }
 
@@ -392,7 +403,7 @@ pub struct OccupiedEntryRaw<StateApi: HasStateApi> {
 ///
 /// This `enum` is constructed from the [`entry`][crate::HasStateApi::entry]
 /// method on a [`HasStateApi`][crate::HasStateApi] type.
-pub enum EntryRaw<StateApi: HasStateApi> {
+pub enum EntryRaw<StateApi: HasStateApi = ExternStateApi> {
     Vacant(VacantEntryRaw<StateApi>),
     Occupied(OccupiedEntryRaw<StateApi>),
 }
@@ -402,7 +413,7 @@ pub enum EntryRaw<StateApi: HasStateApi> {
 ///
 /// Differs from [`VacantEntryRaw`] in that this automatically handles
 /// serialization.
-pub struct VacantEntry<'a, K, V, S> {
+pub struct VacantEntry<'a, K, V, S = ExternStateApi> {
     pub(crate) key: K,
     pub(crate) key_bytes: Vec<u8>,
     pub(crate) state_api: S,
@@ -421,7 +432,7 @@ pub struct VacantEntry<'a, K, V, S> {
 /// This differs from [`OccupiedEntryRaw`] in that this automatically handles
 /// serialization and provides convenience methods for modifying the value via
 /// the [`DerefMut`](crate::ops::DerefMut) implementation.
-pub struct OccupiedEntry<'a, K, V: Serial, S: HasStateApi> {
+pub struct OccupiedEntry<'a, K, V: Serial, S: HasStateApi = ExternStateApi> {
     pub(crate) key: K,
     pub(crate) value: V,
     /// Indicates whether the value should be stored by the drop implementation.
@@ -463,7 +474,7 @@ impl<K, V: Serial, S: HasStateApi> Drop for OccupiedEntry<'_, K, V, S> {
 ///
 /// This `enum` is constructed from the [`entry`][StateMap::entry] method
 /// on a [`StateMap`] type.
-pub enum Entry<'a, K, V: Serial, S: HasStateApi> {
+pub enum Entry<'a, K, V: Serial, S: HasStateApi = ExternStateApi> {
     Vacant(VacantEntry<'a, K, V, S>),
     Occupied(OccupiedEntry<'a, K, V, S>),
 }

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -69,9 +69,8 @@ use core::{fmt, str::FromStr};
 ///
 /// ### Low-level state type
 ///
-/// The third type parameter has a default type that
-/// specifies the type of the low-level state `S`.
-/// Generally, there should be no need to specify it manually.
+/// The third type parameter specifies the type of the low-level state `S`
+/// and as a default type. Generally, there should be no need to specify it manually.
 ///
 /// ## **Caution**
 ///
@@ -203,9 +202,8 @@ pub struct StateMapIterMut<'a, K, V, S: HasStateApi = ExternStateApi> {
 ///
 /// ### Low-level state type
 ///
-/// The second type parameter has a default type that
-/// specifies the type of the low-level state `S`.
-/// Generally, there should be no need to specify it manually.
+/// The second type parameter specifies the type of the low-level state `S`
+/// and as a default type. Generally, there should be no need to specify it manually.
 ///
 /// ## **Caution**
 ///

--- a/examples/cis2-dynamic-nft/src/lib.rs
+++ b/examples/cis2-dynamic-nft/src/lib.rs
@@ -85,16 +85,15 @@ pub struct SetImplementorsParams {
 
 /// The state for each address.
 #[derive(Serial, DeserialWithState, Deletable)]
-#[concordium(state_parameter = "S")]
-struct AddressState<S> {
+struct AddressState {
     /// The amount of tokens owned by this address.
-    balances: StateMap<ContractTokenId, ContractTokenAmount, S>,
+    balances: StateMap<ContractTokenId, ContractTokenAmount>,
     /// The addresses which are currently enabled as operators for this address.
-    operators: StateSet<Address, S>,
+    operators: StateSet<Address>,
 }
 
-impl<S: HasStateApi> AddressState<S> {
-    fn empty(state_builder: &mut StateBuilder<S>) -> Self {
+impl AddressState {
+    fn empty(state_builder: &mut StateBuilder) -> Self {
         AddressState {
             balances: state_builder.new_map(),
             operators: state_builder.new_set(),
@@ -125,16 +124,15 @@ impl TokenMetadataState {
 /// Note: The specification does not specify how to structure the contract state
 /// and this could be structured in a more space efficient way.
 #[derive(Serial, DeserialWithState)]
-#[concordium(state_parameter = "S")]
-struct State<S> {
+struct State {
     /// The state of addresses.
-    state: StateMap<Address, AddressState<S>, S>,
+    state: StateMap<Address, AddressState>,
     /// Token IDs and the MetadataStates which holds the counter and the list of
     /// MetadataURls
-    tokens: StateMap<ContractTokenId, TokenMetadataState, S>,
+    tokens: StateMap<ContractTokenId, TokenMetadataState>,
     /// Map with contract addresses providing implementations of additional
     /// standards.
-    implementors: StateMap<StandardIdentifierOwned, Vec<ContractAddress>, S>,
+    implementors: StateMap<StandardIdentifierOwned, Vec<ContractAddress>>,
 }
 
 /// The different errors the contract can produce.
@@ -183,9 +181,9 @@ impl From<CustomContractError> for ContractError {
     }
 }
 
-impl<S: HasStateApi> State<S> {
+impl State {
     /// Construct a state with no tokens
-    fn empty(state_builder: &mut StateBuilder<S>) -> Self {
+    fn empty(state_builder: &mut StateBuilder) -> Self {
         State {
             state: state_builder.new_map(),
             tokens: state_builder.new_map(),
@@ -200,7 +198,7 @@ impl<S: HasStateApi> State<S> {
         token_id: &ContractTokenId,
         mint_param: &MintParam,
         owner: &Address,
-        state_builder: &mut StateBuilder<S>,
+        state_builder: &mut StateBuilder,
     ) {
         let _ = self.tokens.insert(
             *token_id,
@@ -318,7 +316,7 @@ impl<S: HasStateApi> State<S> {
         amount: ContractTokenAmount,
         from: &Address,
         to: &Address,
-        state_builder: &mut StateBuilder<S>,
+        state_builder: &mut StateBuilder,
     ) -> ContractResult<()> {
         ensure!(self.contains_token(token_id), ContractError::InvalidTokenId);
         // A zero transfer does not modify the state.
@@ -362,7 +360,7 @@ impl<S: HasStateApi> State<S> {
         &mut self,
         owner: &Address,
         operator: &Address,
-        state_builder: &mut StateBuilder<S>,
+        state_builder: &mut StateBuilder,
     ) {
         let mut owner_state = self
             .state
@@ -405,10 +403,7 @@ impl<S: HasStateApi> State<S> {
     contract = "cis2_dynamic_nft",
     event = "Cis2Event<ContractTokenId, ContractTokenAmount>"
 )]
-fn contract_init<S: HasStateApi>(
-    _ctx: &impl HasInitContext,
-    state_builder: &mut StateBuilder<S>,
-) -> InitResult<State<S>> {
+fn contract_init(_ctx: &InitContext, state_builder: &mut StateBuilder) -> InitResult<State> {
     // Construct the initial contract state.
     Ok(State::empty(state_builder))
 }
@@ -441,10 +436,7 @@ pub struct ViewState {
     name = "view",
     return_value = "ViewState"
 )]
-fn contract_view<S: HasStateApi>(
-    _ctx: &impl HasReceiveContext,
-    host: &impl HasHost<State<S>, StateApiType = S>,
-) -> ReceiveResult<ViewState> {
+fn contract_view(_ctx: &ReceiveContext, host: &Host<State>) -> ReceiveResult<ViewState> {
     let state = host.state();
 
     let mut inner_state = Vec::new();
@@ -491,10 +483,10 @@ pub type TokenUpdateParams = ContractTokenId;
     enable_logger,
     mutable
 )]
-fn contract_upgrade<S: HasStateApi>(
-    ctx: &impl HasReceiveContext,
-    host: &mut impl HasHost<State<S>, StateApiType = S>,
-    logger: &mut impl HasLogger,
+fn contract_upgrade(
+    ctx: &ReceiveContext,
+    host: &mut Host<State>,
+    logger: &mut Logger,
 ) -> ContractResult<()> {
     // Get the contract owner
     let owner = ctx.owner();
@@ -538,10 +530,10 @@ pub struct AddParams {
     enable_logger,
     mutable
 )]
-fn contract_add_metadata<S: HasStateApi>(
-    ctx: &impl HasReceiveContext,
-    host: &mut impl HasHost<State<S>, StateApiType = S>,
-    logger: &mut impl HasLogger,
+fn contract_add_metadata(
+    ctx: &ReceiveContext,
+    host: &mut Host<State>,
+    logger: &mut Logger,
 ) -> ContractResult<()> {
     // Get the contract owner
     let owner = ctx.owner();
@@ -590,10 +582,10 @@ fn contract_add_metadata<S: HasStateApi>(
     enable_logger,
     mutable
 )]
-fn contract_mint<S: HasStateApi>(
-    ctx: &impl HasReceiveContext,
-    host: &mut impl HasHost<State<S>, StateApiType = S>,
-    logger: &mut impl HasLogger,
+fn contract_mint(
+    ctx: &ReceiveContext,
+    host: &mut Host<State>,
+    logger: &mut Logger,
 ) -> ContractResult<()> {
     // Get the contract owner
     let owner = ctx.owner();
@@ -652,10 +644,10 @@ type TransferParameter = TransferParams<ContractTokenId, ContractTokenAmount>;
     enable_logger,
     mutable
 )]
-fn contract_transfer<S: HasStateApi>(
-    ctx: &impl HasReceiveContext,
-    host: &mut impl HasHost<State<S>, StateApiType = S>,
-    logger: &mut impl HasLogger,
+fn contract_transfer(
+    ctx: &ReceiveContext,
+    host: &mut Host<State>,
+    logger: &mut Logger,
 ) -> ContractResult<()> {
     // Parse the parameter.
     let TransferParams(transfers): TransferParameter = ctx.parameter_cursor().get()?;
@@ -721,10 +713,10 @@ fn contract_transfer<S: HasStateApi>(
     enable_logger,
     mutable
 )]
-fn contract_update_operator<S: HasStateApi>(
-    ctx: &impl HasReceiveContext,
-    host: &mut impl HasHost<State<S>, StateApiType = S>,
-    logger: &mut impl HasLogger,
+fn contract_update_operator(
+    ctx: &ReceiveContext,
+    host: &mut Host<State>,
+    logger: &mut Logger,
 ) -> ContractResult<()> {
     // Parse the parameter.
     let UpdateOperatorParams(params) = ctx.parameter_cursor().get()?;
@@ -773,9 +765,9 @@ type ContractBalanceOfQueryResponse = BalanceOfQueryResponse<ContractTokenAmount
     return_value = "ContractBalanceOfQueryResponse",
     error = "ContractError"
 )]
-fn contract_balance_of<S: HasStateApi>(
-    ctx: &impl HasReceiveContext,
-    host: &impl HasHost<State<S>, StateApiType = S>,
+fn contract_balance_of(
+    ctx: &ReceiveContext,
+    host: &Host<State>,
 ) -> ContractResult<ContractBalanceOfQueryResponse> {
     // Parse the parameter.
     let params: ContractBalanceOfQueryParams = ctx.parameter_cursor().get()?;
@@ -802,9 +794,9 @@ fn contract_balance_of<S: HasStateApi>(
     return_value = "OperatorOfQueryResponse",
     error = "ContractError"
 )]
-fn contract_operator_of<S: HasStateApi>(
-    ctx: &impl HasReceiveContext,
-    host: &impl HasHost<State<S>, StateApiType = S>,
+fn contract_operator_of(
+    ctx: &ReceiveContext,
+    host: &Host<State>,
 ) -> ContractResult<OperatorOfQueryResponse> {
     // Parse the parameter.
     let params: OperatorOfQueryParams = ctx.parameter_cursor().get()?;
@@ -835,9 +827,9 @@ pub type ContractTokenMetadataQueryParams = TokenMetadataQueryParams<ContractTok
     return_value = "TokenMetadataQueryResponse",
     error = "ContractError"
 )]
-fn contract_token_metadata<S: HasStateApi>(
-    ctx: &impl HasReceiveContext,
-    host: &impl HasHost<State<S>, StateApiType = S>,
+fn contract_token_metadata(
+    ctx: &ReceiveContext,
+    host: &Host<State>,
 ) -> ContractResult<TokenMetadataQueryResponse> {
     // Parse the parameter.
     let params: ContractTokenMetadataQueryParams = ctx.parameter_cursor().get()?;
@@ -872,9 +864,9 @@ struct TokenMetadataList {
     return_value = "TokenMetadataList",
     error = "ContractError"
 )]
-fn contract_token_metadata_list<S: HasStateApi>(
-    ctx: &impl HasReceiveContext,
-    host: &impl HasHost<State<S>, StateApiType = S>,
+fn contract_token_metadata_list(
+    ctx: &ReceiveContext,
+    host: &Host<State>,
 ) -> ContractResult<TokenMetadataList> {
     // Parse the parameter.
     let params: ContractTokenMetadataQueryParams = ctx.parameter_cursor().get()?;
@@ -918,10 +910,7 @@ fn contract_token_metadata_list<S: HasStateApi>(
     name = "onReceivingCIS2",
     error = "ContractError"
 )]
-fn contract_on_cis2_received<S: HasStateApi>(
-    ctx: &impl HasReceiveContext,
-    host: &impl HasHost<State<S>, StateApiType = S>,
-) -> ContractResult<()> {
+fn contract_on_cis2_received(ctx: &ReceiveContext, host: &Host<State>) -> ContractResult<()> {
     // Ensure the sender is a contract.
     let sender = if let Address::Contract(contract) = ctx.sender() {
         contract
@@ -966,9 +955,9 @@ fn contract_on_cis2_received<S: HasStateApi>(
     return_value = "SupportsQueryResponse",
     error = "ContractError"
 )]
-fn contract_supports<S: HasStateApi>(
-    ctx: &impl HasReceiveContext,
-    host: &impl HasHost<State<S>, StateApiType = S>,
+fn contract_supports(
+    ctx: &ReceiveContext,
+    host: &Host<State>,
 ) -> ContractResult<SupportsQueryResponse> {
     // Parse the parameter.
     let params: SupportsQueryParams = ctx.parameter_cursor().get()?;
@@ -999,10 +988,7 @@ fn contract_supports<S: HasStateApi>(
     error = "ContractError",
     mutable
 )]
-fn contract_set_implementor<S: HasStateApi>(
-    ctx: &impl HasReceiveContext,
-    host: &mut impl HasHost<State<S>, StateApiType = S>,
-) -> ContractResult<()> {
+fn contract_set_implementor(ctx: &ReceiveContext, host: &mut Host<State>) -> ContractResult<()> {
     // Authorize the sender.
     ensure!(
         ctx.sender().matches_account(&ctx.owner()),


### PR DESCRIPTION
## Purpose

Set default low level state type to `ExternStateApi` for `StateMap` and `StateSet` types.

Paired with https://github.com/Concordium/concordium-base/pull/949

## Changes

Additionally updated a single example to use the new syntax.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

