### PR TITLE
Ar/cor 2473 implement a default allocator for concordium std on wasm32

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           submodules: recursive
       - name: Run internal wasm unit test
-        working-directory: concordium-std
+        working-directory: concordium-std-internal-test
         run: |
           # curl -L https://github.com/Concordium/concordium-smart-contract-tools/releases/download/releases/cargo-concordium/${CARGO_CONCORDIUM_VERSION}/cargo-concordium-linux-amd64 -o /tmp/cargo-concordium
           # chmod +x /tmp/cargo-concordium
@@ -84,7 +84,7 @@ jobs:
           # todo change to use release as part of https://linear.app/concordium/issue/COR-2479/release-for-wasm32v1
           rustup target add wasm32v1-none          
           cargo install --git https://github.com/Concordium/concordium-smart-contract-tools.git --branch feature/wasm32v1 --locked
-          cargo concordium test --only-unit-tests -- --features internal-wasm-test
+          cargo concordium test --only-unit-tests
 
   std_clippy_wasm32v1:
     name: Clippy on concordium-std for wasm32v1 target
@@ -99,7 +99,7 @@ jobs:
         run: |
           rustup component add clippy
           rustup target add wasm32v1-none
-          cargo clippy --target wasm32v1-none -- -D warnings
+          cargo clippy --target wasm32v1-none --features wasm-test,build-schema,bump_alloc,debug -- -D warnings
 
   std_check:
     name: Check on concordium-std for x64 and wasm32 and different features
@@ -113,11 +113,15 @@ jobs:
         working-directory: concordium-std
         run: |
           # Try different feature combinations on default (x86 linux) target
+          cargo check --no-default-features
           cargo check
 
           # Try different feature combinations on wasm32v1 target
           rustup target add wasm32v1-none
-          cargo check --target wasm32v1-none 
+          cargo check --target wasm32v1-none --no-default-features
+          cargo check --target wasm32v1-none --no-default-features --features bump_alloc                    
+          cargo check --target wasm32v1-none --no-default-features --features bump_alloc,global_alloc
+          cargo check --target wasm32v1-none
           cargo check --target wasm32v1-none --features wasm-test
           cargo check --target wasm32v1-none --features build-schema
           cargo check --target wasm32v1-none --features bump_alloc

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -119,8 +119,8 @@ jobs:
           # Try different feature combinations on wasm32v1 target
           rustup target add wasm32v1-none
           cargo check --target wasm32v1-none --no-default-features
-          cargo check --target wasm32v1-none --no-default-features --features bump_alloc                    
-          cargo check --target wasm32v1-none --no-default-features --features bump_alloc,global_alloc
+          cargo check --target wasm32v1-none --no-default-features --features bump_alloc
+          cargo check --target wasm32v1-none --no-default-features --features dlmalloc
           cargo check --target wasm32v1-none
           cargo check --target wasm32v1-none --features wasm-test
           cargo check --target wasm32v1-none --features build-schema

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "3"
 members = [
    "concordium-cis2",
    "concordium-std",
+   "concordium-std-internal-test",
    "concordium-std-derive",
    "contract-testing",
 ]

--- a/concordium-cis2/Cargo.toml
+++ b/concordium-cis2/Cargo.toml
@@ -42,7 +42,7 @@ serde = [
 crate-type = ["rlib"]
 
 [package.metadata.docs.rs]
-# This sets the default target to `wasm32-unknown-unknown` and only builds that
+# This sets the default target to `wasm32v1-none` and only builds that
 # target on docs.rs. This is useful because the some parts of documentation only
 # exist on that platform.
 targets = ["wasm32v1-none"]

--- a/concordium-cis2/Cargo.toml
+++ b/concordium-cis2/Cargo.toml
@@ -38,9 +38,6 @@ serde = [
     "primitive-types/impl-serde",
 ]
 
-[lib]
-crate-type = ["rlib"]
-
 [package.metadata.docs.rs]
 # This sets the default target to `wasm32v1-none` and only builds that
 # target on docs.rs. This is useful because the some parts of documentation only

--- a/concordium-std-internal-test/Cargo.toml
+++ b/concordium-std-internal-test/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "concordium-std-internal-test"
+version = "1.0.0"
+authors = ["Concordium <developers@concordium.com>"]
+edition = "2024"
+rust-version = "1.85"
+license = "MPL-2.0"
+
+[dependencies]
+concordium-std = { path = "../concordium-std", features = ["internal-wasm-test", "wasm-test"]}
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/concordium-std-internal-test/README.md
+++ b/concordium-std-internal-test/README.md
@@ -1,0 +1,2 @@
+Crate whose only purpose is to build the internal tests in `concordium-std` into a WASM file, such that they can
+be run by `cargo concoridum test`.

--- a/concordium-std-internal-test/src/lib.rs
+++ b/concordium-std-internal-test/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+extern crate concordium_std;

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -7,7 +7,7 @@
   Smart contracts using `concordium-std` should specify `#[no_std]` and compile to the target `wasm32v1-none`. The previously supported target `wasm32-unknown-unknown`
   (which has a partly stubbed `std` implementation) is no longer supported with `concordium-std`. The crate feature `std` has likewise been removed. 
   The allocator used by default by `concordium-std` is [`dlmalloc`](https://crates.io/crates/dlmalloc). The crate feature `bump_alloc` 
-  will switch to use the custom, lightweight `bump_alloc` allocator. If you want to specify the allocator yourself, you can disable the crate feature `global_alloc`.
+  will switch to use the custom, lightweight `bump_alloc` allocator. 
   Notice that `dlmalloc` is the same as used by the `std` implementation of `wasm32-unknown-unknown`. 
   The `concordium-std` crate still supports compiling to targets like x64 linux (for unit testing e.g.), in which case the crate will add the Rust `std` crate as a dependency.
 - The crate feature `p7` has been removed. The functionality it guarded (related to protocol P7) is unconditionally compiled.

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Removed the native test `StateTrie`
-- The crate is now intended for use on the [`wasm32v1-none`](https://doc.rust-lang.org/rustc/platform-support/wasm32v1-none.html) target, which is a no-`std` target.   
+- The crate is now intended for use on the [`wasm32v1-none`](https://doc.rust-lang.org/rustc/platform-support/wasm32v1-none.html) target, which is a `no_std` target.   
   Smart contracts using `concordium-std` should specify `#[no_std]` and compile to the target `wasm32v1-none`. The previously supported target `wasm32-unknown-unknown`
   (which has a partly stubbed `std` implementation) is no longer supported with `concordium-std`. The crate feature `std` has likewise been removed. 
   The allocator used by default by `concordium-std` is [`dlmalloc`](https://crates.io/crates/dlmalloc). The crate feature `bump_alloc` still exists and

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -3,9 +3,13 @@
 ## Unreleased
 
 - Removed the native test `StateTrie`
-- The crate now targets [`wasm32v1-none`](https://doc.rust-lang.org/rustc/platform-support/wasm32v1-none.html) as the supported WASM target. The crate also no longer has an `std` crate feature. 
-  Smart contracts using `concordium-std` should specify `#[no_std]` and compile to `wasm32v1-none`. 
-  The `concordium-std` crate still supports compiling to targets like x86 linux (for unit testing e.g.), in which case the crate will add the Rust `std` crate as a dependency.
+- The crate is now intended for use on the [`wasm32v1-none`](https://doc.rust-lang.org/rustc/platform-support/wasm32v1-none.html) target, which is a no-`std` target.   
+  Smart contracts using `concordium-std` should specify `#[no_std]` and compile to the target `wasm32v1-none`. The previously supported target `wasm32-unknown-unknown`
+  (which has a partly stubbed `std` implementation) is no longer supported with `concordium-std`. The crate feature `std` has likewise been removed. 
+  The allocator used by default by `concordium-std` is [`dlmalloc`](https://crates.io/crates/dlmalloc). The crate feature `bump_alloc` still exists and
+  will switch to use the custom, lightweight `bump_alloc` allocator. If you want to specify the allocator ourself, you can use the crate feature `no_alloc`.
+  `dlmalloc` is the same as used by the `std` implementation of `wasm32-unknown-unknown`. 
+  The `concordium-std` crate still supports compiling to targets like x64 linux (for unit testing e.g.), in which case the crate will add the Rust `std` crate as a dependency.
 - The crate feature `p7` has been removed. The functionality it guarded (related to protocol P7) is unconditionally compiled.
 - The crate feature `crypto-primitives` has been removed. It had no effect anymore (was previously used by the now deprecated test infrastructure).
 

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -7,7 +7,7 @@
   Smart contracts using `concordium-std` should specify `#[no_std]` and compile to the target `wasm32v1-none`. The previously supported target `wasm32-unknown-unknown`
   (which has a partly stubbed `std` implementation) is no longer supported with `concordium-std`. The crate feature `std` has likewise been removed. 
   The allocator used by default by `concordium-std` is [`dlmalloc`](https://crates.io/crates/dlmalloc). The crate feature `bump_alloc` 
-  will switch to use the custom, lightweight `bump_alloc` allocator. If you want to specify the allocator ourself, you can disable the crate feature `global_alloc`.
+  will switch to use the custom, lightweight `bump_alloc` allocator. If you want to specify the allocator yourself, you can disable the crate feature `global_alloc`.
   Notice that `dlmalloc` is the same as used by the `std` implementation of `wasm32-unknown-unknown`. 
   The `concordium-std` crate still supports compiling to targets like x64 linux (for unit testing e.g.), in which case the crate will add the Rust `std` crate as a dependency.
 - The crate feature `p7` has been removed. The functionality it guarded (related to protocol P7) is unconditionally compiled.

--- a/concordium-std/CHANGELOG.md
+++ b/concordium-std/CHANGELOG.md
@@ -6,9 +6,9 @@
 - The crate is now intended for use on the [`wasm32v1-none`](https://doc.rust-lang.org/rustc/platform-support/wasm32v1-none.html) target, which is a `no_std` target.   
   Smart contracts using `concordium-std` should specify `#[no_std]` and compile to the target `wasm32v1-none`. The previously supported target `wasm32-unknown-unknown`
   (which has a partly stubbed `std` implementation) is no longer supported with `concordium-std`. The crate feature `std` has likewise been removed. 
-  The allocator used by default by `concordium-std` is [`dlmalloc`](https://crates.io/crates/dlmalloc). The crate feature `bump_alloc` still exists and
-  will switch to use the custom, lightweight `bump_alloc` allocator. If you want to specify the allocator ourself, you can use the crate feature `no_alloc`.
-  `dlmalloc` is the same as used by the `std` implementation of `wasm32-unknown-unknown`. 
+  The allocator used by default by `concordium-std` is [`dlmalloc`](https://crates.io/crates/dlmalloc). The crate feature `bump_alloc` 
+  will switch to use the custom, lightweight `bump_alloc` allocator. If you want to specify the allocator ourself, you can disable the crate feature `global_alloc`.
+  Notice that `dlmalloc` is the same as used by the `std` implementation of `wasm32-unknown-unknown`. 
   The `concordium-std` crate still supports compiling to targets like x64 linux (for unit testing e.g.), in which case the crate will add the Rust `std` crate as a dependency.
 - The crate feature `p7` has been removed. The functionality it guarded (related to protocol P7) is unconditionally compiled.
 - The crate feature `crypto-primitives` has been removed. It had no effect anymore (was previously used by the now deprecated test infrastructure).

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -48,4 +48,4 @@ trybuild = "1.0"
 # exist on that platform.
 targets = ["wasm32v1-none"]
 # Default features to build documentation for.
-features = ["bump_alloc", "debug"]
+features = ["debug"]

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/Concordium/concordium-rust-smart-contracts/"
 readme = "./README.md"
 
 [dependencies]
+dlmalloc = { version = "0.2.14", features = ["global"] }
 quickcheck = {version = "1", optional = true }
 getrandom = { version = "0.2", features = ["custom"], optional = true }
 
@@ -21,7 +22,7 @@ default-features = false
 features = ["smart-contract"]
 
 [features]
-default = ["bump_alloc"]
+default = []
 # Enabling the wasm-test feature changes the #[concoridum_test] macro to output test functions callable from WASM interpreter
 wasm-test = ["concordium-contracts-common/wasm-test"]
 # Own internal wasm-tests leak out to the smart contracts using this library,
@@ -33,12 +34,14 @@ build-schema = ["concordium-contracts-common/build-schema"]
 concordium-quickcheck = ["getrandom", "quickcheck", "concordium-contracts-common/concordium-quickcheck"] # // decide what to do with this feature flag as part of https://linear.app/concordium/issue/COR-2474/property-based-tests-on-wasm32-target
 # Enabling debug feature changes the #[concoridum_dbg] macro to log messages via the WASM interpreter
 debug = []
-# Custom allocator. See module documentation for bump_alloc in this crate
+# Use the custom bump allocator instead of dlmalloc. See module documentation for bump_alloc in this crate.
 bump_alloc = []
+# Do not set an allocator (must be set in smart contract then).
+no_alloc = []
 
 [lib]
 # cdylib is needed below to compile into a wasm module with internal unit tests.
-crate-type = ["cdylib", "rlib"]
+#crate-type = ["cdylib", "rlib"] #todo ar
 
 [dev-dependencies]
 trybuild = "1.0"
@@ -48,3 +51,5 @@ trybuild = "1.0"
 # target on docs.rs. This is useful because the some parts of documentation only
 # exist on that platform.
 targets = ["wasm32v1-none"]
+# Default features to build documentation for.
+features = ["bump_alloc", "debug"]

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/Concordium/concordium-rust-smart-contracts/"
 readme = "./README.md"
 
 [dependencies]
-dlmalloc = { version = "0.2.14", features = ["global"] }
+dlmalloc = { version = "0.2.14", features = ["global"], optional = true }
 quickcheck = {version = "1", optional = true }
 getrandom = { version = "0.2", features = ["custom"], optional = true }
 
@@ -22,7 +22,7 @@ default-features = false
 features = ["smart-contract"]
 
 [features]
-default = []
+default = ["dlmalloc", "global_alloc"]
 # Enabling the wasm-test feature changes the #[concoridum_test] macro to output test functions callable from WASM interpreter
 wasm-test = ["concordium-contracts-common/wasm-test"]
 # Own internal wasm-tests leak out to the smart contracts using this library,
@@ -34,14 +34,12 @@ build-schema = ["concordium-contracts-common/build-schema"]
 concordium-quickcheck = ["getrandom", "quickcheck", "concordium-contracts-common/concordium-quickcheck"] # // decide what to do with this feature flag as part of https://linear.app/concordium/issue/COR-2474/property-based-tests-on-wasm32-target
 # Enabling debug feature changes the #[concoridum_dbg] macro to log messages via the WASM interpreter
 debug = []
+# Use the dlmalloc allocator
+dlmalloc = ["dep:dlmalloc"]
 # Use the custom bump allocator instead of dlmalloc. See module documentation for bump_alloc in this crate.
 bump_alloc = []
-# Do not set an allocator (must be set in smart contract then).
-no_alloc = []
-
-[lib]
-# cdylib is needed below to compile into a wasm module with internal unit tests.
-#crate-type = ["cdylib", "rlib"] #todo ar
+# Set a global allocator. Otherwise, it must be set in smart contract.
+global_alloc = []
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -22,7 +22,7 @@ default-features = false
 features = ["smart-contract"]
 
 [features]
-default = ["dlmalloc", "global_alloc"]
+default = ["dlmalloc"]
 # Enabling the wasm-test feature changes the #[concoridum_test] macro to output test functions callable from WASM interpreter
 wasm-test = ["concordium-contracts-common/wasm-test"]
 # Own internal wasm-tests leak out to the smart contracts using this library,
@@ -38,8 +38,6 @@ debug = []
 dlmalloc = ["dep:dlmalloc"]
 # Use the custom bump allocator instead of dlmalloc. See module documentation for bump_alloc in this crate.
 bump_alloc = []
-# Set a global allocator. Otherwise, it must be set in smart contract.
-global_alloc = []
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -30,7 +30,7 @@
 //! ## `dlmalloc`, `bump_alloc` and `global_alloc`: Use a custom allocator
 //!
 //! The default allocator is [`dlmalloc`](https://crates.io/crates/dlmalloc), which
-//! is a general purpose allocator. For smart contracts, the lighter [`bump_alloc`](mod@bump_alloc)
+//! is a general purpose allocator. For smart contracts, the lighter `bump_alloc`
 //! may be enabled with the feature flag of the same name.
 //! The main reason for using `bump_alloc` instead of the default allocator,
 //! is that `bump_alloc` has a smaller code footprint,

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -411,7 +411,7 @@ pub use alloc::{
 /// Re-export.
 pub use core::{cell, cmp, convert, fmt, hash, hint, iter, marker, mem, num, ops, result::*};
 
-// dlalloc is the "default" allocator
+// dlmalloc is the "default" allocator
 #[cfg(all(
     not(feature = "no_alloc"),
     not(feature = "bump_alloc"),

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -19,15 +19,14 @@
 //! # Features
 //!
 //! This library has the following features:
-//! [`dlmalloc`](#dlmalloc-bump_alloc-and-global_alloc-use-a-custom-allocator),
-//! [`bump_alloc`](#dlmalloc-bump_alloc-and-global_alloc-use-a-custom-allocator),
-//! [`global_alloc`](#dlmalloc-bump_alloc-and-global_alloc-use-a-custom-allocator), and
+//! [`dlmalloc`](#dlmalloc-and-bump_alloc-use-a-custom-allocator),
+//! [`bump_alloc`](#dlmalloc-and-bump_alloc-use-a-custom-allocator), and
 //! [`debug`](#debug-emit-debug-information).
 //! And the following features used by tooling only:
 //! [`build-schema`](#build-schema-build-for-generating-a-module-schema) and
 //! [`wasm-test`](#wasm-test-build-for-testing-in-wasm),
 //!
-//! ## `dlmalloc`, `bump_alloc` and `global_alloc`: Use a custom allocator
+//! ## `dlmalloc` and `bump_alloc`: Use a custom allocator
 //!
 //! The default allocator is [`dlmalloc`](https://crates.io/crates/dlmalloc), which
 //! is a general purpose allocator. For smart contracts, the lighter `bump_alloc`
@@ -41,8 +40,7 @@
 //! tradeoff. Especially for contracts such as those dealing with tokens.
 //! For very complex contracts it may be beneficial to run benchmarks to see
 //! whether `bump_alloc` is the best option. It is also possible to specify
-//! your own allocator by disabling the feature flag `global_alloc`. If the flag
-//! is enabled, the `concordium-std` will set the global allocator.
+//! your own allocator by not enabling any of the `dlmalloc` and `bump_alloc` features.
 //! See the Rust [allocator](https://doc.rust-lang.org/std/alloc/index.html#the-global_allocator-attribute)
 //! documentation for more context and details on using custom allocators.
 //!
@@ -277,7 +275,7 @@
 //! sense to compile it with `no_std`. If you have code that conditionally should only compile
 //! when WASM is the target, you can condition on the WASM target: `#[cfg(target_arch = "wasm32")]`.
 //!
-//! If you are using a custom allocator, see [this section](#dlmalloc-bump_alloc-and-global_alloc-use-a-custom-allocator)
+//! If you are using a custom allocator, see [this section](#dlmalloc-and-bump_alloc-use-a-custom-allocator)
 //! on how to configure it.
 //!
 //! ## Version 8.1
@@ -415,20 +413,15 @@ pub use core::{cell, cmp, convert, fmt, hash, hint, iter, marker, mem, num, ops,
 #[cfg(all(
     feature = "dlmalloc",
     not(feature = "bump_alloc"),
-    feature = "global_alloc",
     target_arch = "wasm32"
 ))]
 #[global_allocator]
 static ALLOC: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
 
-#[cfg(all(feature = "bump_alloc", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 pub mod bump_alloc;
 
-#[cfg(all(
-    feature = "bump_alloc",
-    feature = "global_alloc",
-    target_arch = "wasm32"
-))]
+#[cfg(all(feature = "bump_alloc", target_arch = "wasm32"))]
 #[global_allocator]
 static ALLOC: bump_alloc::BumpAllocator = unsafe { bump_alloc::BumpAllocator::new() };
 

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -6,62 +6,59 @@
 //! contracts. For this reason it re-exports a number of definitions from other
 //! libraries.
 //!
-//! # Versions
-//!
-//! The concordium blockchain at present supports two variants of smart
-//! contracts. The original V0 contracts that use message-passing for
-//! communication and have limited state, and V1 contracts which use synchronous
-//! calls, and have extended state. Versions 1 and 2 of `concordium-std`
-//! **support only V0 contracts**. Version 3 and later of `concordium-std`
-//! **supports only V1 contracts**.
-//!
-//! Also note that `concordium-std` version 4 only works with `cargo-concordium`
-//! version 2.1+.
-//!
-//! Version 8.1 deprecates the module [`test_infrastructure`] in favor of the
-//! library [concordium_smart_contract_testing], which should be used instead.
-//! For more details including how to migrate your contract, see the
-//! [Deprecating the
-//! `test_infrastructure`](#deprecating-the-test_infrastructure) section.
+//! The library is intended to be compiled to the target [`wasm32v1-none`](https://doc.rust-lang.org/rustc/platform-support/wasm32v1-none.html)
+//! which is a `no_std` target, hence smart contracts must declare `#![no_std]`. The default allocator used
+//! is [`dlmalloc`](https://crates.io/crates/dlmalloc), see the feature flags below.
 //!
 //! # Panic handler
 //!
-//! When compiled without the `std` feature this crate sets the panic handler
-//! so that it terminates the process immediately, without any unwinding or
-//! prints.
-//! Concretely, when compiled to the `wasm32` target panic boils down to the
+//! When compiled to the `wasm32` target panic boils down to the
 //! `unreachable` instruction, which triggers a runtime failure, aborting
 //! execution of the program.
 //!
 //! # Features
 //!
 //! This library has the following features:
-//! [`std`](#std-build-with-the-rust-standard-library),
-//! [`build-schema`](#build-schema-build-for-generating-a-module-schema),
+//! [`bump_alloc`](#bump_alloc-and-no_alloc-use-a-custom-allocator),
+//! [`no_alloc`](#bump_alloc-and-no_alloc-use-a-custom-allocator), and
+//! [`debug`](#debug-emit-debug-information)
+//! And the following features used by tooling only:
+//! [`build-schema`](#build-schema-build-for-generating-a-module-schema) and
 //! [`wasm-test`](#wasm-test-build-for-testing-in-wasm),
-//! [`crypto-primitives`][crypto-feature], and
-//! [`bump_alloc`](#use-a-custom-allocator)
-//! [`debug`](#emit-debug-information)
 //!
-//! [crypto-feature]:
-//! #crypto-primitives-for-testing-crypto-with-actual-implementations
+//! ## `bump_alloc` and `no_alloc`: Use a custom allocator
 //!
-//! ## `std`: Build with the Rust standard library
+//! The default allocator is [`dlmalloc`](https://crates.io/crates/dlmalloc), which
+//! is a general purpose allocator. For smart contracts, the lighter [`bump_alloc`](mod@bump_alloc)
+//! may be enabled with the feature flag of the same name.
+//! The main reason for using `bump_alloc` instead of the default allocator,
+//! is that `bump_alloc` has a smaller code footprint,
+//! i.e, the resulting smart contracts are going to be smaller by about 6-10kB,
+//! which means they are cheaper to deploy and run. `bump_alloc` is designed to
+//! be simple and fast, but it does not use the memory very efficiently. For
+//! short-lived programs, such as smart contracts, this is usually the right
+//! tradeoff. Especially for contracts such as those dealing with tokens.
+//! For very complex contracts it may be beneficial to run benchmarks to see
+//! whether `bump_alloc` is the best option. It is also possible to specify
+//! your own allocator by using the feature flag `no_alloc`.
+//! See the Rust [allocator](https://doc.rust-lang.org/std/alloc/index.html#the-global_allocator-attribute)
+//! documentation for more context and details on using custom allocators.
 //!
-//! By default this library will be linked with the
-//! [std](https://doc.rust-lang.org/std/) crate, the rust standard library,
-//! however to minimize code size this library supports toggling compilation
-//! with the `#![no_std]` attribute via the feature `std` which is enabled by
-//! default. Compilation without the `std` feature requires a nightly version of
-//! rust.
+//! ## `debug`: Emit debug information
 //!
-//! To use this library without the `std` feature you have to disable it, which
-//! can be done, for example, as follows.
-//! ```toml
-//! [dependencies.concordium-std]
-//! default-features = false
-//! ```
-//! In your project's `Cargo.toml` file.
+//! During testing and debugging it is often useful to emit debug information to
+//! narrow down the source of the problem. `concordium-std` supports this using
+//! the [`concordium_dbg`] macro which will emit its arguments using a special
+//! host function `debug_print` which is only available when the `debug` feature
+//! is enabled. The output of this function is used by `cargo concordium run`
+//! and `cargo concordium test` to display any output that was emitted.
+//!
+//! The `debug` feature should typically not be enabled manually. It is used
+//! implicitly by `cargo concordium` when debug output is requested. It is also
+//! **crucial** that the `debug` feature is **not** enabled when building the
+//! contract for deployment. If it is the contract is most likely to be rejected
+//! when it is being deployed to the chain. The `concordium_dbg!` macro will
+//! ignore its arguments when the `debug` feature is not enabled.
 //!
 //! ## `build-schema`: Build for generating a module schema
 //!
@@ -102,62 +99,6 @@
 //!
 //! **Note** This feature is used by `cargo-concordium`, when building for
 //! testing and for most cases this feature should not be set manually.
-//!
-//! ## `crypto-primitives`: For testing crypto with actual implementations
-//!
-//! This features is only relevant when using the **deprecated**
-//! [test_infrastructure].
-//!
-//! Build with this feature if you want to run smart contract tests with actual
-//! (i.e., not mock) implementations of the cryptographic primitives from
-//! [`HasCryptoPrimitives`].
-//!
-//! **WARNING**: It is not possible to build this crate on macOS with the
-//! `crypto-primitives` feature when targeting `wasm32-unknown-unknown`.
-//! The issue arises when compiling the [`secp256k1`](https://docs.rs/secp256k1/latest/secp256k1/) crate.
-//!
-//! ## Use a custom allocator
-//!
-//! Some operations in `concordium-std` need to dynamically allocate memory.
-//! Rust programs compiled with default compiler settings have access to a
-//! [standard allocator](https://doc.rust-lang.org/std/alloc/struct.System.html)
-//! implemented in the Rust standard library. When using the
-//! `no-std` feature there is no default allocator provided by the Rust
-//! toolchain, and so one must be set explicitly.
-//!
-//! In the past `concordium-std` hard-coded the use of [wee_alloc](https://docs.rs/wee_alloc/)
-//! however since version `5.2.0` this is no longer the case.
-//! Instead no allocator is set by default, however there is a `bump_alloc`
-//! feature (disabled by default) that can be enabled which sets the allocator
-//! to `bump_alloc`, which ships with `concordium-std`. This can be used both
-//! with and without the `std` feature.
-//!
-//! The main reason for using `bump_alloc` instead of the default allocator,
-//! even in `std` builds, is that `bump_alloc` has a smaller code footprint,
-//! i.e, the resulting smart contracts are going to be smaller by about 6-10kB,
-//! which means they are cheaper to deploy and run. `bump_alloc` is designed to
-//! be simple and fast, but it does not use the memory very efficiently. For
-//! short-lived programs, such as smart contracts, this is usually the right
-//! tradeoff. Especially for contracts such as those dealing with tokens.
-//! For very complex contracts it may be beneficial to run benchmarks to see
-//! whether `bump_alloc` is the best option. See the Rust [allocator](https://doc.rust-lang.org/std/alloc/index.html#the-global_allocator-attribute)
-//! documentation for more context and details on using custom allocators.
-//!
-//! # Emit debug information
-//!
-//! During testing and debugging it is often useful to emit debug information to
-//! narrow down the source of the problem. `concordium-std` supports this using
-//! the [`concordium_dbg`] macro which will emit its arguments using a special
-//! host function `debug_print` which is only available when the `debug` feature
-//! is enabled. The output of this function is used by `cargo concordium run`
-//! and `cargo concordium test` to display any output that was emitted.
-//!
-//! The `debug` feature should typically not be enabled manually. It is used
-//! implicitly by `cargo concordium` when debug output is requested. It is also
-//! **crucial** that the `debug` feature is **not** enabled when building the
-//! contract for deployment. If it is the contract is most likely to be rejected
-//! when it is being deployed to the chain. The `concordium_dbg!` macro will
-//! ignore its arguments when the `debug` feature is not enabled.
 //!
 //! # Essential types
 //!
@@ -308,16 +249,49 @@
 //!   which is located right above/below another key using
 //!   [`higher`](StateBTreeMap::higher)/[`lower`](StateBTreeMap::lower).
 //!
-//! # Deprecating the `test_infrastructure`
+//! # Versions
 //!
-//! Version 8.1 deprecates the [test_infrastructure] in favor of the library
-//! [concordium_smart_contract_testing]. A number of traits are also
+//! ## Version 11
+//!
+//! Version 11 and later of `concordium-std` uses the WASM target `wasm32v1-none`.
+//! Version 10 and earlier uses `wasm32-unknown-unknown`.
+//! The tool [`cargo-concordium`](https://crates.io/crates/cargo-concordium) likewise shifts
+//! which target it uses, which means that the following version combinations are supported:
+//!
+//! | concordium-std   | cargo-concordium |
+//! | ---: | ---: |
+//! | 11.x  | 5.x    |
+//! | <= 10 (recent versions) | 4.x |
+//!
+//! ### Migration guide for `wasm32v1-none`
+//!
+//! Smart contracts are now always compiled to the target `wasm32v1-none` which has no Rust `std` library
+//! implementation. Hence, the contract must specify `no_std` in its `lib.rs` file:
+//! ```no_run
+//! #![no_std]
+//! use concordium_std::*;
+//! ```
+//! `concordium-std` largely replaces the features supplied by the Rust `std` library. If your
+//! smart contract crate currently has an `std` feature flag, you should remove it, since it only makes
+//! sense to compile it with `no_std`. If you have code that conditionally should only compile
+//! when WASM is the target, you can condition on the WASM target: `#[cfg(target_arch = "wasm32")]`.
+//!
+//! If you are using a custom allocator, see [this section](#bump_alloc-and-no_alloc-use-a-custom-allocator)
+//! on how to configure it.
+//!
+//! ## Version 8.1
+//!
+//! Version 8.1 of `concordium-std` deprecates the module [`test_infrastructure`] in favor of the
+//! library [concordium_smart_contract_testing], which should be used instead.
+//!
+//! ### Migration guide for `concordium_smart_contract_testing`
+//!
+//! The module [test_infrastructure] is deprecated and a number of traits are
 //! deprecated at the same time since they only exist to support the
 //! [test_infrastructure] and are not needed in the new testing library.
 //! The primary of these traits are [`HasHost`], [`HasStateApi`],
 //! [`HasInitContext`], and [`HasReceiveContext`].
 //!
-//! ## Migration guide
 //! To migrate your contract and its tests to the new testing library, you need
 //! to do the following two steps:
 //!
@@ -392,6 +366,15 @@
 //! [1]: https://doc.rust-lang.org/std/primitive.unit.html
 //! [test_infrastructure]: ./test_infrastructure/index.html
 //! [concordium_smart_contract_testing]: https://docs.rs/concordium-smart-contract-testing
+//!
+//! ## Version 3
+//!
+//! The concordium blockchain at present supports two variants of smart
+//! contracts. The original V0 contracts that use message-passing for
+//! communication and have limited state, and V1 contracts which use synchronous
+//! calls, and have extended state. Versions 1 and 2 of `concordium-std`
+//! **support only V0 contracts**. Version 3 and later of `concordium-std`
+//! **supports only V1 contracts**.
 
 // For targets that are not wasm32v1, we compile with std. This enables compiling (which requires and allocator)
 // and also running pure unit tests.
@@ -428,12 +411,25 @@ pub use alloc::{
 /// Re-export.
 pub use core::{cell, cmp, convert, fmt, hash, hint, iter, marker, mem, num, ops, result::*};
 
+// dlalloc is the "default" allocator
+#[cfg(all(
+    not(feature = "no_alloc"),
+    not(feature = "bump_alloc"),
+    target_arch = "wasm32"
+))]
+#[global_allocator]
+static ALLOC: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
+
 #[cfg(all(feature = "bump_alloc", target_arch = "wasm32"))]
 pub mod bump_alloc;
 
-#[cfg(all(feature = "bump_alloc", target_arch = "wasm32"))]
+#[cfg(all(
+    not(feature = "no_alloc"),
+    feature = "bump_alloc",
+    target_arch = "wasm32"
+))]
 #[global_allocator]
-static ALLOC: crate::bump_alloc::BumpAllocator = unsafe { crate::bump_alloc::BumpAllocator::new() };
+static ALLOC: bump_alloc::BumpAllocator = unsafe { bump_alloc::BumpAllocator::new() };
 
 /// Re-export.
 pub mod collections {

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -19,14 +19,15 @@
 //! # Features
 //!
 //! This library has the following features:
-//! [`bump_alloc`](#bump_alloc-and-no_alloc-use-a-custom-allocator),
-//! [`no_alloc`](#bump_alloc-and-no_alloc-use-a-custom-allocator), and
-//! [`debug`](#debug-emit-debug-information)
+//! [`dlmalloc`](#dlmalloc-bump_alloc-and-global_alloc-use-a-custom-allocator),
+//! [`bump_alloc`](#dlmalloc-bump_alloc-and-global_alloc-use-a-custom-allocator),
+//! [`global_alloc`](#dlmalloc-bump_alloc-and-global_alloc-use-a-custom-allocator), and
+//! [`debug`](#debug-emit-debug-information).
 //! And the following features used by tooling only:
 //! [`build-schema`](#build-schema-build-for-generating-a-module-schema) and
 //! [`wasm-test`](#wasm-test-build-for-testing-in-wasm),
 //!
-//! ## `bump_alloc` and `no_alloc`: Use a custom allocator
+//! ## `dlmalloc`, `bump_alloc` and `global_alloc`: Use a custom allocator
 //!
 //! The default allocator is [`dlmalloc`](https://crates.io/crates/dlmalloc), which
 //! is a general purpose allocator. For smart contracts, the lighter [`bump_alloc`](mod@bump_alloc)
@@ -40,7 +41,8 @@
 //! tradeoff. Especially for contracts such as those dealing with tokens.
 //! For very complex contracts it may be beneficial to run benchmarks to see
 //! whether `bump_alloc` is the best option. It is also possible to specify
-//! your own allocator by using the feature flag `no_alloc`.
+//! your own allocator by disabling the feature flag `global_alloc`. If the flag
+//! is enabled, the `concordium-std` will set the global allocator.
 //! See the Rust [allocator](https://doc.rust-lang.org/std/alloc/index.html#the-global_allocator-attribute)
 //! documentation for more context and details on using custom allocators.
 //!
@@ -271,12 +273,11 @@
 //! #![no_std]
 //! use concordium_std::*;
 //! ```
-//! `concordium-std` largely replaces the features supplied by the Rust `std` library. If your
-//! smart contract crate currently has an `std` feature flag, you should remove it, since it only makes
+//! If your smart contract crate currently has an `std` feature flag, you should remove it, since it only makes
 //! sense to compile it with `no_std`. If you have code that conditionally should only compile
 //! when WASM is the target, you can condition on the WASM target: `#[cfg(target_arch = "wasm32")]`.
 //!
-//! If you are using a custom allocator, see [this section](#bump_alloc-and-no_alloc-use-a-custom-allocator)
+//! If you are using a custom allocator, see [this section](#dlmalloc-bump_alloc-and-global_alloc-use-a-custom-allocator)
 //! on how to configure it.
 //!
 //! ## Version 8.1
@@ -411,10 +412,10 @@ pub use alloc::{
 /// Re-export.
 pub use core::{cell, cmp, convert, fmt, hash, hint, iter, marker, mem, num, ops, result::*};
 
-// dlmalloc is the "default" allocator
 #[cfg(all(
-    not(feature = "no_alloc"),
+    feature = "dlmalloc",
     not(feature = "bump_alloc"),
+    feature = "global_alloc",
     target_arch = "wasm32"
 ))]
 #[global_allocator]
@@ -424,8 +425,8 @@ static ALLOC: dlmalloc::GlobalDlmalloc = dlmalloc::GlobalDlmalloc;
 pub mod bump_alloc;
 
 #[cfg(all(
-    not(feature = "no_alloc"),
     feature = "bump_alloc",
+    feature = "global_alloc",
     target_arch = "wasm32"
 ))]
 #[global_allocator]

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -269,7 +269,7 @@
 //!
 //! Smart contracts are now always compiled to the target `wasm32v1-none` which has no Rust `std` library
 //! implementation. Hence, the contract must specify `no_std` in its `lib.rs` file:
-//! ```no_run
+//! ```ignore
 //! #![no_std]
 //! use concordium_std::*;
 //! ```


### PR DESCRIPTION
## Purpose

Set dlmalloc as the default allocator. It was default when compiling to https://doc.rust-lang.org/rustc/platform-support/wasm32-unknown-unknown.html with std library.

## Changes

* `dlmalloc` is default
* `bump_alloc` feature enabled `bump_alloc`
* `global_alloc` is default and sets the global allocator
* updated `concordium_std` `lib.rs` docs for this change and the previous changes for `wasm32v1` feature
* moved running internal wasm tests to concordium-std-internal-test, since it requires the cdylib crate type, which cannot be applied to `concordium-std` if it must be compilable without the `global_alloc` feature

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
